### PR TITLE
fix(file): 移除文本编辑对系统 diff 的依赖

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.26.5
 require (
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/rogpeppe/go-internal v1.15.0
 	golang.org/x/sys v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJ
 github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=

--- a/internal/app/code_tools_test.go
+++ b/internal/app/code_tools_test.go
@@ -692,6 +692,7 @@ func TestReadFileReturnsNextStartLineOnTruncation(t *testing.T) {
 }
 
 func TestEditFileReplacesSingleMatch(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
 	rt, root := newCodeToolsRuntime(t)
 	path := filepath.Join(root, "main.go")
 	if err := os.WriteFile(path, []byte("package main\n\nfunc main() {}\n"), 0o640); err != nil {

--- a/internal/tool/file/diff_preview.go
+++ b/internal/tool/file/diff_preview.go
@@ -1,16 +1,15 @@
 package file
 
 import (
+	"bytes"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
+	anchoreddiff "github.com/rogpeppe/go-internal/diff"
 	"github.com/uvwt/agentdock/internal/textutil"
 )
 
-const maxDiffProcessOutputBytes = 64 << 20
+const maxDiffOutputBytes = 64 << 20
 
 type diffStats struct {
 	FilesChanged int
@@ -19,29 +18,15 @@ type diffStats struct {
 }
 
 func unifiedDiffPreview(path, oldContent, newContent string, maxBytes int) (string, bool, diffStats, error) {
-	dir, err := os.MkdirTemp("", "agentdock-diff-*")
-	if err != nil {
-		return "", false, diffStats{}, err
-	}
-	defer os.RemoveAll(dir)
-
-	oldPath := filepath.Join(dir, "old")
-	newPath := filepath.Join(dir, "new")
-	if err := os.WriteFile(oldPath, []byte(oldContent), 0o600); err != nil {
-		return "", false, diffStats{}, err
-	}
-	if err := os.WriteFile(newPath, []byte(newContent), 0o600); err != nil {
-		return "", false, diffStats{}, err
-	}
-	cmd := exec.Command("diff", "-u", "--label", "a/"+path, "--label", "b/"+path, oldPath, newPath)
-	output, totalBytes, outputTruncated, err := runBoundedCombinedOutput(cmd, maxDiffProcessOutputBytes)
-	if outputTruncated {
-		return "", false, diffStats{}, fmt.Errorf("diff output exceeds %d bytes (observed %d bytes)", maxDiffProcessOutputBytes, totalBytes)
-	}
-	if err != nil {
-		if exit, ok := err.(*exec.ExitError); !ok || exit.ExitCode() != 1 {
-			return "", false, diffStats{}, err
+	output := anchoreddiff.Diff("a/"+path, []byte(oldContent), "b/"+path, []byte(newContent))
+	if len(output) > 0 {
+		// 该实现会额外输出 diff 命令头；工具契约只返回 unified diff。
+		if newline := bytes.IndexByte(output, '\n'); newline >= 0 {
+			output = output[newline+1:]
 		}
+	}
+	if len(output) > maxDiffOutputBytes {
+		return "", false, diffStats{}, fmt.Errorf("diff output exceeds %d bytes (observed %d bytes)", maxDiffOutputBytes, len(output))
 	}
 	stats := countDiffStats(string(output))
 	truncated := textutil.SafeTruncateBytes(output, maxBytes)

--- a/internal/tool/file/diff_preview_test.go
+++ b/internal/tool/file/diff_preview_test.go
@@ -1,0 +1,95 @@
+package file
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnifiedDiffPreviewWithoutExternalDiff(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	preview, truncated, stats, err := unifiedDiffPreview(
+		"example.txt",
+		"alpha\nkeep\n",
+		"beta\nkeep\n",
+		65536,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Fatal("small diff was truncated")
+	}
+	for _, want := range []string{
+		"--- a/example.txt\n",
+		"+++ b/example.txt\n",
+		"-alpha\n",
+		"+beta\n",
+	} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("preview does not contain %q:\n%s", want, preview)
+		}
+	}
+	if strings.HasPrefix(preview, "diff ") {
+		t.Fatalf("preview contains an unexpected command header:\n%s", preview)
+	}
+	if stats != (diffStats{FilesChanged: 1, Insertions: 1, Deletions: 1}) {
+		t.Fatalf("stats = %#v", stats)
+	}
+}
+
+func TestUnifiedDiffPreviewPreservesMissingNewlineMarkers(t *testing.T) {
+	preview, _, _, err := unifiedDiffPreview("example.txt", "alpha", "beta", 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(preview, "\\ No newline at end of file"); got != 2 {
+		t.Fatalf("missing newline markers = %d, want 2:\n%s", got, preview)
+	}
+}
+
+func TestUnifiedDiffPreviewUsesEmptyRanges(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{name: "add", new: "alpha\n", want: "@@ -0,0 +1,1 @@"},
+		{name: "delete", old: "alpha\n", want: "@@ -1,1 +0,0 @@"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			preview, _, _, err := unifiedDiffPreview("example.txt", test.old, test.new, 65536)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(preview, test.want) {
+				t.Fatalf("preview does not contain %q:\n%s", test.want, preview)
+			}
+		})
+	}
+}
+
+func TestUnifiedDiffPreviewTruncatesAfterCollectingStats(t *testing.T) {
+	preview, truncated, stats, err := unifiedDiffPreview("example.txt", "alpha\n", "beta\n", 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated || len([]byte(preview)) > 16 {
+		t.Fatalf("preview length = %d, truncated = %v", len([]byte(preview)), truncated)
+	}
+	if stats != (diffStats{FilesChanged: 1, Insertions: 1, Deletions: 1}) {
+		t.Fatalf("stats = %#v", stats)
+	}
+}
+
+func TestUnifiedDiffPreviewReturnsEmptyForIdenticalContent(t *testing.T) {
+	preview, truncated, stats, err := unifiedDiffPreview("example.txt", "same\n", "same\n", 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview != "" || truncated || stats != (diffStats{}) {
+		t.Fatalf("preview = %q, truncated = %v, stats = %#v", preview, truncated, stats)
+	}
+}


### PR DESCRIPTION
## 问题

`file_edit` 的 replace、add 和 patch 路径在提交前会调用系统 `diff -u` 生成预览。Windows 正式安装包没有携带 `diff.exe`，Git for Windows 的 `usr/bin` 也不在 AgentDock 自启进程的 PATH 中，因此预览阶段返回 `executable file not found`，原子提交不会执行。

## 修改

- 使用 `github.com/rogpeppe/go-internal/diff` 的纯 Go anchored unified-diff 实现替代外部进程和临时文件
- 保留 `a/`、`b/` 标签、64 MiB 输出上限、预览截断与增删统计
- 保留空文件范围和文件末尾缺少换行的 unified diff 语义
- 增加 PATH 中不存在 `diff` 时的端到端文本编辑回归测试

## 验证

- `go test ./...`
- `go vet ./...`
- `go build -trimpath -o ./bin/agentdock-pr-test.exe ./cmd/agentdock`
- `go mod verify`
- `go test -race ./internal/tool/file -count=1`
- `go test -race ./internal/app -run 'Test(EditFile|ApplyEnvelopePatch|FileEdit)' -count=1`
- `node --check examples/browser-runner/browser-runner.js`
- `python scripts/test_recall_backup_export.py`