### PR TITLE
fix(windows): support cross-volume file listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ AGENTDOCK_OAUTH_ENABLED=true
 AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=***
 AGENTDOCK_OAUTH_TOKEN_SECRET=***
+# Optional Go duration; defaults to 1h and accepts 1m through 2160h
+AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 
 Then open **Settings > Plugins > Advanced settings** in ChatGPT, enable developer mode, and create a plugin using this MCP Server URL:

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=***
 AGENTDOCK_OAUTH_TOKEN_SECRET=***
 # Optional; defaults to 1h. Accepts Go durations, integer days such as 999999d, or never.
+# In never mode, the server does not expire access tokens and advertises 999999d to OAuth clients for compatibility.
 AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ AGENTDOCK_OAUTH_ENABLED=true
 AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=***
 AGENTDOCK_OAUTH_TOKEN_SECRET=***
-# Optional Go duration; defaults to 1h and accepts 1m through 2160h
+# Optional; defaults to 1h. Accepts Go durations, integer days such as 999999d, or never.
 AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,7 +300,7 @@ AGENTDOCK_OAUTH_ENABLED=true
 AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=<至少-12-个字符的授权密码>
 AGENTDOCK_OAUTH_TOKEN_SECRET=<至少-32-字节的随机签名密钥>
-# 可选，Go duration 格式，默认 1h，范围 1m 至 2160h
+# 可选，默认 1h；支持 Go duration、999999d 这类整数天数，或 never（永不过期）
 AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,6 +300,8 @@ AGENTDOCK_OAUTH_ENABLED=true
 AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=<至少-12-个字符的授权密码>
 AGENTDOCK_OAUTH_TOKEN_SECRET=<至少-32-字节的随机签名密钥>
+# 可选，Go duration 格式，默认 1h，范围 1m 至 2160h
+AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 
 然后进入 ChatGPT 的 **设置 > 插件 > 高级设置**，开启开发人员模式并创建插件，MCP Server URL 填写：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,7 +300,8 @@ AGENTDOCK_OAUTH_ENABLED=true
 AGENTDOCK_SERVER_URL=https://agentdock.example.com
 AGENTDOCK_OAUTH_PASSWORD=<至少-12-个字符的授权密码>
 AGENTDOCK_OAUTH_TOKEN_SECRET=<至少-32-字节的随机签名密钥>
