### PR TITLE
feat(runtime): 暴露 MCP 管理接口

### DIFF
--- a/internal/httpx/runtime_api.go
+++ b/internal/httpx/runtime_api.go
@@ -1,9 +1,11 @@
 package httpx
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -24,6 +26,8 @@ func registerRuntimeAPI(mux *http.ServeMux, server *mcp.Server, cfg config.Confi
 	mux.HandleFunc("/internal/runtime/skills/", h)
 	mux.HandleFunc("/internal/runtime/tasks", h)
 	mux.HandleFunc("/internal/runtime/tasks/", h)
+	mux.HandleFunc("/internal/runtime/mcp", h)
+	mux.HandleFunc("/internal/runtime/mcp/", h)
 }
 
 func runtimeAPIHandler(server *mcp.Server, cfg config.Config, oauthStore *auth.OAuthStore) http.HandlerFunc {
@@ -62,7 +66,7 @@ func runtimeAPIMethodAllowed(method, path string) bool {
 		_, ok := runtimeTaskID(cleanPath)
 		return ok
 	}
-	return method == http.MethodPost && cleanPath == "/internal/runtime/capabilities"
+	return method == http.MethodPost && (cleanPath == "/internal/runtime/capabilities" || cleanPath == "/internal/runtime/mcp")
 }
 
 func runtimeAPIAllowHeader(path string) string {
@@ -70,7 +74,7 @@ func runtimeAPIAllowHeader(path string) string {
 	if _, ok := runtimeTaskID(cleanPath); ok {
 		return "GET, DELETE"
 	}
-	if cleanPath == "/internal/runtime/capabilities" {
+	if cleanPath == "/internal/runtime/capabilities" || cleanPath == "/internal/runtime/mcp" {
 		return "GET, POST"
 	}
 	return "GET"
@@ -93,6 +97,23 @@ func dispatchRuntimeAPI(ctx context.Context, server *mcp.Server, r *http.Request
 		skill := strings.TrimPrefix(path, "/internal/runtime/skills/")
 		result, err := server.RuntimeSkill(skill)
 		return map[string]any(result), err
+	case path == "/internal/runtime/mcp" && r.Method == http.MethodPost:
+		args, err := decodeRuntimeMCPRequest(r)
+		if err != nil {
+			return nil, err
+		}
+		result, err := server.RuntimeMCPManage(ctx, args)
+		return map[string]any(result), err
+	case path == "/internal/runtime/mcp":
+		result, err := server.RuntimeMCPServers(ctx)
+		return map[string]any(result), err
+	case strings.HasPrefix(path, "/internal/runtime/mcp/"):
+		name, ok := runtimeMCPName(path)
+		if !ok {
+			return nil, &tools.ToolError{Code: "MCP_NAME_REQUIRED", Message: "dynamic MCP server name is required", Category: "validation"}
+		}
+		result, err := server.RuntimeMCPServer(ctx, name)
+		return map[string]any(result), err
 	case path == "/internal/runtime/tasks":
 		limit, err := parseRuntimeTaskLimit(r.URL.Query().Get("limit"))
 		if err != nil {
@@ -109,6 +130,94 @@ func dispatchRuntimeAPI(ctx context.Context, server *mcp.Server, r *http.Request
 	default:
 		return nil, &tools.ToolError{Code: "NOT_FOUND", Message: "runtime API route not found", Category: "not_found"}
 	}
+}
+
+type runtimeMCPRequest struct {
+	Action      string            `json:"action"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Transport   string            `json:"transport"`
+	URL         string            `json:"url"`
+	Command     string            `json:"command"`
+	Args        []string          `json:"args"`
+	Cwd         string            `json:"cwd"`
+	HeaderEnv   map[string]string `json:"header_env"`
+	EnvFromEnv  map[string]string `json:"env_from_env"`
+	Enabled     *bool             `json:"enabled"`
+	TimeoutMS   int               `json:"timeout_ms"`
+	Key         string            `json:"key"`
+	Value       *string           `json:"value"`
+}
+
+var runtimeMCPManageActions = map[string]bool{
+	"add": true, "remove": true, "enable": true, "disable": true,
+	"env_set": true, "env_unset": true, "env_list": true, "refresh": true,
+}
+
+func decodeRuntimeMCPRequest(r *http.Request) (map[string]any, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024+1))
+	if err != nil {
+		return nil, runtimeMCPRequestError("failed to read MCP request body")
+	}
+	if len(body) > 64*1024 {
+		return nil, runtimeMCPRequestError("MCP request body is too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var request runtimeMCPRequest
+	if err := decoder.Decode(&request); err != nil {
+		return nil, runtimeMCPRequestError("invalid MCP request body")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, runtimeMCPRequestError("request body must contain exactly one JSON value")
+	}
+	action := strings.ToLower(strings.TrimSpace(request.Action))
+	if action == "" {
+		return nil, &tools.ToolError{Code: "MCP_ACTION_REQUIRED", Message: "dynamic MCP action is required", Category: "validation"}
+	}
+	if !runtimeMCPManageActions[action] {
+		return nil, &tools.ToolError{Code: "MCP_ACTION_UNSUPPORTED", Message: "dynamic MCP action is not available through the Runtime API", Category: "validation"}
+	}
+	args := map[string]any{
+		"action":       action,
+		"name":         request.Name,
+		"description":  request.Description,
+		"transport":    request.Transport,
+		"url":          request.URL,
+		"command":      request.Command,
+		"args":         request.Args,
+		"cwd":          request.Cwd,
+		"header_env":   request.HeaderEnv,
+		"env_from_env": request.EnvFromEnv,
+		"key":          request.Key,
+	}
+	if request.Value != nil {
+		args["value"] = *request.Value
+	}
+	if request.Enabled != nil {
+		args["enabled"] = *request.Enabled
+	}
+	if request.TimeoutMS > 0 {
+		args["timeout_ms"] = request.TimeoutMS
+	}
+	return args, nil
+}
+
+func runtimeMCPRequestError(message string) error {
+	return &tools.ToolError{Code: "INVALID_MCP_REQUEST", Message: message, Category: "validation"}
+}
+
+func runtimeMCPName(path string) (string, bool) {
+	const prefix = "/internal/runtime/mcp/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(path, prefix))
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return name, true
 }
 
 func runtimeTaskID(path string) (string, bool) {

--- a/internal/httpx/runtime_mcp_api_test.go
+++ b/internal/httpx/runtime_mcp_api_test.go
@@ -1,0 +1,72 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/uvwt/agentdock/internal/auth"
+	"github.com/uvwt/agentdock/internal/mcp"
+	"github.com/uvwt/agentdock/internal/tools"
+)
+
+func TestRuntimeMCPAPIManagesServersWithoutReturningSecrets(t *testing.T) {
+	cfg := testConfig(t)
+	runtime, err := tools.NewRuntime(cfg)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer runtime.Close()
+	handler := runtimeAPIHandler(mcp.NewServer(runtime, cfg), cfg, auth.NewOAuthStore())
+
+	postRuntimeMCP(t, handler, `{"action":"add","name":"demo","description":"Demo MCP","transport":"streamable_http","url":"http://127.0.0.1:1/mcp","enabled":false}`, http.StatusOK)
+
+	list := httptest.NewRecorder()
+	handler.ServeHTTP(list, httptest.NewRequest(http.MethodGet, "/internal/runtime/mcp", nil))
+	if list.Code != http.StatusOK || !strings.Contains(list.Body.String(), `"name":"demo"`) {
+		t.Fatalf("list status=%d body=%s", list.Code, list.Body.String())
+	}
+
+	detail := httptest.NewRecorder()
+	handler.ServeHTTP(detail, httptest.NewRequest(http.MethodGet, "/internal/runtime/mcp/demo", nil))
+	if detail.Code != http.StatusOK || !strings.Contains(detail.Body.String(), `"url":"http://127.0.0.1:1/mcp"`) {
+		t.Fatalf("detail status=%d body=%s", detail.Code, detail.Body.String())
+	}
+
+	const secret = "runtime-mcp-secret-value"
+	setEnv := postRuntimeMCP(t, handler, `{"action":"env_set","name":"demo","key":"DEMO_TOKEN","value":"`+secret+`"}`, http.StatusOK)
+	if strings.Contains(setEnv, secret) {
+		t.Fatalf("env_set response leaked secret: %s", setEnv)
+	}
+	listEnv := postRuntimeMCP(t, handler, `{"action":"env_list","name":"demo"}`, http.StatusOK)
+	if !strings.Contains(listEnv, `"key":"DEMO_TOKEN"`) || strings.Contains(listEnv, secret) {
+		t.Fatalf("unexpected env_list response: %s", listEnv)
+	}
+
+	invalid := postRuntimeMCP(t, handler, `{"action":"env_list","name":"demo","unknown":true}`, http.StatusBadRequest)
+	if !strings.Contains(invalid, `"code":"INVALID_MCP_REQUEST"`) {
+		t.Fatalf("unexpected invalid response: %s", invalid)
+	}
+	unsupported := postRuntimeMCP(t, handler, `{"action":"inspect","name":"demo"}`, http.StatusBadRequest)
+	if !strings.Contains(unsupported, `"code":"MCP_ACTION_UNSUPPORTED"`) {
+		t.Fatalf("unexpected unsupported response: %s", unsupported)
+	}
+
+	postRuntimeMCP(t, handler, `{"action":"remove","name":"demo"}`, http.StatusOK)
+	missing := httptest.NewRecorder()
+	handler.ServeHTTP(missing, httptest.NewRequest(http.MethodGet, "/internal/runtime/mcp/demo", nil))
+	if missing.Code != http.StatusBadRequest || !strings.Contains(missing.Body.String(), `"code":"MCP_SERVER_NOT_FOUND"`) {
+		t.Fatalf("missing status=%d body=%s", missing.Code, missing.Body.String())
+	}
+}
+
+func postRuntimeMCP(t *testing.T, handler http.Handler, body string, wantStatus int) string {
+	t.Helper()
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/internal/runtime/mcp", strings.NewReader(body)))
+	if response.Code != wantStatus {
+		t.Fatalf("POST /internal/runtime/mcp status=%d want=%d body=%s", response.Code, wantStatus, response.Body.String())
+	}
+	return response.Body.String()
+}

--- a/internal/mcp/runtime_api.go
+++ b/internal/mcp/runtime_api.go
@@ -33,3 +33,15 @@ func (s *Server) RuntimeTaskDelete(id string) (tools.Result, error) {
 func (s *Server) RuntimeCapabilities(ctx context.Context, refresh bool) (tools.Result, error) {
 	return s.runtime.RuntimeCapabilities(ctx, refresh)
 }
+
+func (s *Server) RuntimeMCPServers(ctx context.Context) (tools.Result, error) {
+	return s.runtime.RuntimeMCPServers(ctx)
+}
+
+func (s *Server) RuntimeMCPServer(ctx context.Context, name string) (tools.Result, error) {
+	return s.runtime.RuntimeMCPServer(ctx, name)
+}
+
+func (s *Server) RuntimeMCPManage(ctx context.Context, args map[string]any) (tools.Result, error) {
+	return s.runtime.RuntimeMCPManage(ctx, args)
+}

--- a/internal/tools/dynamic_mcp.go
+++ b/internal/tools/dynamic_mcp.go
@@ -56,10 +56,11 @@ func (r *Runtime) mcpManage(ctx context.Context, args map[string]any) (Result, e
 		return Result{"action": action, "server": server}, nil
 	case "env_set", "env_unset", "env_list":
 		name := strings.TrimSpace(stringArg(args, "name", ""))
-		if _, _, err := r.mcpClients.Inspect(name); err != nil {
+		cfg, _, err := r.mcpClients.Inspect(name)
+		if err != nil {
 			return nil, dynamicMCPToolError(err)
 		}
-		return r.scopedEnvAction(envstore.ScopeMCP, name, action, args)
+		return r.scopedEnvAction(envstore.ScopeMCP, cfg.Name, action, args)
 	case "refresh":
 		name := stringArg(args, "name", "")
 		server, tools, err := r.mcpClients.Refresh(ctx, name)

--- a/internal/tools/runtime_api.go
+++ b/internal/tools/runtime_api.go
@@ -105,3 +105,25 @@ func (r *Runtime) RuntimeCapabilities(ctx context.Context, refresh bool) (Result
 	result["source"] = runtimeAPISource
 	return result, nil
 }
+
+func (r *Runtime) RuntimeMCPServers(ctx context.Context) (Result, error) {
+	return r.runtimeMCPManage(ctx, map[string]any{"action": "list"})
+}
+
+func (r *Runtime) RuntimeMCPServer(ctx context.Context, name string) (Result, error) {
+	return r.runtimeMCPManage(ctx, map[string]any{"action": "inspect", "name": name})
+}
+
+func (r *Runtime) RuntimeMCPManage(ctx context.Context, args map[string]any) (Result, error) {
+	return r.runtimeMCPManage(ctx, args)
+}
+
+func (r *Runtime) runtimeMCPManage(ctx context.Context, args map[string]any) (Result, error) {
+	result, err := r.mcpManage(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	result["ok"] = true
+	result["source"] = runtimeAPISource
+	return result, nil
+}

--- a/internal/tools/scoped_env_test.go
+++ b/internal/tools/scoped_env_test.go
@@ -107,7 +107,7 @@ func TestMCPEnvironmentActionsDoNotReturnValues(t *testing.T) {
 	const secret = "mcp-secret-value"
 	setResult, err := runtime.Call(context.Background(), "mcp_manage", map[string]any{
 		"action": "env_set",
-		"name":   "demo-mcp",
+		"name":   " demo-mcp ",
 		"key":    "MCP_SECRET",
 		"value":  secret,
 	})
@@ -120,7 +120,7 @@ func TestMCPEnvironmentActionsDoNotReturnValues(t *testing.T) {
 
 	listResult, err := runtime.Call(context.Background(), "mcp_manage", map[string]any{
 		"action": "env_list",
-		"name":   "demo-mcp",
+		"name":   " demo-mcp ",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +131,7 @@ func TestMCPEnvironmentActionsDoNotReturnValues(t *testing.T) {
 
 	unsetResult, err := runtime.Call(context.Background(), "mcp_manage", map[string]any{
 		"action": "env_unset",
-		"name":   "demo-mcp",
+		"name":   " demo-mcp ",
 		"key":    "MCP_SECRET",
 	})
 	if err != nil {


### PR DESCRIPTION
## 改动
- 新增受保护的 MCP Runtime 列表、详情与管理接口
- 复用现有 mcp_manage 业务逻辑并限制动作白名单
- 增加请求边界、未知字段与秘密值不回显测试

## 验证
- go test ./...
- go vet ./...
- 本地与 Nexus 真实端到端联调