### PR TITLE
fix(windows): 修复 DPAPI 类型加载失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Check browser runner syntax
         run: node --check examples/browser-runner/browser-runner.js
 
-      - name: Check PowerShell installer syntax
+      - name: Check Windows PowerShell installer syntax
         if: runner.os == 'Windows'
-        shell: pwsh
+        shell: powershell
         run: |
           $failed = $false
           foreach ($path in @('scripts/install-windows.ps1', 'scripts/uninstall-windows.ps1')) {
@@ -62,3 +62,28 @@ jobs:
             }
           }
           if ($failed) { exit 1 }
+
+      - name: Test Windows PowerShell DPAPI round trip
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Add-Type -AssemblyName System.Security
+
+          $plainText = 'agentdock-dpapi-roundtrip'
+          $entropy = [Text.Encoding]::UTF8.GetBytes('agentdock.startup.v1')
+          $protectedBytes = [System.Security.Cryptography.ProtectedData]::Protect(
+            [Text.Encoding]::UTF8.GetBytes($plainText),
+            $entropy,
+            [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+          )
+          $unprotectedBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
+            $protectedBytes,
+            $entropy,
+            [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+          )
+          $actual = [Text.Encoding]::UTF8.GetString($unprotectedBytes)
+
+          if ($actual -ne $plainText) {
+            throw "DPAPI round trip mismatch. Expected '$plainText', got '$actual'."
+          }

--- a/internal/installscript/install_script_test.go
+++ b/internal/installscript/install_script_test.go
@@ -47,6 +47,10 @@ func TestInstallWindowsUsesChecksumsDPAPIAndCurrentUserStartup(t *testing.T) {
 			t.Fatalf("install-windows.ps1 missing %q", want)
 		}
 	}
+	const securityAssemblyLoad = "Add-Type -AssemblyName System.Security"
+	if got := strings.Count(script, securityAssemblyLoad); got != 2 {
+		t.Fatalf("install-windows.ps1 must load System.Security in the installer and generated launcher; got %d occurrences", got)
+	}
 	if strings.Contains(script, "RunLevel Highest") {
 		t.Fatal("Windows installer should not require elevated startup")
 	}

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -133,6 +133,7 @@ try {
         if (-not $AuthToken) {
             $AuthToken = New-AgentDockToken
         }
+        Add-Type -AssemblyName System.Security
         $protectedToken = [System.Security.Cryptography.ProtectedData]::Protect(
             [Text.Encoding]::UTF8.GetBytes($AuthToken),
             [Text.Encoding]::UTF8.GetBytes('agentdock.startup.v1'),
@@ -148,6 +149,7 @@ try {
         $escapedBinaryPath = $binaryPath.Replace("'", "''")
         $launcher = @"
 `$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
 `$tokenBytes = [Convert]::FromBase64String([IO.File]::ReadAllText('$escapedTokenPath').Trim())
 `$plainToken = [System.Security.Cryptography.ProtectedData]::Unprotect(
     `$tokenBytes,


### PR DESCRIPTION
## 修改

- 在 Windows 安装器调用 DPAPI `Protect` 前显式加载 `System.Security`
- 在生成的 `start-agentdock.ps1` 调用 `Unprotect` 前执行相同加载
- 将安装脚本语法检查切换到 Windows PowerShell 5.1
- 新增真实 DPAPI Protect/Unprotect 往返测试
- 新增安装脚本回归断言，确保两个运行路径都加载程序集

## 本地验证

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/agentdock`
- `node --check examples/browser-runner/browser-runner.js`
- YAML 解析与 `git diff --check`