-# 可选，默认 1h；支持 Go duration、999999d 这类整数天数，或 never（永不过期）
+# 可选，默认 1h；支持 Go duration、999999d 这类整数天数，或 never（服务端永不过期）
+# never 模式会为兼容 OAuth 客户端对外声明 999999d，但服务端不会让 Access Token 到期
 AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL=1h
 ```
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -33,15 +33,15 @@ const (
 )
 
 type OAuthStore struct {
-	mu          sync.Mutex
-	codes       map[string]OAuthCode
-	grants      map[string]OAuthGrant
-	clients     map[string]OAuthClientRegistration
-	accessIndex map[string]string
-	statePath   string
-	signingKey  string
-	accessTTL   time.Duration
-	refreshTTL  time.Duration
+	mu               sync.Mutex
+	codes            map[string]OAuthCode
+	grants           map[string]OAuthGrant
+	clients          map[string]OAuthClientRegistration
+	accessIndex      map[string]string
+	statePath        string
+	signingKey       string
+	accessTTLSeconds int64
+	refreshTTL       time.Duration
 }
 
 type OAuthCode struct {
@@ -55,15 +55,16 @@ type OAuthCode struct {
 }
 
 type OAuthGrant struct {
-	ClientID          string `json:"client_id"`
-	Resource          string `json:"resource"`
-	AccessTokenHash   string `json:"access_token_hash,omitempty"`
-	AccessIssuedAt    int64  `json:"access_issued_at,omitempty"`
-	AccessExpiresAt   int64  `json:"access_expires_at,omitempty"`
-	RefreshIssuedAt   int64  `json:"refresh_issued_at,omitempty"`
-	CurrentGeneration uint64 `json:"current_generation"`
-	ExpiresAt         int64  `json:"expires_at"`
-	Revoked           bool   `json:"revoked,omitempty"`
+	ClientID           string `json:"client_id"`
+	Resource           string `json:"resource"`
+	AccessTokenHash    string `json:"access_token_hash,omitempty"`
+	AccessIssuedAt     int64  `json:"access_issued_at,omitempty"`
+	AccessExpiresAt    int64  `json:"access_expires_at,omitempty"`
+	AccessNeverExpires bool   `json:"access_never_expires,omitempty"`
+	RefreshIssuedAt    int64  `json:"refresh_issued_at,omitempty"`
+	CurrentGeneration  uint64 `json:"current_generation"`
+	ExpiresAt          int64  `json:"expires_at"`
+	Revoked            bool   `json:"revoked,omitempty"`
 }
 
 type OAuthClientRegistration struct {
@@ -100,13 +101,13 @@ func NewOAuthStore() *OAuthStore {
 		panic(fmt.Sprintf("generate in-memory OAuth signing key: %v", err))
 	}
 	return &OAuthStore{
-		codes:       map[string]OAuthCode{},
-		grants:      map[string]OAuthGrant{},
-		clients:     map[string]OAuthClientRegistration{},
-		accessIndex: map[string]string{},
-		signingKey:  key,
-		accessTTL:   time.Hour,
-		refreshTTL:  90 * 24 * time.Hour,
+		codes:            map[string]OAuthCode{},
+		grants:           map[string]OAuthGrant{},
+		clients:          map[string]OAuthClientRegistration{},
+		accessIndex:      map[string]string{},
+		signingKey:       key,
+		accessTTLSeconds: int64(time.Hour / time.Second),
+		refreshTTL:       90 * 24 * time.Hour,
 	}
 }
 
@@ -246,7 +247,9 @@ func (s *OAuthStore) RevokeGrant(grantID string, ttl time.Duration) error {
 
 func (s *OAuthStore) pruneExpiredGrantsLocked(now int64) {
 	for grantID, grant := range s.grants {
-		if grant.ExpiresAt <= now {
+		accessAlive := !grant.Revoked && (grant.AccessNeverExpires || grant.AccessExpiresAt > now)
+		refreshAlive := grant.ExpiresAt > now
+		if !accessAlive && !refreshAlive {
 			delete(s.accessIndex, grant.AccessTokenHash)
 			delete(s.grants, grantID)
 		}
@@ -320,8 +323,10 @@ func (s *OAuthStore) persistStateLocked() error {
 
 func validStoredGrant(grantID string, grant OAuthGrant, now int64) bool {
 	decoded, err := base64.RawURLEncoding.DecodeString(grantID)
+	accessAlive := !grant.Revoked && (grant.AccessNeverExpires || grant.AccessExpiresAt > now)
+	refreshAlive := grant.ExpiresAt > now
 	return err == nil && len(decoded) == 24 &&
-		grant.ExpiresAt > now &&
+		(accessAlive || refreshAlive) &&
 		(grant.Revoked || grant.ClientID != "" && grant.Resource != "")
 }
 

--- a/internal/auth/oauth_manager.go
+++ b/internal/auth/oauth_manager.go
@@ -21,9 +21,11 @@ const oauthResourceExtension = "resource"
 func NewOAuthManager(
 	store *OAuthStore,
 	signingKey string,
-	accessTTL, refreshTTL time.Duration,
+	accessTTLSeconds int64,
+	refreshTTL time.Duration,
 ) *manage.Manager {
-	store.configureOAuthFramework(signingKey, accessTTL, refreshTTL)
+	store.configureOAuthFramework(signingKey, accessTTLSeconds, refreshTTL)
+	accessTTL := oauthFrameworkTTL(accessTTLSeconds)
 
 	manager := manage.NewDefaultManager()
 	manager.MapClientStorage(oauthClientStore{store: store})
@@ -58,6 +60,16 @@ func NewOAuthManager(
 		info.SetExtension(url.Values{oauthResourceExtension: []string{resource}})
 	})
 	return manager
+}
+
+// go-oauth2 使用 time.Duration 表示令牌寿命，超出约 292 年后会溢出。
+// 对更长的配置返回 0，利用框架的“不自动过期”语义；精确到期时间仍由 OAuthStore 校验。
+func oauthFrameworkTTL(seconds int64) time.Duration {
+	const maxDurationSeconds = int64((1<<63 - 1) / time.Second)
+	if seconds <= 0 || seconds > maxDurationSeconds {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 type oauthClientStore struct {

--- a/internal/auth/oauth_manager_test.go
+++ b/internal/auth/oauth_manager_test.go
@@ -184,6 +184,46 @@ func TestOAuthFrameworkRefreshRotationStateRemainsBounded(t *testing.T) {
 	}
 }
 
+func TestOAuthFrameworkSupportsNeverExpiringAccessToken(t *testing.T) {
+	store := NewOAuthStore()
+	clientID, err := store.RegisterClient(
+		"never-expiring test",
+		[]string{frameworkTestRedirect},
+		[]string{gooauth2.AuthorizationCode.String(), gooauth2.Refreshing.String()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewOAuthManager(store, frameworkTestKey, 0, 90*24*time.Hour)
+	ctx := oauthFrameworkTestContext(clientID, frameworkTestResource)
+	issued := authorizeAndExchangeWithFramework(t, manager, clientID, ctx)
+	info, err := manager.LoadAccessToken(ctx, issued.Access)
+	if err != nil {
+		t.Fatalf("LoadAccessToken() error = %v", err)
+	}
+	if info.GetAccessExpiresIn() != 0 {
+		t.Fatalf("access token lifetime = %s, want no expiration", info.GetAccessExpiresIn())
+	}
+
+	store.mu.Lock()
+	for grantID, grant := range store.grants {
+		if !grant.AccessNeverExpires || grant.AccessExpiresAt != 0 {
+			store.mu.Unlock()
+			t.Fatalf("grant = %#v, want permanent access token metadata", grant)
+		}
+		grant.ExpiresAt = time.Now().Add(-time.Second).Unix()
+		store.grants[grantID] = grant
+	}
+	store.mu.Unlock()
+
+	if _, err := manager.LoadAccessToken(ctx, issued.Access); err != nil {
+		t.Fatalf("access token expired with its refresh token: %v", err)
+	}
+	if _, err := manager.RefreshAccessToken(ctx, refreshRequest(issued.Refresh, clientID, frameworkTestResource)); err == nil {
+		t.Fatal("expired refresh token remained active")
+	}
+}
+
 type oauthFrameworkTokens struct {
 	Code    string
 	Access  string
@@ -208,7 +248,7 @@ func newOAuthFrameworkTestManagerForClient(t *testing.T, store *OAuthStore, clie
 	manager := NewOAuthManager(
 		store,
 		frameworkTestKey,
-		time.Hour,
+		int64(time.Hour/time.Second),
 		90*24*time.Hour,
 	)
 	return manager, clientID

--- a/internal/auth/oauth_token_store.go
+++ b/internal/auth/oauth_token_store.go
@@ -15,14 +15,14 @@ import (
 	"github.com/go-oauth2/oauth2/v4/models"
 )
 
-func (s *OAuthStore) configureOAuthFramework(signingKey string, accessTTL, refreshTTL time.Duration) {
+func (s *OAuthStore) configureOAuthFramework(signingKey string, accessTTLSeconds int64, refreshTTL time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if value := strings.TrimSpace(signingKey); value != "" {
 		s.signingKey = value
 	}
-	if accessTTL > 0 {
-		s.accessTTL = accessTTL
+	if accessTTLSeconds >= 0 {
+		s.accessTTLSeconds = accessTTLSeconds
 	}
 	if refreshTTL > 0 {
 		s.refreshTTL = refreshTTL
@@ -89,14 +89,22 @@ func (s *OAuthStore) storeGrantTokens(info gooauth2.TokenInfo) error {
 	}
 
 	accessIssuedAt := info.GetAccessCreateAt()
-	accessExpiresAt := accessIssuedAt.Add(info.GetAccessExpiresIn())
+	accessNeverExpires := s.accessTTLSeconds == 0
+	var accessExpiresAt int64
+	if !accessNeverExpires {
+		var ok bool
+		accessExpiresAt, ok = unixAfterSeconds(accessIssuedAt, s.accessTTLSeconds)
+		if !ok {
+			return errors.New("OAuth access token lifetime overflows Unix time")
+		}
+	}
 	grantExpiresAt := accessExpiresAt
 	refreshIssuedAt := time.Time{}
 	if refresh != "" {
 		refreshIssuedAt = info.GetRefreshCreateAt()
-		grantExpiresAt = refreshIssuedAt.Add(info.GetRefreshExpiresIn())
+		grantExpiresAt = refreshIssuedAt.Add(info.GetRefreshExpiresIn()).Unix()
 	}
-	if !accessExpiresAt.After(time.Now()) || !grantExpiresAt.After(time.Now()) {
+	if (!accessNeverExpires && accessExpiresAt <= time.Now().Unix()) || (grantExpiresAt != 0 && grantExpiresAt <= time.Now().Unix()) {
 		return errors.New("OAuth token lifetime is already expired")
 	}
 
@@ -121,13 +129,14 @@ func (s *OAuthStore) storeGrantTokens(info gooauth2.TokenInfo) error {
 	}
 
 	grant := OAuthGrant{
-		ClientID:          clientID,
-		Resource:          resource,
-		AccessTokenHash:   hashOAuthToken(access),
-		AccessIssuedAt:    accessIssuedAt.Unix(),
-		AccessExpiresAt:   accessExpiresAt.Unix(),
-		CurrentGeneration: generation,
-		ExpiresAt:         grantExpiresAt.Unix(),
+		ClientID:           clientID,
+		Resource:           resource,
+		AccessTokenHash:    hashOAuthToken(access),
+		AccessIssuedAt:     accessIssuedAt.Unix(),
+		AccessExpiresAt:    accessExpiresAt,
+		AccessNeverExpires: accessNeverExpires,
+		CurrentGeneration:  generation,
+		ExpiresAt:          grantExpiresAt,
 	}
 	if !refreshIssuedAt.IsZero() {
 		grant.RefreshIssuedAt = refreshIssuedAt.Unix()
@@ -224,7 +233,7 @@ func (s *OAuthStore) GetByAccess(ctx context.Context, raw string) (gooauth2.Toke
 		grantID = legacyGrantID
 	}
 	grant, ok := s.grants[grantID]
-	if !ok || grant.Revoked || grant.ExpiresAt <= now {
+	if !ok || grant.Revoked {
 		return nil, nil
 	}
 	if expected := oauthResourceFromContext(ctx); expected != "" && !EquivalentResourceURI(grant.Resource, expected) {
@@ -236,10 +245,10 @@ func (s *OAuthStore) GetByAccess(ctx context.Context, raw string) (gooauth2.Toke
 	if grant.AccessTokenHash != "" && grant.AccessTokenHash != hash {
 		return nil, nil
 	}
-	if grant.AccessExpiresAt != 0 && grant.AccessExpiresAt <= now {
+	if !grant.AccessNeverExpires && (grant.AccessExpiresAt == 0 || grant.AccessExpiresAt <= now) {
 		return nil, nil
 	}
-	return tokenInfoForGrant(grantID, grant, raw, "", s.accessTTL, s.refreshTTL), nil
+	return tokenInfoForGrant(grantID, grant, raw, "", s.accessTTLSeconds, s.refreshTTL), nil
 }
 
 func (s *OAuthStore) GetByRefresh(ctx context.Context, raw string) (gooauth2.TokenInfo, error) {
@@ -278,7 +287,7 @@ func (s *OAuthStore) GetByRefresh(ctx context.Context, raw string) (gooauth2.Tok
 		}
 		return nil, nil
 	}
-	return tokenInfoForGrant(claims.GrantID, grant, "", raw, s.accessTTL, s.refreshTTL), nil
+	return tokenInfoForGrant(claims.GrantID, grant, "", raw, s.accessTTLSeconds, s.refreshTTL), nil
 }
 
 func (s *OAuthStore) revokeByAccess(raw string) error {
@@ -332,7 +341,7 @@ func tokenInfoForCode(raw string, code OAuthCode) gooauth2.TokenInfo {
 	return info
 }
 
-func tokenInfoForGrant(grantID string, grant OAuthGrant, access, refresh string, accessTTL, refreshTTL time.Duration) gooauth2.TokenInfo {
+func tokenInfoForGrant(grantID string, grant OAuthGrant, access, refresh string, accessTTLSeconds int64, refreshTTL time.Duration) gooauth2.TokenInfo {
 	info := models.NewToken()
 	info.SetClientID(grant.ClientID)
 	info.SetUserID(grantID)
@@ -345,10 +354,12 @@ func tokenInfoForGrant(grantID string, grant OAuthGrant, access, refresh string,
 		accessIssuedAt = time.Now()
 	}
 	info.SetAccessCreateAt(accessIssuedAt)
-	if grant.AccessExpiresAt > grant.AccessIssuedAt {
-		info.SetAccessExpiresIn(time.Unix(grant.AccessExpiresAt, 0).Sub(accessIssuedAt))
+	if grant.AccessNeverExpires {
+		info.SetAccessExpiresIn(0)
+	} else if grant.AccessExpiresAt > grant.AccessIssuedAt {
+		info.SetAccessExpiresIn(oauthFrameworkTTL(grant.AccessExpiresAt - grant.AccessIssuedAt))
 	} else {
-		info.SetAccessExpiresIn(accessTTL)
+		info.SetAccessExpiresIn(oauthFrameworkTTL(accessTTLSeconds))
 	}
 
 	if refresh != "" {
@@ -360,6 +371,13 @@ func tokenInfoForGrant(grantID string, grant OAuthGrant, access, refresh string,
 		info.SetRefreshExpiresIn(time.Unix(grant.ExpiresAt, 0).Sub(refreshIssuedAt))
 	}
 	return info
+}
+
+func unixAfterSeconds(start time.Time, seconds int64) (int64, bool) {
+	if seconds <= 0 || start.Unix() > (1<<63-1)-seconds {
+		return 0, false
+	}
+	return start.Unix() + seconds, true
 }
 
 func resourceFromTokenInfo(info gooauth2.TokenInfo) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,33 +23,37 @@ const (
 	BrowserRunnerDir   = "browser-runner"
 	BrowserArtifactDir = "browser-artifacts"
 	RecallTimeoutMS    = 30000
+
+	defaultOAuthAccessTokenTTLSeconds = int64(time.Hour / time.Second)
+	maxOAuthAccessTokenTTLSeconds     = int64(999999 * 24 * 60 * 60)
 )
 
 type Config struct {
-	AgentDockHome       string
-	AgentDockDefaultDir string
-	Host                string
-	Port                int
-	AuthToken           string
-	OAuthEnabled        bool
-	OAuthServerURL      string
-	OAuthAccessTokenTTL time.Duration
-	LogLevel            string
-	NexusEndpoint       string
-	NexusToken          string
-	BrowserEnabled      bool
-	BrowserRunnerDir    string
-	BrowserNodePath     string
-	ACPEnabled          bool
-	ACPAgentName        string
-	ACPCommand          string
-	ACPArgs             []string
-	ACPEnvFromEnv       map[string]string
-	ACPAllowedRoots     []string
-	ACPMaxPrompts       int
-	ACPInteractionMS    int
-	Stdio               bool
-	TrustedProxyCIDRs   []string
+	AgentDockHome                string
+	AgentDockDefaultDir          string
+	Host                         string
+	Port                         int
+	AuthToken                    string
+	OAuthEnabled                 bool
+	OAuthServerURL               string
+	OAuthAccessTokenTTLSeconds   int64
+	OAuthAccessTokenNeverExpires bool
+	LogLevel                     string
+	NexusEndpoint                string
+	NexusToken                   string
+	BrowserEnabled               bool
+	BrowserRunnerDir             string
+	BrowserNodePath              string
+	ACPEnabled                   bool
+	ACPAgentName                 string
+	ACPCommand                   string
+	ACPArgs                      []string
+	ACPEnvFromEnv                map[string]string
+	ACPAllowedRoots              []string
+	ACPMaxPrompts                int
+	ACPInteractionMS             int
+	Stdio                        bool
+	TrustedProxyCIDRs            []string
 }
 
 func FromEnv() (Config, error) {
@@ -65,7 +69,7 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	oauthAccessTokenTTL, err := getenvDuration("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", time.Hour)
+	oauthAccessTokenTTLSeconds, oauthAccessTokenNeverExpires, err := getenvOAuthAccessTokenTTL("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", defaultOAuthAccessTokenTTLSeconds)
 	if err != nil {
 		return Config{}, err
 	}
@@ -106,30 +110,31 @@ func FromEnv() (Config, error) {
 		}
 	}
 	return Config{
-		AgentDockHome:       strings.TrimSpace(os.Getenv("AGENTDOCK_HOME")),
-		AgentDockDefaultDir: strings.TrimSpace(os.Getenv("AGENTDOCK_DEFAULT_DIR")),
-		Host:                getenv("AGENTDOCK_HOST", "127.0.0.1"),
-		Port:                port,
-		AuthToken:           os.Getenv("AGENTDOCK_AUTH_TOKEN"),
-		OAuthEnabled:        oauthEnabled,
-		OAuthServerURL:      os.Getenv("AGENTDOCK_SERVER_URL"),
-		OAuthAccessTokenTTL: oauthAccessTokenTTL,
-		LogLevel:            getenv("AGENTDOCK_LOG_LEVEL", "info"),
-		NexusEndpoint:       getenv("AGENTDOCK_NEXUS_ENDPOINT", ""),
-		NexusToken:          os.Getenv("AGENTDOCK_NEXUS_TOKEN"),
-		BrowserEnabled:      browserEnabled,
-		BrowserRunnerDir:    os.Getenv("AGENTDOCK_BROWSER_RUNNER_DIR"),
-		BrowserNodePath:     os.Getenv("AGENTDOCK_BROWSER_NODE_PATH"),
-		ACPEnabled:          acpEnabled,
-		ACPAgentName:        acpAgentName,
-		ACPCommand:          acpCommand,
-		ACPArgs:             acpArgs,
-		ACPEnvFromEnv:       acpEnvFromEnv,
-		ACPAllowedRoots:     acpAllowedRoots,
-		ACPMaxPrompts:       acpMaxPrompts,
-		ACPInteractionMS:    acpInteractionMS,
-		Stdio:               stdio,
-		TrustedProxyCIDRs:   splitCommaSeparated(os.Getenv("AGENTDOCK_TRUSTED_PROXY_CIDRS")),
+		AgentDockHome:                strings.TrimSpace(os.Getenv("AGENTDOCK_HOME")),
+		AgentDockDefaultDir:          strings.TrimSpace(os.Getenv("AGENTDOCK_DEFAULT_DIR")),
+		Host:                         getenv("AGENTDOCK_HOST", "127.0.0.1"),
+		Port:                         port,
+		AuthToken:                    os.Getenv("AGENTDOCK_AUTH_TOKEN"),
+		OAuthEnabled:                 oauthEnabled,
+		OAuthServerURL:               os.Getenv("AGENTDOCK_SERVER_URL"),
+		OAuthAccessTokenTTLSeconds:   oauthAccessTokenTTLSeconds,
+		OAuthAccessTokenNeverExpires: oauthAccessTokenNeverExpires,
+		LogLevel:                     getenv("AGENTDOCK_LOG_LEVEL", "info"),
+		NexusEndpoint:                getenv("AGENTDOCK_NEXUS_ENDPOINT", ""),
+		NexusToken:                   os.Getenv("AGENTDOCK_NEXUS_TOKEN"),
+		BrowserEnabled:               browserEnabled,
+		BrowserRunnerDir:             os.Getenv("AGENTDOCK_BROWSER_RUNNER_DIR"),
+		BrowserNodePath:              os.Getenv("AGENTDOCK_BROWSER_NODE_PATH"),
+		ACPEnabled:                   acpEnabled,
+		ACPAgentName:                 acpAgentName,
+		ACPCommand:                   acpCommand,
+		ACPArgs:                      acpArgs,
+		ACPEnvFromEnv:                acpEnvFromEnv,
+		ACPAllowedRoots:              acpAllowedRoots,
+		ACPMaxPrompts:                acpMaxPrompts,
+		ACPInteractionMS:             acpInteractionMS,
+		Stdio:                        stdio,
+		TrustedProxyCIDRs:            splitCommaSeparated(os.Getenv("AGENTDOCK_TRUSTED_PROXY_CIDRS")),
 	}, nil
 }
 
@@ -197,11 +202,16 @@ func (c *Config) Normalize() error {
 		c.Host = "127.0.0.1"
 	}
 	c.OAuthServerURL = strings.TrimSpace(c.OAuthServerURL)
-	if c.OAuthAccessTokenTTL == 0 {
-		c.OAuthAccessTokenTTL = time.Hour
+	if c.OAuthAccessTokenNeverExpires {
+		c.OAuthAccessTokenTTLSeconds = 0
+	} else if c.OAuthAccessTokenTTLSeconds == 0 {
+		c.OAuthAccessTokenTTLSeconds = defaultOAuthAccessTokenTTLSeconds
 	}
-	if c.OAuthAccessTokenTTL < time.Minute || c.OAuthAccessTokenTTL > 90*24*time.Hour {
-		return fmt.Errorf("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL must be between 1m and 2160h: %s", c.OAuthAccessTokenTTL)
+	if !c.OAuthAccessTokenNeverExpires && (c.OAuthAccessTokenTTLSeconds < int64(time.Minute/time.Second) || c.OAuthAccessTokenTTLSeconds > maxOAuthAccessTokenTTLSeconds) {
+		return fmt.Errorf(
+			"AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL must be between 1m and 999999d: %ds",
+			c.OAuthAccessTokenTTLSeconds,
+		)
 	}
 	if c.Port == 0 {
 		c.Port = 8765
@@ -447,16 +457,29 @@ func getenvBool(key string, fallback bool) (bool, error) {
 	return parsed, nil
 }
 
-func getenvDuration(key string, fallback time.Duration) (time.Duration, error) {
+func getenvOAuthAccessTokenTTL(key string, fallback int64) (seconds int64, never bool, err error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
-		return fallback, nil
+		return fallback, false, nil
+	}
+	if strings.EqualFold(value, "never") {
+		return 0, true, nil
+	}
+	if strings.HasSuffix(strings.ToLower(value), "d") {
+		days, err := strconv.ParseInt(strings.TrimSpace(value[:len(value)-1]), 10, 64)
+		if err != nil || days <= 0 || days > maxOAuthAccessTokenTTLSeconds/(24*60*60) {
+			return 0, false, fmt.Errorf("parse %s as duration: invalid day count %q", key, value)
+		}
+		return days * 24 * 60 * 60, false, nil
 	}
 	parsed, err := time.ParseDuration(value)
 	if err != nil {
-		return 0, fmt.Errorf("parse %s as duration: %w", key, err)
+		return 0, false, fmt.Errorf("parse %s as duration: %w", key, err)
 	}
-	return parsed, nil
+	if parsed%time.Second != 0 {
+		return 0, false, fmt.Errorf("parse %s as duration: value must use whole seconds", key)
+	}
+	return int64(parsed / time.Second), false, nil
 }
 
 func getenvStringSliceJSON(key string) ([]string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/uvwt/agentdock/internal/fs/securepath"
 )
@@ -32,6 +33,7 @@ type Config struct {
 	AuthToken           string
 	OAuthEnabled        bool
 	OAuthServerURL      string
+	OAuthAccessTokenTTL time.Duration
 	LogLevel            string
 	NexusEndpoint       string
 	NexusToken          string
@@ -60,6 +62,10 @@ func FromEnv() (Config, error) {
 		return Config{}, err
 	}
 	oauthEnabled, err := getenvBool("AGENTDOCK_OAUTH_ENABLED", false)
+	if err != nil {
+		return Config{}, err
+	}
+	oauthAccessTokenTTL, err := getenvDuration("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", time.Hour)
 	if err != nil {
 		return Config{}, err
 	}
@@ -107,6 +113,7 @@ func FromEnv() (Config, error) {
 		AuthToken:           os.Getenv("AGENTDOCK_AUTH_TOKEN"),
 		OAuthEnabled:        oauthEnabled,
 		OAuthServerURL:      os.Getenv("AGENTDOCK_SERVER_URL"),
+		OAuthAccessTokenTTL: oauthAccessTokenTTL,
 		LogLevel:            getenv("AGENTDOCK_LOG_LEVEL", "info"),
 		NexusEndpoint:       getenv("AGENTDOCK_NEXUS_ENDPOINT", ""),
 		NexusToken:          os.Getenv("AGENTDOCK_NEXUS_TOKEN"),
@@ -190,6 +197,12 @@ func (c *Config) Normalize() error {
 		c.Host = "127.0.0.1"
 	}
 	c.OAuthServerURL = strings.TrimSpace(c.OAuthServerURL)
+	if c.OAuthAccessTokenTTL == 0 {
+		c.OAuthAccessTokenTTL = time.Hour
+	}
+	if c.OAuthAccessTokenTTL < time.Minute || c.OAuthAccessTokenTTL > 90*24*time.Hour {
+		return fmt.Errorf("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL must be between 1m and 2160h: %s", c.OAuthAccessTokenTTL)
+	}
 	if c.Port == 0 {
 		c.Port = 8765
 	}
@@ -430,6 +443,18 @@ func getenvBool(key string, fallback bool) (bool, error) {
 	parsed, err := strconv.ParseBool(value)
 	if err != nil {
 		return false, fmt.Errorf("parse %s as boolean: %w", key, err)
+	}
+	return parsed, nil
+}
+
+func getenvDuration(key string, fallback time.Duration) (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s as duration: %w", key, err)
 	}
 	return parsed, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,26 +227,49 @@ func TestFromEnvParsesTypedValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromEnv() error = %v", err)
 	}
-	if cfg.Port != 9876 || !cfg.BrowserEnabled || !cfg.OAuthEnabled || !cfg.Stdio || cfg.OAuthAccessTokenTTL != 24*time.Hour ||
+	if cfg.Port != 9876 || !cfg.BrowserEnabled || !cfg.OAuthEnabled || !cfg.Stdio || cfg.OAuthAccessTokenTTLSeconds != int64(24*time.Hour/time.Second) ||
 		cfg.BrowserRunnerDir != runnerDir || cfg.BrowserNodePath != nodePath {
 		t.Fatalf("config = %#v", cfg)
+	}
+}
+
+func TestFromEnvParsesLongOAuthAccessTokenTTLInDays(t *testing.T) {
+	t.Setenv("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", "999999d")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	want := int64(999999 * 24 * 60 * 60)
+	if cfg.OAuthAccessTokenTTLSeconds != want {
+		t.Fatalf("OAuthAccessTokenTTLSeconds = %d, want %d", cfg.OAuthAccessTokenTTLSeconds, want)
+	}
+}
+
+func TestFromEnvParsesNeverExpiringOAuthAccessToken(t *testing.T) {
+	t.Setenv("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", "never")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if !cfg.OAuthAccessTokenNeverExpires || cfg.OAuthAccessTokenTTLSeconds != 0 {
+		t.Fatalf("config = %#v, want a non-expiring OAuth access token", cfg)
 	}
 }
 
 func TestNormalizeValidatesOAuthAccessTokenTTL(t *testing.T) {
 	home := t.TempDir()
 	for _, test := range []struct {
-		name string
-		ttl  time.Duration
+		name       string
+		ttlSeconds int64
 	}{
-		{name: "too short", ttl: time.Second},
-		{name: "too long", ttl: 90*24*time.Hour + time.Second},
+		{name: "too short", ttlSeconds: 1},
+		{name: "too long", ttlSeconds: int64(999999*24*60*60) + 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := Config{
-				AgentDockHome:       filepath.Join(home, test.name, "home"),
-				AgentDockDefaultDir: filepath.Join(home, test.name, "workspace"),
-				OAuthAccessTokenTTL: test.ttl,
+				AgentDockHome:              filepath.Join(home, test.name, "home"),
+				AgentDockDefaultDir:        filepath.Join(home, test.name, "workspace"),
+				OAuthAccessTokenTTLSeconds: test.ttlSeconds,
 			}
 			if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL") {
 				t.Fatalf("Normalize() error = %v, want OAuth access token TTL error", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func setTestUserHome(t *testing.T, home string) {
@@ -193,6 +194,7 @@ func TestFromEnvRejectsInvalidTypedValues(t *testing.T) {
 		{name: "port", key: "AGENTDOCK_PORT", value: "not-a-number"},
 		{name: "browser enabled", key: "AGENTDOCK_BROWSER_ENABLED", value: "sometimes"},
 		{name: "oauth enabled", key: "AGENTDOCK_OAUTH_ENABLED", value: "enabled"},
+		{name: "oauth access token ttl", key: "AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", value: "one-day"},
 		{name: "stdio", key: "AGENTDOCK_STDIO", value: "enabled"},
 	}
 	for _, test := range tests {
@@ -200,6 +202,7 @@ func TestFromEnvRejectsInvalidTypedValues(t *testing.T) {
 			t.Setenv("AGENTDOCK_PORT", "")
 			t.Setenv("AGENTDOCK_BROWSER_ENABLED", "")
 			t.Setenv("AGENTDOCK_OAUTH_ENABLED", "")
+			t.Setenv("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", "")
 			t.Setenv("AGENTDOCK_STDIO", "")
 			t.Setenv(test.key, test.value)
 			if _, err := FromEnv(); err == nil || !strings.Contains(err.Error(), test.key) {
@@ -218,14 +221,37 @@ func TestFromEnvParsesTypedValues(t *testing.T) {
 	t.Setenv("AGENTDOCK_BROWSER_RUNNER_DIR", runnerDir)
 	t.Setenv("AGENTDOCK_BROWSER_NODE_PATH", nodePath)
 	t.Setenv("AGENTDOCK_OAUTH_ENABLED", "true")
+	t.Setenv("AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL", "24h")
 	t.Setenv("AGENTDOCK_STDIO", "1")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv() error = %v", err)
 	}
-	if cfg.Port != 9876 || !cfg.BrowserEnabled || !cfg.OAuthEnabled || !cfg.Stdio ||
+	if cfg.Port != 9876 || !cfg.BrowserEnabled || !cfg.OAuthEnabled || !cfg.Stdio || cfg.OAuthAccessTokenTTL != 24*time.Hour ||
 		cfg.BrowserRunnerDir != runnerDir || cfg.BrowserNodePath != nodePath {
 		t.Fatalf("config = %#v", cfg)
+	}
+}
+
+func TestNormalizeValidatesOAuthAccessTokenTTL(t *testing.T) {
+	home := t.TempDir()
+	for _, test := range []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{name: "too short", ttl: time.Second},
+		{name: "too long", ttl: 90*24*time.Hour + time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Config{
+				AgentDockHome:       filepath.Join(home, test.name, "home"),
+				AgentDockDefaultDir: filepath.Join(home, test.name, "workspace"),
+				OAuthAccessTokenTTL: test.ttl,
+			}
+			if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL") {
+				t.Fatalf("Normalize() error = %v, want OAuth access token TTL error", err)
+			}
+		})
 	}
 }
 

--- a/internal/httpx/oauth_flow_test.go
+++ b/internal/httpx/oauth_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/uvwt/agentdock/internal/auth"
 	"github.com/uvwt/agentdock/internal/config"
@@ -562,6 +563,63 @@ func oauthTestConfig(t *testing.T) config.Config {
 	cfg.OAuthEnabled = true
 	cfg.OAuthServerURL = "https://agentdock.example"
 	return cfg
+}
+
+func TestOAuthAccessTokenTTLUsesConfiguration(t *testing.T) {
+	t.Setenv("AGENTDOCK_OAUTH_PASSWORD", "")
+	t.Setenv("AGENTDOCK_OAUTH_TOKEN_SECRET", "token-signing-secret")
+	cfg := oauthTestConfig(t)
+	cfg.OAuthAccessTokenTTL = 24 * time.Hour
+	store := auth.NewOAuthStore()
+	clientID := oauthRegisteredClientID(t, store, oauthTestRedirect)
+	resource := cfg.OAuthServerURL + "/mcp"
+	authorizeValues := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {oauthTestRedirect},
+		"code_challenge":        {oauthTestChallenge},
+		"code_challenge_method": {"S256"},
+		"resource":              {resource},
+		"state":                 {"state-value"},
+	}
+	authorizeResponse := httptest.NewRecorder()
+	handleAuthorizeForTest(
+		authorizeResponse,
+		httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+authorizeValues.Encode(), nil),
+		cfg,
+		store,
+	)
+	if authorizeResponse.Code != http.StatusFound {
+		t.Fatalf("authorize status = %d; body=%s", authorizeResponse.Code, authorizeResponse.Body.String())
+	}
+	location, err := url.Parse(authorizeResponse.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := location.Query().Get("code")
+	if code == "" {
+		t.Fatalf("authorization redirect = %s", location)
+	}
+	response := postTokenRequest(t, cfg, store, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {oauthTestRedirect},
+		"client_id":     {clientID},
+		"code_verifier": {oauthTestVerifier},
+		"resource":      {resource},
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("token status = %d; body=%s", response.Code, response.Body.String())
+	}
+	var payload struct {
+		ExpiresIn int `json:"expires_in"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ExpiresIn != int((24 * time.Hour).Seconds()) {
+		t.Fatalf("expires_in = %d, want %d", payload.ExpiresIn, int((24 * time.Hour).Seconds()))
+	}
 }
 
 func postTokenRequest(t *testing.T, cfg config.Config, codes *auth.OAuthStore, values url.Values) *httptest.ResponseRecorder {

--- a/internal/httpx/oauth_flow_test.go
+++ b/internal/httpx/oauth_flow_test.go
@@ -590,19 +590,18 @@ func TestOAuthAccessTokenCanBeConfiguredToNeverExpire(t *testing.T) {
 	cfg.OAuthAccessTokenTTLSeconds = 0
 	store := auth.NewOAuthStore()
 	response := issueOAuthTokenForTTLTest(t, cfg, store)
-	var payload map[string]json.RawMessage
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
 	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
 		t.Fatal(err)
 	}
-	if _, exists := payload["expires_in"]; exists {
-		t.Fatalf("token response = %s, want expires_in omitted", response.Body.String())
-	}
-	var accessToken string
-	if err := json.Unmarshal(payload["access_token"], &accessToken); err != nil {
-		t.Fatal(err)
+	if payload.ExpiresIn != neverOAuthClientExpiresInSeconds {
+		t.Fatalf("expires_in = %d, want compatibility value %d", payload.ExpiresIn, neverOAuthClientExpiresInSeconds)
 	}
 	request := httptest.NewRequest(http.MethodPost, cfg.OAuthServerURL+"/mcp", nil)
-	request.Header.Set("Authorization", "Bearer "+accessToken)
+	request.Header.Set("Authorization", "Bearer "+payload.AccessToken)
 	ctx := auth.WithOAuthRequest(request.Context(), cfg.OAuthServerURL, cfg.OAuthServerURL+"/mcp", "")
 	if _, err := newOAuthProtocolServer(cfg, store).ValidationBearerToken(request.WithContext(ctx)); err != nil {
 		t.Fatalf("ValidationBearerToken() error = %v", err)

--- a/internal/httpx/oauth_flow_test.go
+++ b/internal/httpx/oauth_flow_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/uvwt/agentdock/internal/auth"
 	"github.com/uvwt/agentdock/internal/config"
@@ -569,8 +568,49 @@ func TestOAuthAccessTokenTTLUsesConfiguration(t *testing.T) {
 	t.Setenv("AGENTDOCK_OAUTH_PASSWORD", "")
 	t.Setenv("AGENTDOCK_OAUTH_TOKEN_SECRET", "token-signing-secret")
 	cfg := oauthTestConfig(t)
-	cfg.OAuthAccessTokenTTL = 24 * time.Hour
+	cfg.OAuthAccessTokenTTLSeconds = int64(999999 * 24 * 60 * 60)
 	store := auth.NewOAuthStore()
+	response := issueOAuthTokenForTTLTest(t, cfg, store)
+	var payload struct {
+		ExpiresIn int64 `json:"expires_in"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ExpiresIn != cfg.OAuthAccessTokenTTLSeconds {
+		t.Fatalf("expires_in = %d, want %d", payload.ExpiresIn, cfg.OAuthAccessTokenTTLSeconds)
+	}
+}
+
+func TestOAuthAccessTokenCanBeConfiguredToNeverExpire(t *testing.T) {
+	t.Setenv("AGENTDOCK_OAUTH_PASSWORD", "")
+	t.Setenv("AGENTDOCK_OAUTH_TOKEN_SECRET", "token-signing-secret")
+	cfg := oauthTestConfig(t)
+	cfg.OAuthAccessTokenNeverExpires = true
+	cfg.OAuthAccessTokenTTLSeconds = 0
+	store := auth.NewOAuthStore()
+	response := issueOAuthTokenForTTLTest(t, cfg, store)
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["expires_in"]; exists {
+		t.Fatalf("token response = %s, want expires_in omitted", response.Body.String())
+	}
+	var accessToken string
+	if err := json.Unmarshal(payload["access_token"], &accessToken); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, cfg.OAuthServerURL+"/mcp", nil)
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	ctx := auth.WithOAuthRequest(request.Context(), cfg.OAuthServerURL, cfg.OAuthServerURL+"/mcp", "")
+	if _, err := newOAuthProtocolServer(cfg, store).ValidationBearerToken(request.WithContext(ctx)); err != nil {
+		t.Fatalf("ValidationBearerToken() error = %v", err)
+	}
+}
+
+func issueOAuthTokenForTTLTest(t *testing.T, cfg config.Config, store *auth.OAuthStore) *httptest.ResponseRecorder {
+	t.Helper()
 	clientID := oauthRegisteredClientID(t, store, oauthTestRedirect)
 	resource := cfg.OAuthServerURL + "/mcp"
 	authorizeValues := url.Values{
@@ -611,15 +651,7 @@ func TestOAuthAccessTokenTTLUsesConfiguration(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("token status = %d; body=%s", response.Code, response.Body.String())
 	}
-	var payload struct {
-		ExpiresIn int `json:"expires_in"`
-	}
-	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
-		t.Fatal(err)
-	}
-	if payload.ExpiresIn != int((24 * time.Hour).Seconds()) {
-		t.Fatalf("expires_in = %d, want %d", payload.ExpiresIn, int((24 * time.Hour).Seconds()))
-	}
+	return response
 }
 
 func postTokenRequest(t *testing.T, cfg config.Config, codes *auth.OAuthStore, values url.Values) *httptest.ResponseRecorder {

--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	defaultOAuthAccessTokenTTLSeconds = int64(time.Hour / time.Second)
+	neverOAuthClientExpiresInSeconds  = int64(999999 * 24 * 60 * 60)
 	oauthRefreshTokenTTL              = 90 * 24 * time.Hour
 	oauthFormBodyLimit                = 64 << 10
 )
@@ -834,7 +835,9 @@ func newOAuthProtocolServer(cfg config.Config, store *auth.OAuthStore) *oauthser
 	protocol.SetResponseTokenHandler(func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error {
 		if _, issued := data["access_token"]; issued {
 			if cfg.OAuthAccessTokenNeverExpires {
-				delete(data, "expires_in")
+				// ChatGPT 当前不会持久保存缺少 expires_in 的 OAuth 令牌。
+				// 服务端仍按永久令牌校验，这个极远的有限值只用于客户端兼容。
+				data["expires_in"] = neverOAuthClientExpiresInSeconds
 			} else {
 				data["expires_in"] = accessTokenTTLSeconds
 			}

--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	defaultOAuthAccessTokenTTL = time.Hour
-	oauthRefreshTokenTTL       = 90 * 24 * time.Hour
-	oauthFormBodyLimit         = 64 << 10
+	defaultOAuthAccessTokenTTLSeconds = int64(time.Hour / time.Second)
+	oauthRefreshTokenTTL              = 90 * 24 * time.Hour
+	oauthFormBodyLimit                = 64 << 10
 )
 
 func Serve(ctx context.Context, server *mcp.Server, cfg config.Config) error {
@@ -808,14 +808,16 @@ func authorizedOAuth(r *http.Request, cfg config.Config, store *auth.OAuthStore)
 }
 
 func newOAuthProtocolServer(cfg config.Config, store *auth.OAuthStore) *oauthserver.Server {
-	accessTokenTTL := cfg.OAuthAccessTokenTTL
-	if accessTokenTTL <= 0 {
-		accessTokenTTL = defaultOAuthAccessTokenTTL
+	accessTokenTTLSeconds := cfg.OAuthAccessTokenTTLSeconds
+	if cfg.OAuthAccessTokenNeverExpires {
+		accessTokenTTLSeconds = 0
+	} else if accessTokenTTLSeconds <= 0 {
+		accessTokenTTLSeconds = defaultOAuthAccessTokenTTLSeconds
 	}
 	manager := auth.NewOAuthManager(
 		store,
 		oauthSigningKey(),
-		accessTokenTTL,
+		accessTokenTTLSeconds,
 		oauthRefreshTokenTTL,
 	)
 	protocolConfig := oauthserver.NewConfig()
@@ -828,6 +830,27 @@ func newOAuthProtocolServer(cfg config.Config, store *auth.OAuthStore) *oauthser
 	protocol.SetClientInfoHandler(oauthserver.ClientFormHandler)
 	protocol.SetAccessTokenResolveHandler(func(request *http.Request) (string, bool) {
 		return auth.ParseBearerToken(request.Header.Get("Authorization"))
+	})
+	protocol.SetResponseTokenHandler(func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error {
+		if _, issued := data["access_token"]; issued {
+			if cfg.OAuthAccessTokenNeverExpires {
+				delete(data, "expires_in")
+			} else {
+				data["expires_in"] = accessTokenTTLSeconds
+			}
+		}
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		for key := range header {
+			w.Header().Set(key, header.Get(key))
+		}
+		status := http.StatusOK
+		if len(statusCode) > 0 && statusCode[0] > 0 {
+			status = statusCode[0]
+		}
+		w.WriteHeader(status)
+		return json.NewEncoder(w).Encode(data)
 	})
 	protocol.SetClientAuthorizedHandler(func(clientID string, grant gooauth2.GrantType) (bool, error) {
 		return store.ClientAllowsGrant(clientID, grant.String()), nil

--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	oauthAccessTokenTTL  = time.Hour
-	oauthRefreshTokenTTL = 90 * 24 * time.Hour
-	oauthFormBodyLimit   = 64 << 10
+	defaultOAuthAccessTokenTTL = time.Hour
+	oauthRefreshTokenTTL       = 90 * 24 * time.Hour
+	oauthFormBodyLimit         = 64 << 10
 )
 
 func Serve(ctx context.Context, server *mcp.Server, cfg config.Config) error {
@@ -808,10 +808,14 @@ func authorizedOAuth(r *http.Request, cfg config.Config, store *auth.OAuthStore)
 }
 
 func newOAuthProtocolServer(cfg config.Config, store *auth.OAuthStore) *oauthserver.Server {
+	accessTokenTTL := cfg.OAuthAccessTokenTTL
+	if accessTokenTTL <= 0 {
+		accessTokenTTL = defaultOAuthAccessTokenTTL
+	}
 	manager := auth.NewOAuthManager(
 		store,
 		oauthSigningKey(),
-		oauthAccessTokenTTL,
+		accessTokenTTL,
 		oauthRefreshTokenTTL,
 	)
 	protocolConfig := oauthserver.NewConfig()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -109,7 +109,11 @@ func (s *Server) callTool(ctx context.Context, name string, request *mcpsdk.Call
 	}
 	slog.Info("tool started", "tool", name)
 	result, err := s.runtime.Call(ctx, name, arguments)
-	slog.Info("tool finished", "tool", name, "duration_ms", time.Since(started).Milliseconds(), "ok", err == nil)
+	finishedAttrs := []any{"tool", name, "duration_ms", time.Since(started).Milliseconds(), "ok", err == nil}
+	if err != nil {
+		finishedAttrs = append(finishedAttrs, "error", err)
+	}
+	slog.Info("tool finished", finishedAttrs...)
 
 	encoded, encodeErr := json.Marshal(toolEnvelope(name, result, err))
 	if encodeErr != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -169,6 +169,11 @@ func (w *Workspace) displayPath(abs string) string {
 }
 
 func (w *Workspace) Relative(abs string) (string, error) {
+	rootVolume := filepath.VolumeName(w.root)
+	targetVolume := filepath.VolumeName(abs)
+	if rootVolume != "" && targetVolume != "" && !strings.EqualFold(rootVolume, targetVolume) {
+		return filepath.Clean(abs), nil
+	}
 	rel, err := filepath.Rel(w.root, abs)
 	if err != nil {
 		return "", err

--- a/internal/workspace/workspace_windows_test.go
+++ b/internal/workspace/workspace_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package workspace
+
+import "testing"
+
+func TestRelativeReturnsAbsolutePathAcrossWindowsVolumes(t *testing.T) {
+	ws := &Workspace{root: `C:\Users\Administrator\AgentDock`}
+	target := `E:\PY\example\package.json`
+
+	got, err := ws.Relative(target)
+	if err != nil {
+		t.Fatalf("Relative() error = %v", err)
+	}
+	if got != target {
+		t.Fatalf("Relative() = %q, want %q", got, target)
+	}
+}


### PR DESCRIPTION
## Summary

- handle Windows paths on a different volume from the configured workspace root
- keep absolute paths for cross-volume directory entries instead of failing `filepath.Rel`
- include runtime errors in MCP tool completion logs

## Root cause

Absolute host paths are supported by file tools, but `list_dir` converted every resolved entry back to a workspace-relative path. On Windows, `filepath.Rel` fails when the workspace root is on `C:` and the requested directory is on `E:`, so an otherwise valid listing returned an error.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- deployed the Windows build and invoked `list_dir` through the ChatGPT AgentDock connector against `E:\PY\小红书话题采集`; the MCP request returned HTTP 200 and 16 visible entries