### PR TITLE
fix(installer): 简化 Linux 安装并补充恢复入口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,10 @@ jobs:
       - name: Check Linux installer entry
         if: runner.os == 'Linux'
         run: |
-          sh -n scripts/install.sh scripts/test-install-entry.sh
+          sh -n scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh
+          dash -n scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh
           bash -n scripts/install-linux-platform.sh scripts/test-docker-images.sh
+          shellcheck scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh scripts/install-linux-platform.sh
           ./scripts/test-install-entry.sh
 
       - name: Test macOS scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Validate unified installer entry
         run: |
-          sh -n scripts/install.sh scripts/test-install-entry.sh
+          sh -n scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh
+          dash -n scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh
           bash -n scripts/install-linux-platform.sh
+          shellcheck scripts/install.sh scripts/uninstall-linux.sh scripts/test-install-entry.sh scripts/install-linux-platform.sh
           ./scripts/test-install-entry.sh
 
       - name: Build and package
@@ -436,6 +438,7 @@ jobs:
           set -euo pipefail
           cp scripts/install.sh dist/install.sh
           cp scripts/install-linux-platform.sh dist/install-linux-platform.sh
+          cp scripts/uninstall-linux.sh dist/uninstall-linux.sh
           cp scripts/install-macos-platform.sh dist/install-macos-platform.sh
           cp scripts/uninstall-macos.sh dist/uninstall-macos.sh
           cp scripts/install.ps1 dist/install.ps1
@@ -478,6 +481,7 @@ jobs:
             for file in \
               install.sh \
               install-linux-platform.sh \
+              uninstall-linux.sh \
               install-macos-platform.sh \
               uninstall-macos.sh \
               install.ps1 \
@@ -639,6 +643,7 @@ jobs:
             sh "$installer"
 
           "$install_dir/bin/agentdock" --help >/dev/null 2>&1
+
           test -f "$data_dir/.agentdock/skill-store/bundled-skills.json"
           for skill in skill-authoring skill-installation skill-vetter-runtime; do
             state="$data_dir/.agentdock/skill-store/state/$skill.json"
@@ -646,6 +651,21 @@ jobs:
             test -n "$version"
             test -f "$data_dir/.agentdock/skill-store/installed/$skill/$version/SKILL.md"
           done
+
+          systemd_dir="$RUNNER_TEMP/systemd"
+          openrc_dir="$RUNNER_TEMP/openrc"
+          mkdir -p "$systemd_dir" "$openrc_dir"
+          AGENTDOCK_INSTALLER_BASE_URL="$release_base" \
+          AGENTDOCK_SOURCE_DIR="$install_dir" \
+          AGENTDOCK_DATA_DIR="$data_dir" \
+          AGENTDOCK_ENV_FILE="$env_file" \
+          AGENTDOCK_SYSTEMD_DIR="$systemd_dir" \
+          AGENTDOCK_OPENRC_DIR="$openrc_dir" \
+            sh "$installer" --uninstall --purge-data
+
+          test ! -e "$install_dir"
+          test ! -e "$data_dir"
+          test ! -e "$env_file"
 
   verify-macos-release:
     name: Verify published unified installer on macOS

--- a/scripts/install-linux-platform.sh
+++ b/scripts/install-linux-platform.sh
@@ -34,10 +34,10 @@ trap cleanup_core_skill_bundle EXIT
 
 TTY_IN="/dev/tty"
 TTY_OUT="/dev/tty"
-if [[ ! -r "$TTY_IN" ]]; then
+if ! ( : <"$TTY_IN" ) 2>/dev/null; then
   TTY_IN="/dev/stdin"
 fi
-if [[ ! -w "$TTY_OUT" ]]; then
+if ! ( : >"$TTY_OUT" ) 2>/dev/null; then
   TTY_OUT="/dev/stderr"
 fi
 

--- a/scripts/install-linux-platform.sh
+++ b/scripts/install-linux-platform.sh
@@ -221,6 +221,8 @@ run_as_service_user() {
   elif command -v runuser >/dev/null 2>&1; then
     run_root runuser -u "$user" -- env HOME="$home_dir" "$@"
   elif command -v su >/dev/null 2>&1; then
+    # 单引号中的位置参数由 su 启动的 /bin/sh 展开。
+    # shellcheck disable=SC2016
     run_root su -s /bin/sh "$user" -c 'HOME="$1"; export HOME; shift; exec "$@"' sh "$home_dir" "$@"
   else
     die "缺少 runuser 或 su，无法以运行用户初始化核心 Skill：$user"
@@ -290,6 +292,7 @@ read_env_assignment() {
   local file_path="$1"
   local key="$2"
   [[ -f "$file_path" ]] || return 0
+  # shellcheck disable=SC2016
   run_root awk -F= -v key="$key" '$1 == key {value=substr($0, index($0, "=") + 1)} END {print value}' "$file_path"
 }
 
@@ -371,6 +374,8 @@ install_go_official() {
   rm -rf "$tmp_dir"
   export PATH="/usr/local/go/bin:$PATH"
   if [[ -d /etc/profile.d ]]; then
+    # 需要将字面量 $PATH 写入 profile 脚本。
+    # shellcheck disable=SC2016
     printf '%s\n' 'export PATH=/usr/local/go/bin:$PATH' | run_root tee /etc/profile.d/agentdock-go.sh >/dev/null
   fi
 }
@@ -588,29 +593,32 @@ write_env_file() {
   # 重跑安装器时保留浏览器、代理和其他高级配置，只替换本次安装器负责的键。
   # 同时兼容用户手工写入的 `export KEY=...` 形式，避免重复定义。
   if [[ -f "$env_file" ]]; then
+    # shellcheck disable=SC2016
     run_root awk -v keys="$managed_keys"       '$0 !~ "^[[:space:]]*(export[[:space:]]+)?(" keys ")[[:space:]]*="'       "$env_file" >"$tmp_file"
   fi
 
-  cat >>"$tmp_file" <<ENV
+  {
+    cat <<ENV
 AGENTDOCK_HOST=$host
 AGENTDOCK_PORT=$port
 AGENTDOCK_AUTH_TOKEN=$token
 AGENTDOCK_LOG_LEVEL=$log_level
 ENV
-  if [[ -n "$nexus_endpoint" ]]; then
-    printf 'AGENTDOCK_NEXUS_ENDPOINT=%s\n' "$nexus_endpoint" >>"$tmp_file"
-  fi
-  if [[ -n "$nexus_token" ]]; then
-    printf 'AGENTDOCK_NEXUS_TOKEN=%s\n' "$nexus_token" >>"$tmp_file"
-  fi
-  if [[ -n "$server_url" ]]; then
-    printf 'AGENTDOCK_SERVER_URL=%s\n' "$server_url" >>"$tmp_file"
-  fi
-  if [[ "$configure_oauth" == "yes" ]]; then
-    printf 'AGENTDOCK_OAUTH_ENABLED=%s\n' "$oauth_enabled" >>"$tmp_file"
-    printf 'AGENTDOCK_OAUTH_PASSWORD=%s\n' "$oauth_password" >>"$tmp_file"
-    printf 'AGENTDOCK_OAUTH_TOKEN_SECRET=%s\n' "$oauth_token_secret" >>"$tmp_file"
-  fi
+    if [[ -n "$nexus_endpoint" ]]; then
+      printf 'AGENTDOCK_NEXUS_ENDPOINT=%s\n' "$nexus_endpoint"
+    fi
+    if [[ -n "$nexus_token" ]]; then
+      printf 'AGENTDOCK_NEXUS_TOKEN=%s\n' "$nexus_token"
+    fi
+    if [[ -n "$server_url" ]]; then
+      printf 'AGENTDOCK_SERVER_URL=%s\n' "$server_url"
+    fi
+    if [[ "$configure_oauth" == "yes" ]]; then
+      printf 'AGENTDOCK_OAUTH_ENABLED=%s\n' "$oauth_enabled"
+      printf 'AGENTDOCK_OAUTH_PASSWORD=%s\n' "$oauth_password"
+      printf 'AGENTDOCK_OAUTH_TOKEN_SECRET=%s\n' "$oauth_token_secret"
+    fi
+  } >>"$tmp_file"
 
   run_root mkdir -p "$env_dir"
   run_root install -m 600 -o root -g root "$tmp_file" "$env_file"
@@ -974,7 +982,8 @@ wait_for_cloudflared() {
   while (( attempts-- > 0 )); do
     if cloudflared_service_active "$service_manager" "$tunnel_service_name"; then
       if [[ "$mode" == quick ]]; then
-        local public_url="$(cloudflared_quick_url "$service_manager" "$tunnel_service_name" "$started_at" || true)"
+        local public_url
+        public_url="$(cloudflared_quick_url "$service_manager" "$tunnel_service_name" "$started_at" || true)"
         if [[ -n "$public_url" ]]; then
           printf '%s' "$public_url"
           return 0
@@ -999,7 +1008,8 @@ start_cloudflared_service() {
   local tunnel_service_name="$2"
   local mode="$3"
   local server_url="$4"
-  local started_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  local started_at
+  started_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 
   case "$service_manager" in
     systemd)
@@ -1196,7 +1206,7 @@ main() {
   local service_name service_user service_group service_manager service_manager_prompt host port token log_level
   local install_mode release_version nexus_endpoint nexus_token update_existing run_full_check install_deps
   local oauth_password oauth_token_secret oauth_enabled configure_oauth
-  local go_version public_domain smoke_url health_host build_from_source binary_installed
+  local go_version public_domain smoke_url health_host build_from_source
   local tunnel_mode tunnel_default tunnel_token server_url existing_server_url existing_tunnel_token
   local existing_host existing_port existing_log_level existing_token existing_oauth_password existing_oauth_secret
   local cloudflared_binary cloudflared_env_file tunnel_service_name tunnel_target_url
@@ -1394,7 +1404,6 @@ SUMMARY
   confirm '确认开始执行部署？' y || die '用户取消。'
 
   build_from_source="no"
-  binary_installed="no"
 
   if [[ "$install_deps" == "yes" ]]; then
     if [[ "$install_mode" == "source" ]]; then
@@ -1406,7 +1415,6 @@ SUMMARY
 
   if [[ "$install_mode" == "binary" || "$install_mode" == "auto" ]]; then
     if install_prebuilt_binary "$repo_url" "$release_version" "$source_dir"; then
-      binary_installed="yes"
       log "预编译二进制安装完成：$source_dir/bin/agentdock"
     elif [[ "$install_mode" == "auto" ]]; then
       warn "预编译二进制下载失败，将 fallback 到源码构建。"

--- a/scripts/install-linux-platform.sh
+++ b/scripts/install-linux-platform.sh
@@ -216,14 +216,23 @@ run_as_service_user() {
   local user="$1"
   local home_dir="$2"
   shift 2
+
+  # 安装器可能由另一个 AgentDock 实例启动，不能让父进程的实例目录泄漏到新实例。
+  # 核心 Skill 必须始终写入本次部署选择的数据目录。
   if [[ "$(id -u)" == "$(id -u "$user")" ]]; then
-    env HOME="$home_dir" "$@"
+    env HOME="$home_dir" \
+      AGENTDOCK_HOME="$home_dir/.agentdock" \
+      AGENTDOCK_DEFAULT_DIR="$home_dir/AgentDock" \
+      "$@"
   elif command -v runuser >/dev/null 2>&1; then
-    run_root runuser -u "$user" -- env HOME="$home_dir" "$@"
+    run_root runuser -u "$user" -- env HOME="$home_dir" \
+      AGENTDOCK_HOME="$home_dir/.agentdock" \
+      AGENTDOCK_DEFAULT_DIR="$home_dir/AgentDock" \
+      "$@"
   elif command -v su >/dev/null 2>&1; then
     # 单引号中的位置参数由 su 启动的 /bin/sh 展开。
     # shellcheck disable=SC2016
-    run_root su -s /bin/sh "$user" -c 'HOME="$1"; export HOME; shift; exec "$@"' sh "$home_dir" "$@"
+    run_root su -s /bin/sh "$user" -c 'HOME="$1"; AGENTDOCK_HOME="$1/.agentdock"; AGENTDOCK_DEFAULT_DIR="$1/AgentDock"; export HOME AGENTDOCK_HOME AGENTDOCK_DEFAULT_DIR; shift; exec "$@"' sh "$home_dir" "$@"
   else
     die "缺少 runuser 或 su，无法以运行用户初始化核心 Skill：$user"
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,7 @@ log() { printf '==> %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 # 由 trap 间接调用。
-# shellcheck disable=SC2329
+# shellcheck disable=SC2317,SC2329
 cleanup() {
   if [ "${ENV_BACKUP_ACTIVE:-false}" = true ]; then
     restore_public_config >/dev/null 2>&1 || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,10 +16,10 @@ PREVIOUS_TUNNEL_MODE="none"
 TTY_IN="${AGENTDOCK_TTY_IN:-/dev/tty}"
 TTY_OUT="${AGENTDOCK_TTY_OUT:-/dev/tty}"
 
-if [ ! -r "$TTY_IN" ]; then
+if ! ( : <"$TTY_IN" ) 2>/dev/null; then
   TTY_IN="/dev/stdin"
 fi
-if [ ! -w "$TTY_OUT" ]; then
+if ! ( : >"$TTY_OUT" ) 2>/dev/null; then
   TTY_OUT="/dev/stderr"
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,10 @@ TMP_ROOT=""
 CLEAR_PUBLIC_URL=false
 ENV_BACKUP=""
 ENV_BACKUP_ACTIVE=false
+ENV_BACKUP_EXISTS=false
+TUNNEL_ENV_BACKUP=""
+TUNNEL_ENV_BACKUP_EXISTS=false
+PREVIOUS_TUNNEL_MODE="none"
 TTY_IN="${AGENTDOCK_TTY_IN:-/dev/tty}"
 TTY_OUT="${AGENTDOCK_TTY_OUT:-/dev/tty}"
 
@@ -22,9 +26,11 @@ fi
 log() { printf '==> %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+# 由 trap 间接调用。
+# shellcheck disable=SC2329
 cleanup() {
-  if [ "${ENV_BACKUP_ACTIVE:-false}" = true ] && [ -f "${ENV_BACKUP:-}" ]; then
-    run_root cp "$ENV_BACKUP" "$(linux_env_file)" >/dev/null 2>&1 || true
+  if [ "${ENV_BACKUP_ACTIVE:-false}" = true ]; then
+    restore_public_config >/dev/null 2>&1 || true
   fi
   if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
     rm -rf "$TMP_ROOT"
@@ -107,6 +113,37 @@ verify_checksum() {
   [ "$actual" = "$expected" ] || die "安装器 SHA-256 校验失败：$file"
 }
 
+script_dir() {
+  case "$0" in
+    */*) CDPATH='' cd -- "$(dirname -- "$0")" && pwd ;;
+    *) die "本地安装器模式要求从文件路径执行 install.sh。" ;;
+  esac
+}
+
+prepare_release_asset() {
+  asset="$1"
+  if [ "${AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER:-false}" = "true" ]; then
+    asset_path="$(script_dir)/$asset"
+    [ -f "$asset_path" ] || die "找不到本地安装器资源：$asset_path"
+    printf '%s' "$asset_path"
+    return
+  fi
+
+  asset_path="$TMP_ROOT/$asset"
+  checksum_path="$asset_path.sha256"
+  log "下载 AgentDock 安装器资源：$asset"
+  download_file "$BASE_URL/$asset" "$asset_path"
+  download_file "$BASE_URL/$asset.sha256" "$checksum_path"
+  verify_checksum "$asset_path" "$checksum_path"
+  chmod 700 "$asset_path"
+  printf '%s' "$asset_path"
+}
+
+run_linux_uninstaller() {
+  uninstaller_path="$(prepare_release_asset uninstall-linux.sh)"
+  sh "$uninstaller_path" "$@"
+}
+
 prompt_choice() {
   label="$1"
   default_value="$2"
@@ -153,6 +190,8 @@ read_env_assignment() {
   file="$1"
   key="$2"
   root_file_exists "$file" || return 0
+  # awk 程序使用单引号避免 Shell 展开，其中的 $1 属于 awk 字段。
+  # shellcheck disable=SC2016
   run_root awk -F= -v key="$key" '$1 == key {value=substr($0, index($0, "=") + 1)} END {print value}' "$file"
 }
 
@@ -174,6 +213,11 @@ current_tunnel_mode() {
   if [ -z "$mode" ]; then
     mode="$(read_env_assignment "$(linux_cloudflared_env_file)" AGENTDOCK_TUNNEL_MODE)"
   fi
+  printf '%s' "${mode:-none}"
+}
+
+persisted_tunnel_mode() {
+  mode="$(read_env_assignment "$(linux_cloudflared_env_file)" AGENTDOCK_TUNNEL_MODE)"
   printf '%s' "${mode:-none}"
 }
 
@@ -216,58 +260,67 @@ CHOICE
   fi
 }
 
+backup_public_config() {
+  [ "$ENV_BACKUP_ACTIVE" = false ] || return 0
+
+  env_file="$(linux_env_file)"
+  tunnel_env_file="$(linux_cloudflared_env_file)"
+  ENV_BACKUP="$TMP_ROOT/agentdock.env.before-public-change"
+  TUNNEL_ENV_BACKUP="$TMP_ROOT/cloudflared.env.before-public-change"
+  PREVIOUS_TUNNEL_MODE="$(persisted_tunnel_mode)"
+
+  if root_file_exists "$env_file"; then
+    run_root cp -p "$env_file" "$ENV_BACKUP"
+    ENV_BACKUP_EXISTS=true
+  fi
+  if root_file_exists "$tunnel_env_file"; then
+    run_root cp -p "$tunnel_env_file" "$TUNNEL_ENV_BACKUP"
+    TUNNEL_ENV_BACKUP_EXISTS=true
+  fi
+  ENV_BACKUP_ACTIVE=true
+}
+
 backup_and_clear_public_url() {
   env_file="$(linux_env_file)"
   root_file_exists "$env_file" || return 0
+  backup_public_config
 
-  ENV_BACKUP="$TMP_ROOT/agentdock.env.before-public-reset"
   filtered_file="$TMP_ROOT/agentdock.env.without-public-url"
-  run_root cp "$env_file" "$ENV_BACKUP"
-  ENV_BACKUP_ACTIVE=true
+  # shellcheck disable=SC2016
   run_root awk '
     $0 !~ /^[[:space:]]*(export[[:space:]]+)?AGENTDOCK_SERVER_URL[[:space:]]*=/ { print }
   ' "$env_file" >"$filtered_file"
   run_root cp "$filtered_file" "$env_file"
 }
 
-restore_env_backup() {
-  [ -n "$ENV_BACKUP" ] || return 0
-  [ -f "$ENV_BACKUP" ] || return 0
-  run_root cp "$ENV_BACKUP" "$(linux_env_file)"
+restore_public_config() {
+  [ "$ENV_BACKUP_ACTIVE" = true ] || return 0
+  env_file="$(linux_env_file)"
+  tunnel_env_file="$(linux_cloudflared_env_file)"
+  run_root mkdir -p "$(dirname "$env_file")" "$(dirname "$tunnel_env_file")"
+
+  if [ "$ENV_BACKUP_EXISTS" = true ]; then
+    run_root cp -p "$ENV_BACKUP" "$env_file"
+  else
+    run_root rm -f "$env_file"
+  fi
+  if [ "$TUNNEL_ENV_BACKUP_EXISTS" = true ]; then
+    run_root cp -p "$TUNNEL_ENV_BACKUP" "$tunnel_env_file"
+  else
+    run_root rm -f "$tunnel_env_file"
+  fi
   ENV_BACKUP_ACTIVE=false
+  log "安装未完成，已恢复原公网配置（模式：$PREVIOUS_TUNNEL_MODE）。"
 }
 
-commit_env_backup() {
+commit_public_config() {
   ENV_BACKUP_ACTIVE=false
-}
-
-require_safe_removal_path() {
-  label="$1"
-  path="$2"
-  case "$path" in
-    /*) ;;
-    *) die "$label 必须是绝对路径：$path" ;;
-  esac
-  case "$path" in
-    *"/../"*|*"/.."|*"/./"*|*"/.")
-      die "拒绝删除包含路径跳转的目录（$label）：$path"
-      ;;
-  esac
-  normalized_path="$path"
-  while [ "$normalized_path" != "/" ] && [ "${normalized_path%/}" != "$normalized_path" ]; do
-    normalized_path="${normalized_path%/}"
-  done
-  case "$normalized_path" in
-    /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/var)
-      die "拒绝删除危险路径（$label）：$path"
-      ;;
-  esac
 }
 
 install_quick_tunnel_retry_guard() {
   mode="$1"
   [ "$mode" = "quick" ] || return 0
-  command -v systemctl >/dev/null 2>&1 || return 0
+  [ "$(linux_service_manager)" = "systemd" ] || return 0
 
   systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
   service_name="$(linux_tunnel_service_name)"
@@ -296,27 +349,96 @@ remove_quick_tunnel_retry_guard() {
   if run_root test -e "$managed_file"; then
     run_root rm -f "$managed_file"
     run_root rmdir "$dropin_dir" >/dev/null 2>&1 || true
-    if command -v systemctl >/dev/null 2>&1; then
+    if [ "$(linux_service_manager)" = "systemd" ]; then
       run_root systemctl daemon-reload >/dev/null 2>&1 || true
     fi
   fi
 }
 
+linux_service_manager() {
+  requested="${AGENTDOCK_SERVICE_MANAGER:-auto}"
+  case "$requested" in
+    systemd|openrc|none)
+      printf '%s' "$requested"
+      return
+      ;;
+    auto) ;;
+    *) die "服务管理器必须是 auto/systemd/openrc/none：$requested" ;;
+  esac
+
+  systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
+  if command -v systemctl >/dev/null 2>&1 && { [ -d /run/systemd/system ] || [ -d "$systemd_dir" ]; }; then
+    printf 'systemd'
+  elif [ -f /etc/alpine-release ] || { command -v rc-service >/dev/null 2>&1 && command -v rc-update >/dev/null 2>&1; }; then
+    printf 'openrc'
+  else
+    printf 'none'
+  fi
+}
+
 quick_tunnel_rate_limited() {
   log_file="$1"
+  started_at="${2:-}"
   if grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429' "$log_file" 2>/dev/null; then
     return 0
   fi
-  command -v journalctl >/dev/null 2>&1 || return 1
+
   service_name="$(linux_tunnel_service_name)"
-  run_root journalctl -u "$service_name" -n 100 --no-pager 2>/dev/null \
-    | grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429'
+  case "$(linux_service_manager)" in
+    systemd)
+      command -v journalctl >/dev/null 2>&1 || return 1
+      if [ -n "$started_at" ]; then
+        run_root journalctl -u "$service_name" --since "$started_at" --no-pager 2>/dev/null
+      else
+        run_root journalctl -u "$service_name" -n 100 --no-pager 2>/dev/null
+      fi | grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429'
+      ;;
+    openrc)
+      log_dir="${AGENTDOCK_OPENRC_LOG_DIR:-/var/log}"
+      grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429' \
+        "$log_dir/$service_name.log" "$log_dir/$service_name.err" 2>/dev/null
+      ;;
+    *) return 1 ;;
+  esac
 }
 
 stop_rate_limited_tunnel() {
-  command -v systemctl >/dev/null 2>&1 || return 0
   service_name="$(linux_tunnel_service_name)"
-  run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
+  case "$(linux_service_manager)" in
+    systemd)
+      run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
+      ;;
+    openrc)
+      run_root rc-service "$service_name" stop >/dev/null 2>&1 || true
+      run_root rc-update del "$service_name" default >/dev/null 2>&1 || true
+      ;;
+  esac
+}
+
+restart_restored_services() {
+  service_name="${AGENTDOCK_SERVICE_NAME:-agentdock}"
+  tunnel_service_name="$service_name-cloudflared"
+
+  case "$(linux_service_manager)" in
+    systemd)
+      run_root systemctl restart "$service_name" >/dev/null 2>&1 || true
+      if [ "$PREVIOUS_TUNNEL_MODE" = "none" ]; then
+        run_root systemctl disable --now "$tunnel_service_name" >/dev/null 2>&1 || true
+      else
+        run_root systemctl enable --now "$tunnel_service_name" >/dev/null 2>&1 || true
+      fi
+      ;;
+    openrc)
+      run_root rc-service "$service_name" restart >/dev/null 2>&1 || true
+      if [ "$PREVIOUS_TUNNEL_MODE" = "none" ]; then
+        run_root rc-service "$tunnel_service_name" stop >/dev/null 2>&1 || true
+        run_root rc-update del "$tunnel_service_name" default >/dev/null 2>&1 || true
+      else
+        run_root rc-update add "$tunnel_service_name" default >/dev/null 2>&1 || true
+        run_root rc-service "$tunnel_service_name" restart >/dev/null 2>&1 || true
+      fi
+      ;;
+  esac
 }
 
 print_linux_summary() {
@@ -351,7 +473,9 @@ run_simple_linux_install() {
   installer_path="$1"
   shift
   mode="$(current_tunnel_mode)"
+  started_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
   install_quick_tunnel_retry_guard "$mode"
+  backup_public_config
   if [ "$CLEAR_PUBLIC_URL" = true ]; then
     backup_and_clear_public_url
   fi
@@ -363,19 +487,20 @@ run_simple_linux_install() {
     "$PLATFORM_SHELL" "$installer_path" "$@" >"$install_log" 2>&1 || status=$?
 
   if [ "$status" -ne 0 ]; then
-    if quick_tunnel_rate_limited "$install_log"; then
+    if quick_tunnel_rate_limited "$install_log" "$started_at"; then
       stop_rate_limited_tunnel
       printf 'ERROR: Cloudflare 临时 Tunnel 请求受限（429/1015），已停止 Tunnel 服务，避免持续重试。\n' >&2
       printf '请稍后重新运行安装器，或改用 Cloudflare 固定地址。\n' >&2
-      restore_env_backup
+      restore_public_config
       return "$status"
     fi
-    restore_env_backup
+    restore_public_config
+    restart_restored_services
     cat "$install_log" >&2
     return "$status"
   fi
 
-  commit_env_backup
+  commit_public_config
   if [ "$mode" != "quick" ]; then
     remove_quick_tunnel_retry_guard
   fi
@@ -386,88 +511,39 @@ run_direct_linux_install() {
   installer_path="$1"
   guard_mode="$2"
   shift 2
+  started_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
   install_quick_tunnel_retry_guard "$guard_mode"
 
-  status=0
-  "$PLATFORM_SHELL" "$installer_path" "$@" || status=$?
-  if [ "$status" -eq 0 ] && [ "$(current_tunnel_mode)" != "quick" ]; then
+  install_log="$TMP_ROOT/linux-direct-install.log"
+  status_file="$TMP_ROOT/linux-direct-install.status"
+  (
+    set +e
+    "$PLATFORM_SHELL" "$installer_path" "$@" 2>&1
+    direct_status=$?
+    printf '%s\n' "$direct_status" >"$status_file"
+  ) | tee "$install_log"
+  status="$(cat "$status_file")"
+
+  if [ "$status" -ne 0 ]; then
+    rate_limited=false
+    if quick_tunnel_rate_limited "$install_log" "$started_at"; then
+      stop_rate_limited_tunnel
+      printf 'ERROR: Cloudflare 临时 Tunnel 请求受限（429/1015），已停止 Tunnel 服务，避免持续重试。\n' >&2
+      printf '请稍后重新运行安装器，或改用 Cloudflare 固定地址。\n' >&2
+      rate_limited=true
+    fi
+    restore_public_config
+    if [ "$rate_limited" = false ]; then
+      restart_restored_services
+    fi
+    return "$status"
+  fi
+
+  commit_public_config
+  if [ "$(current_tunnel_mode)" != "quick" ]; then
     remove_quick_tunnel_retry_guard
   fi
-  return "$status"
-}
-
-linux_uninstall() {
-  purge_config="$1"
-  purge_data="$2"
-  service_name="${AGENTDOCK_SERVICE_NAME:-agentdock}"
-  tunnel_service_name="$service_name-cloudflared"
-  systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
-  openrc_dir="${AGENTDOCK_OPENRC_DIR:-/etc/init.d}"
-  env_file="$(linux_env_file)"
-  config_dir="$(dirname "$env_file")"
-  source_dir="${AGENTDOCK_SOURCE_DIR:-/opt/agentdock}"
-  data_dir="${AGENTDOCK_DATA_DIR:-/srv/agentdock}"
-
-  if is_true "$purge_config"; then
-    require_safe_removal_path "配置目录" "$config_dir"
-  fi
-  if is_true "$purge_data"; then
-    require_safe_removal_path "安装目录" "$source_dir"
-    require_safe_removal_path "数据目录" "$data_dir"
-  fi
-
-  if command -v systemctl >/dev/null 2>&1; then
-    run_root systemctl disable --now "$tunnel_service_name" >/dev/null 2>&1 || true
-    run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
-    run_root rm -f "$systemd_dir/$tunnel_service_name.service" "$systemd_dir/$service_name.service"
-    run_root rm -rf "$systemd_dir/$tunnel_service_name.service.d"
-    run_root systemctl daemon-reload >/dev/null 2>&1 || true
-  fi
-
-  if [ -e "$openrc_dir/$tunnel_service_name" ] || [ -e "$openrc_dir/$service_name" ]; then
-    if command -v rc-service >/dev/null 2>&1; then
-      run_root rc-service "$tunnel_service_name" stop >/dev/null 2>&1 || true
-      run_root rc-service "$service_name" stop >/dev/null 2>&1 || true
-    fi
-    if command -v rc-update >/dev/null 2>&1; then
-      run_root rc-update del "$tunnel_service_name" default >/dev/null 2>&1 || true
-      run_root rc-update del "$service_name" default >/dev/null 2>&1 || true
-    fi
-    run_root rm -f "$openrc_dir/$tunnel_service_name" "$openrc_dir/$service_name"
-  fi
-
-  if is_true "$purge_config"; then
-    run_root rm -rf "$config_dir"
-  fi
-  if is_true "$purge_data"; then
-    run_root rm -rf "$source_dir" "$data_dir"
-  fi
-
-  printf '\nAgentDock 已卸载。\n' >>"$TTY_OUT"
-  if ! is_true "$purge_config"; then
-    printf '已保留配置：%s\n' "$config_dir" >>"$TTY_OUT"
-  fi
-  if ! is_true "$purge_data"; then
-    printf '已保留程序和数据：%s、%s\n' "$source_dir" "$data_dir" >>"$TTY_OUT"
-  fi
-  printf 'cloudflared 未删除，避免影响其他服务。\n' >>"$TTY_OUT"
-}
-
-choose_uninstall_scope() {
-  cat >>"$TTY_OUT" <<'CHOICE'
-
-卸载范围：
-1) 仅移除服务，保留配置和数据
-2) 同时清除配置，便于重新安装
-3) 完全清除程序、配置和数据
-CHOICE
-  choice="$(prompt_choice '选择' 1)"
-  case "$choice" in
-    1) linux_uninstall false false ;;
-    2) linux_uninstall true false ;;
-    3) linux_uninstall true true ;;
-    *) die "无效选择：$choice" ;;
-  esac
+  return 0
 }
 
 linux_existing_menu() {
@@ -482,9 +558,9 @@ MENU
   choice="$(prompt_choice '选择' 1)"
   case "$choice" in
     1) SIMPLE_INSTALL=true ;;
-    2) choose_public_access; SIMPLE_INSTALL=true ;;
-    3) choose_uninstall_scope; exit 0 ;;
-    4) ADVANCED=true ;;
+    2) backup_public_config; choose_public_access; SIMPLE_INSTALL=true ;;
+    3) run_linux_uninstaller --interactive; exit 0 ;;
+    4) backup_public_config; ADVANCED=true ;;
     *) die "无效选择：$choice" ;;
   esac
 }
@@ -537,44 +613,37 @@ case "$(uname -s 2>/dev/null || true)" in
     ;;
 esac
 
-if [ "$UNINSTALL" = true ]; then
-  [ "$PLATFORM_INSTALLER" = "install-linux-platform.sh" ] || die "--uninstall 当前仅支持 Linux。"
-  linux_uninstall "$PURGE_CONFIG" "$PURGE_DATA"
-  exit 0
-fi
 if [ "$PURGE_CONFIG" = true ] || [ "$PURGE_DATA" = true ]; then
-  die "--purge-config/--purge-data 必须与 --uninstall 一起使用。"
+  [ "$UNINSTALL" = true ] || die "--purge-config/--purge-data 必须与 --uninstall 一起使用。"
 fi
-
-command -v "$PLATFORM_SHELL" >/dev/null 2>&1 || die "缺少 $PLATFORM_SHELL，无法运行 $PLATFORM_INSTALLER。"
 
 # 源码开发需要显式开启本地模式；Release 用户始终下载并校验平台安装器。
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdock-installer.XXXXXX")"
 
-if [ "${AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER:-false}" = "true" ]; then
-  case "$0" in
-    */*) SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)" ;;
-    *) die "本地平台安装器模式要求从文件路径执行 install.sh。" ;;
-  esac
-  INSTALLER_PATH="$SCRIPT_DIR/$PLATFORM_INSTALLER"
-  [ -f "$INSTALLER_PATH" ] || die "找不到本地平台安装器：$INSTALLER_PATH"
-else
-  INSTALLER_PATH="$TMP_ROOT/$PLATFORM_INSTALLER"
-  CHECKSUM_PATH="$INSTALLER_PATH.sha256"
-
-  log "下载 AgentDock 平台安装器：$PLATFORM_INSTALLER"
-  download_file "$BASE_URL/$PLATFORM_INSTALLER" "$INSTALLER_PATH"
-  download_file "$BASE_URL/$PLATFORM_INSTALLER.sha256" "$CHECKSUM_PATH"
-  verify_checksum "$INSTALLER_PATH" "$CHECKSUM_PATH"
-  chmod 700 "$INSTALLER_PATH"
+if [ "$UNINSTALL" = true ]; then
+  [ "$PLATFORM_INSTALLER" = "install-linux-platform.sh" ] || die "--uninstall 当前仅支持 Linux。"
+  if [ "$PURGE_DATA" = true ]; then
+    run_linux_uninstaller --purge-data
+  elif [ "$PURGE_CONFIG" = true ]; then
+    run_linux_uninstaller --purge-config
+  else
+    run_linux_uninstaller --services-only
+  fi
+  exit $?
 fi
 
 if [ "$PLATFORM_INSTALLER" != "install-linux-platform.sh" ]; then
+  command -v "$PLATFORM_SHELL" >/dev/null 2>&1 || die "缺少 $PLATFORM_SHELL，无法运行 $PLATFORM_INSTALLER。"
+  INSTALLER_PATH="$(prepare_release_asset "$PLATFORM_INSTALLER")"
   "$PLATFORM_SHELL" "$INSTALLER_PATH" "$@"
   exit $?
 fi
 
+command -v "$PLATFORM_SHELL" >/dev/null 2>&1 || die "缺少 $PLATFORM_SHELL，无法运行 $PLATFORM_INSTALLER。"
+
 if is_true "${AGENTDOCK_NONINTERACTIVE:-false}"; then
+  backup_public_config
+  INSTALLER_PATH="$(prepare_release_asset "$PLATFORM_INSTALLER")"
   run_direct_linux_install "$INSTALLER_PATH" "$(current_tunnel_mode)" "$@"
   exit $?
 fi
@@ -582,6 +651,8 @@ fi
 SIMPLE_INSTALL=false
 if [ "$ADVANCED" = true ]; then
   # 高级流程可能在脚本内部选择 Quick Tunnel，因此预先安装保护；成功后按实际模式清理。
+  backup_public_config
+  INSTALLER_PATH="$(prepare_release_asset "$PLATFORM_INSTALLER")"
   run_direct_linux_install "$INSTALLER_PATH" quick "$@"
   exit $?
 fi
@@ -596,11 +667,13 @@ else
 fi
 
 if [ "$ADVANCED" = true ]; then
+  INSTALLER_PATH="$(prepare_release_asset "$PLATFORM_INSTALLER")"
   run_direct_linux_install "$INSTALLER_PATH" quick "$@"
   exit $?
 fi
 
 if [ "$SIMPLE_INSTALL" = true ]; then
+  INSTALLER_PATH="$(prepare_release_asset "$PLATFORM_INSTALLER")"
   run_simple_linux_install "$INSTALLER_PATH" "$@"
   exit $?
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,16 +6,63 @@ umask 077
 DEFAULT_BASE_URL="https://github.com/uvwt/agentdock/releases/latest/download"
 BASE_URL="${AGENTDOCK_INSTALLER_BASE_URL:-$DEFAULT_BASE_URL}"
 TMP_ROOT=""
+CLEAR_PUBLIC_URL=false
+ENV_BACKUP=""
+ENV_BACKUP_ACTIVE=false
+TTY_IN="${AGENTDOCK_TTY_IN:-/dev/tty}"
+TTY_OUT="${AGENTDOCK_TTY_OUT:-/dev/tty}"
+
+if [ ! -r "$TTY_IN" ]; then
+  TTY_IN="/dev/stdin"
+fi
+if [ ! -w "$TTY_OUT" ]; then
+  TTY_OUT="/dev/stderr"
+fi
 
 log() { printf '==> %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 cleanup() {
+  if [ "${ENV_BACKUP_ACTIVE:-false}" = true ] && [ -f "${ENV_BACKUP:-}" ]; then
+    run_root cp "$ENV_BACKUP" "$(linux_env_file)" >/dev/null 2>&1 || true
+  fi
   if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
     rm -rf "$TMP_ROOT"
   fi
 }
 trap cleanup EXIT HUP INT TERM
+
+is_true() {
+  case "${1:-false}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_root() {
+  if is_true "${AGENTDOCK_NO_SUDO:-false}" || [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    die "需要 root 权限，请安装 sudo 或使用 root 运行。"
+  fi
+}
+
+usage() {
+  cat <<'USAGE'
+AgentDock 安装与维护入口。
+
+用法：
+  sh install.sh                 简洁安装；已安装时显示维护菜单
+  sh install.sh --advanced      使用完整高级安装流程
+  sh install.sh --uninstall     Linux：移除服务，保留程序、配置和数据
+  sh install.sh --uninstall --purge-config
+                                同时清除配置，便于重新安装
+  sh install.sh --uninstall --purge-data
+                                完全清除 AgentDock 程序、配置和数据
+USAGE
+}
 
 download_file() {
   url="$1"
@@ -60,6 +107,422 @@ verify_checksum() {
   [ "$actual" = "$expected" ] || die "安装器 SHA-256 校验失败：$file"
 }
 
+prompt_choice() {
+  label="$1"
+  default_value="$2"
+  answer=""
+  printf '%s [%s]: ' "$label" "$default_value" >>"$TTY_OUT"
+  IFS= read -r answer <"$TTY_IN" || true
+  printf '%s' "${answer:-$default_value}"
+}
+
+prompt_value() {
+  label="$1"
+  default_value="${2:-}"
+  answer=""
+  if [ -n "$default_value" ]; then
+    printf '%s [%s]: ' "$label" "$default_value" >>"$TTY_OUT"
+  else
+    printf '%s: ' "$label" >>"$TTY_OUT"
+  fi
+  IFS= read -r answer <"$TTY_IN" || true
+  printf '%s' "${answer:-$default_value}"
+}
+
+prompt_secret_required() {
+  label="$1"
+  answer=""
+  printf '%s（输入不回显）: ' "$label" >>"$TTY_OUT"
+  if [ -t 0 ] || [ "$TTY_IN" = "/dev/tty" ]; then
+    stty -echo <"$TTY_IN" 2>/dev/null || true
+    IFS= read -r answer <"$TTY_IN" || true
+    stty echo <"$TTY_IN" 2>/dev/null || true
+    printf '\n' >>"$TTY_OUT"
+  else
+    IFS= read -r answer <"$TTY_IN" || true
+  fi
+  [ -n "$answer" ] || die "$label 不能为空。"
+  printf '%s' "$answer"
+}
+
+root_file_exists() {
+  run_root test -f "$1"
+}
+
+read_env_assignment() {
+  file="$1"
+  key="$2"
+  root_file_exists "$file" || return 0
+  run_root awk -F= -v key="$key" '$1 == key {value=substr($0, index($0, "=") + 1)} END {print value}' "$file"
+}
+
+linux_env_file() {
+  printf '%s' "${AGENTDOCK_ENV_FILE:-/etc/agentdock/agentdock.env}"
+}
+
+linux_cloudflared_env_file() {
+  env_file="$(linux_env_file)"
+  printf '%s/cloudflared.env' "$(dirname "$env_file")"
+}
+
+linux_tunnel_service_name() {
+  printf '%s-cloudflared' "${AGENTDOCK_SERVICE_NAME:-agentdock}"
+}
+
+current_tunnel_mode() {
+  mode="${AGENTDOCK_TUNNEL_MODE:-}"
+  if [ -z "$mode" ]; then
+    mode="$(read_env_assignment "$(linux_cloudflared_env_file)" AGENTDOCK_TUNNEL_MODE)"
+  fi
+  printf '%s' "${mode:-none}"
+}
+
+choose_public_access() {
+  cat >>"$TTY_OUT" <<'CHOICE'
+
+公网访问：
+1) 仅本机
+2) 临时公网地址
+3) Cloudflare 固定地址
+CHOICE
+  choice="$(prompt_choice '选择' 1)"
+  case "$choice" in
+    1|none)
+      AGENTDOCK_TUNNEL_MODE="none"
+      CLEAR_PUBLIC_URL=true
+      unset AGENTDOCK_SERVER_URL AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN 2>/dev/null || true
+      ;;
+    2|quick)
+      AGENTDOCK_TUNNEL_MODE="quick"
+      CLEAR_PUBLIC_URL=false
+      unset AGENTDOCK_SERVER_URL AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN 2>/dev/null || true
+      ;;
+    3|named)
+      AGENTDOCK_TUNNEL_MODE="named"
+      CLEAR_PUBLIC_URL=false
+      existing_url="$(read_env_assignment "$(linux_env_file)" AGENTDOCK_SERVER_URL)"
+      AGENTDOCK_SERVER_URL="$(prompt_value 'HTTPS 公网地址' "$existing_url")"
+      [ -n "$AGENTDOCK_SERVER_URL" ] || die "HTTPS 公网地址不能为空。"
+      AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN="$(prompt_secret_required 'Cloudflare Tunnel Token')"
+      ;;
+    *) die "无效选择：$choice" ;;
+  esac
+  export AGENTDOCK_TUNNEL_MODE
+  if [ -n "${AGENTDOCK_SERVER_URL:-}" ]; then
+    export AGENTDOCK_SERVER_URL
+  fi
+  if [ -n "${AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN:-}" ]; then
+    export AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN
+  fi
+}
+
+backup_and_clear_public_url() {
+  env_file="$(linux_env_file)"
+  root_file_exists "$env_file" || return 0
+
+  ENV_BACKUP="$TMP_ROOT/agentdock.env.before-public-reset"
+  filtered_file="$TMP_ROOT/agentdock.env.without-public-url"
+  run_root cp "$env_file" "$ENV_BACKUP"
+  ENV_BACKUP_ACTIVE=true
+  run_root awk '
+    $0 !~ /^[[:space:]]*(export[[:space:]]+)?AGENTDOCK_SERVER_URL[[:space:]]*=/ { print }
+  ' "$env_file" >"$filtered_file"
+  run_root cp "$filtered_file" "$env_file"
+}
+
+restore_env_backup() {
+  [ -n "$ENV_BACKUP" ] || return 0
+  [ -f "$ENV_BACKUP" ] || return 0
+  run_root cp "$ENV_BACKUP" "$(linux_env_file)"
+  ENV_BACKUP_ACTIVE=false
+}
+
+commit_env_backup() {
+  ENV_BACKUP_ACTIVE=false
+}
+
+require_safe_removal_path() {
+  label="$1"
+  path="$2"
+  case "$path" in
+    /*) ;;
+    *) die "$label 必须是绝对路径：$path" ;;
+  esac
+  case "$path" in
+    *"/../"*|*"/.."|*"/./"*|*"/.")
+      die "拒绝删除包含路径跳转的目录（$label）：$path"
+      ;;
+  esac
+  normalized_path="$path"
+  while [ "$normalized_path" != "/" ] && [ "${normalized_path%/}" != "$normalized_path" ]; do
+    normalized_path="${normalized_path%/}"
+  done
+  case "$normalized_path" in
+    /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/var)
+      die "拒绝删除危险路径（$label）：$path"
+      ;;
+  esac
+}
+
+install_quick_tunnel_retry_guard() {
+  mode="$1"
+  [ "$mode" = "quick" ] || return 0
+  command -v systemctl >/dev/null 2>&1 || return 0
+
+  systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
+  service_name="$(linux_tunnel_service_name)"
+  dropin_dir="$systemd_dir/$service_name.service.d"
+  temp_file="$TMP_ROOT/agentdock-retry-limit.conf"
+
+  cat >"$temp_file" <<'UNIT'
+[Unit]
+StartLimitIntervalSec=300
+StartLimitBurst=3
+
+[Service]
+RestartSec=30
+UNIT
+  run_root mkdir -p "$dropin_dir"
+  run_root install -m 0644 "$temp_file" "$dropin_dir/retry-limit.conf"
+  run_root systemctl daemon-reload >/dev/null 2>&1 || true
+  run_root systemctl reset-failed "$service_name" >/dev/null 2>&1 || true
+}
+
+remove_quick_tunnel_retry_guard() {
+  systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
+  service_name="$(linux_tunnel_service_name)"
+  dropin_dir="$systemd_dir/$service_name.service.d"
+  managed_file="$dropin_dir/retry-limit.conf"
+  if run_root test -e "$managed_file"; then
+    run_root rm -f "$managed_file"
+    run_root rmdir "$dropin_dir" >/dev/null 2>&1 || true
+    if command -v systemctl >/dev/null 2>&1; then
+      run_root systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+quick_tunnel_rate_limited() {
+  log_file="$1"
+  if grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429' "$log_file" 2>/dev/null; then
+    return 0
+  fi
+  command -v journalctl >/dev/null 2>&1 || return 1
+  service_name="$(linux_tunnel_service_name)"
+  run_root journalctl -u "$service_name" -n 100 --no-pager 2>/dev/null \
+    | grep -Eq '429 Too Many Requests|error code: 1015|status_code=.?429'
+}
+
+stop_rate_limited_tunnel() {
+  command -v systemctl >/dev/null 2>&1 || return 0
+  service_name="$(linux_tunnel_service_name)"
+  run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
+}
+
+print_linux_summary() {
+  env_file="$(linux_env_file)"
+  host="$(read_env_assignment "$env_file" AGENTDOCK_HOST)"
+  port="$(read_env_assignment "$env_file" AGENTDOCK_PORT)"
+  token="$(read_env_assignment "$env_file" AGENTDOCK_AUTH_TOKEN)"
+  oauth_password="$(read_env_assignment "$env_file" AGENTDOCK_OAUTH_PASSWORD)"
+  public_url="$(read_env_assignment "$env_file" AGENTDOCK_SERVER_URL)"
+  mode="$(current_tunnel_mode)"
+  host="${host:-127.0.0.1}"
+  port="${port:-8765}"
+
+  cat >>"$TTY_OUT" <<DONE
+
+AgentDock 安装完成
+本机地址：http://$host:$port/mcp
+DONE
+  if [ "$mode" != "none" ] && [ -n "$public_url" ]; then
+    printf '公网地址：%s/mcp\n' "${public_url%/}" >>"$TTY_OUT"
+  fi
+  if [ -n "$token" ]; then
+    printf 'Bearer Token：%s\n' "$token" >>"$TTY_OUT"
+  fi
+  if [ -n "$oauth_password" ]; then
+    printf 'OAuth 密码：%s\n' "$oauth_password" >>"$TTY_OUT"
+  fi
+  printf '重新配置或卸载：再次运行 install.sh\n' >>"$TTY_OUT"
+}
+
+run_simple_linux_install() {
+  installer_path="$1"
+  shift
+  mode="$(current_tunnel_mode)"
+  install_quick_tunnel_retry_guard "$mode"
+  if [ "$CLEAR_PUBLIC_URL" = true ]; then
+    backup_and_clear_public_url
+  fi
+
+  install_log="$TMP_ROOT/linux-install.log"
+  log "正在安装 AgentDock（公网模式：$mode）"
+  status=0
+  AGENTDOCK_NONINTERACTIVE=true \
+    "$PLATFORM_SHELL" "$installer_path" "$@" >"$install_log" 2>&1 || status=$?
+
+  if [ "$status" -ne 0 ]; then
+    if quick_tunnel_rate_limited "$install_log"; then
+      stop_rate_limited_tunnel
+      printf 'ERROR: Cloudflare 临时 Tunnel 请求受限（429/1015），已停止 Tunnel 服务，避免持续重试。\n' >&2
+      printf '请稍后重新运行安装器，或改用 Cloudflare 固定地址。\n' >&2
+      restore_env_backup
+      return "$status"
+    fi
+    restore_env_backup
+    cat "$install_log" >&2
+    return "$status"
+  fi
+
+  commit_env_backup
+  if [ "$mode" != "quick" ]; then
+    remove_quick_tunnel_retry_guard
+  fi
+  print_linux_summary
+}
+
+run_direct_linux_install() {
+  installer_path="$1"
+  guard_mode="$2"
+  shift 2
+  install_quick_tunnel_retry_guard "$guard_mode"
+
+  status=0
+  "$PLATFORM_SHELL" "$installer_path" "$@" || status=$?
+  if [ "$status" -eq 0 ] && [ "$(current_tunnel_mode)" != "quick" ]; then
+    remove_quick_tunnel_retry_guard
+  fi
+  return "$status"
+}
+
+linux_uninstall() {
+  purge_config="$1"
+  purge_data="$2"
+  service_name="${AGENTDOCK_SERVICE_NAME:-agentdock}"
+  tunnel_service_name="$service_name-cloudflared"
+  systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
+  openrc_dir="${AGENTDOCK_OPENRC_DIR:-/etc/init.d}"
+  env_file="$(linux_env_file)"
+  config_dir="$(dirname "$env_file")"
+  source_dir="${AGENTDOCK_SOURCE_DIR:-/opt/agentdock}"
+  data_dir="${AGENTDOCK_DATA_DIR:-/srv/agentdock}"
+
+  if is_true "$purge_config"; then
+    require_safe_removal_path "配置目录" "$config_dir"
+  fi
+  if is_true "$purge_data"; then
+    require_safe_removal_path "安装目录" "$source_dir"
+    require_safe_removal_path "数据目录" "$data_dir"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    run_root systemctl disable --now "$tunnel_service_name" >/dev/null 2>&1 || true
+    run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
+    run_root rm -f "$systemd_dir/$tunnel_service_name.service" "$systemd_dir/$service_name.service"
+    run_root rm -rf "$systemd_dir/$tunnel_service_name.service.d"
+    run_root systemctl daemon-reload >/dev/null 2>&1 || true
+  fi
+
+  if [ -e "$openrc_dir/$tunnel_service_name" ] || [ -e "$openrc_dir/$service_name" ]; then
+    if command -v rc-service >/dev/null 2>&1; then
+      run_root rc-service "$tunnel_service_name" stop >/dev/null 2>&1 || true
+      run_root rc-service "$service_name" stop >/dev/null 2>&1 || true
+    fi
+    if command -v rc-update >/dev/null 2>&1; then
+      run_root rc-update del "$tunnel_service_name" default >/dev/null 2>&1 || true
+      run_root rc-update del "$service_name" default >/dev/null 2>&1 || true
+    fi
+    run_root rm -f "$openrc_dir/$tunnel_service_name" "$openrc_dir/$service_name"
+  fi
+
+  if is_true "$purge_config"; then
+    run_root rm -rf "$config_dir"
+  fi
+  if is_true "$purge_data"; then
+    run_root rm -rf "$source_dir" "$data_dir"
+  fi
+
+  printf '\nAgentDock 已卸载。\n' >>"$TTY_OUT"
+  if ! is_true "$purge_config"; then
+    printf '已保留配置：%s\n' "$config_dir" >>"$TTY_OUT"
+  fi
+  if ! is_true "$purge_data"; then
+    printf '已保留程序和数据：%s、%s\n' "$source_dir" "$data_dir" >>"$TTY_OUT"
+  fi
+  printf 'cloudflared 未删除，避免影响其他服务。\n' >>"$TTY_OUT"
+}
+
+choose_uninstall_scope() {
+  cat >>"$TTY_OUT" <<'CHOICE'
+
+卸载范围：
+1) 仅移除服务，保留配置和数据
+2) 同时清除配置，便于重新安装
+3) 完全清除程序、配置和数据
+CHOICE
+  choice="$(prompt_choice '选择' 1)"
+  case "$choice" in
+    1) linux_uninstall false false ;;
+    2) linux_uninstall true false ;;
+    3) linux_uninstall true true ;;
+    *) die "无效选择：$choice" ;;
+  esac
+}
+
+linux_existing_menu() {
+  cat >>"$TTY_OUT" <<'MENU'
+
+检测到已安装 AgentDock：
+1) 更新或修复（保留当前配置）
+2) 修改公网访问
+3) 卸载
+4) 高级安装
+MENU
+  choice="$(prompt_choice '选择' 1)"
+  case "$choice" in
+    1) SIMPLE_INSTALL=true ;;
+    2) choose_public_access; SIMPLE_INSTALL=true ;;
+    3) choose_uninstall_scope; exit 0 ;;
+    4) ADVANCED=true ;;
+    *) die "无效选择：$choice" ;;
+  esac
+}
+
+ADVANCED=false
+UNINSTALL=false
+PURGE_CONFIG=false
+PURGE_DATA=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --advanced)
+      ADVANCED=true
+      shift
+      ;;
+    --uninstall)
+      UNINSTALL=true
+      shift
+      ;;
+    --purge-config)
+      PURGE_CONFIG=true
+      shift
+      ;;
+    --purge-data)
+      PURGE_CONFIG=true
+      PURGE_DATA=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 case "$(uname -s 2>/dev/null || true)" in
   Linux)
     PLATFORM_INSTALLER="install-linux-platform.sh"
@@ -74,26 +537,72 @@ case "$(uname -s 2>/dev/null || true)" in
     ;;
 esac
 
+if [ "$UNINSTALL" = true ]; then
+  [ "$PLATFORM_INSTALLER" = "install-linux-platform.sh" ] || die "--uninstall 当前仅支持 Linux。"
+  linux_uninstall "$PURGE_CONFIG" "$PURGE_DATA"
+  exit 0
+fi
+if [ "$PURGE_CONFIG" = true ] || [ "$PURGE_DATA" = true ]; then
+  die "--purge-config/--purge-data 必须与 --uninstall 一起使用。"
+fi
+
 command -v "$PLATFORM_SHELL" >/dev/null 2>&1 || die "缺少 $PLATFORM_SHELL，无法运行 $PLATFORM_INSTALLER。"
 
 # 源码开发需要显式开启本地模式；Release 用户始终下载并校验平台安装器。
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdock-installer.XXXXXX")"
+
 if [ "${AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER:-false}" = "true" ]; then
   case "$0" in
     */*) SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)" ;;
     *) die "本地平台安装器模式要求从文件路径执行 install.sh。" ;;
   esac
-  [ -f "$SCRIPT_DIR/$PLATFORM_INSTALLER" ] || die "找不到本地平台安装器：$SCRIPT_DIR/$PLATFORM_INSTALLER"
-  exec "$PLATFORM_SHELL" "$SCRIPT_DIR/$PLATFORM_INSTALLER" "$@"
+  INSTALLER_PATH="$SCRIPT_DIR/$PLATFORM_INSTALLER"
+  [ -f "$INSTALLER_PATH" ] || die "找不到本地平台安装器：$INSTALLER_PATH"
+else
+  INSTALLER_PATH="$TMP_ROOT/$PLATFORM_INSTALLER"
+  CHECKSUM_PATH="$INSTALLER_PATH.sha256"
+
+  log "下载 AgentDock 平台安装器：$PLATFORM_INSTALLER"
+  download_file "$BASE_URL/$PLATFORM_INSTALLER" "$INSTALLER_PATH"
+  download_file "$BASE_URL/$PLATFORM_INSTALLER.sha256" "$CHECKSUM_PATH"
+  verify_checksum "$INSTALLER_PATH" "$CHECKSUM_PATH"
+  chmod 700 "$INSTALLER_PATH"
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdock-installer.XXXXXX")"
-INSTALLER_PATH="$TMP_ROOT/$PLATFORM_INSTALLER"
-CHECKSUM_PATH="$INSTALLER_PATH.sha256"
+if [ "$PLATFORM_INSTALLER" != "install-linux-platform.sh" ]; then
+  "$PLATFORM_SHELL" "$INSTALLER_PATH" "$@"
+  exit $?
+fi
 
-log "下载 AgentDock 平台安装器：$PLATFORM_INSTALLER"
-download_file "$BASE_URL/$PLATFORM_INSTALLER" "$INSTALLER_PATH"
-download_file "$BASE_URL/$PLATFORM_INSTALLER.sha256" "$CHECKSUM_PATH"
-verify_checksum "$INSTALLER_PATH" "$CHECKSUM_PATH"
-chmod 700 "$INSTALLER_PATH"
+if is_true "${AGENTDOCK_NONINTERACTIVE:-false}"; then
+  run_direct_linux_install "$INSTALLER_PATH" "$(current_tunnel_mode)" "$@"
+  exit $?
+fi
 
-"$PLATFORM_SHELL" "$INSTALLER_PATH" "$@"
+SIMPLE_INSTALL=false
+if [ "$ADVANCED" = true ]; then
+  # 高级流程可能在脚本内部选择 Quick Tunnel，因此预先安装保护；成功后按实际模式清理。
+  run_direct_linux_install "$INSTALLER_PATH" quick "$@"
+  exit $?
+fi
+
+if root_file_exists "$(linux_env_file)"; then
+  linux_existing_menu
+else
+  if [ -z "${AGENTDOCK_TUNNEL_MODE:-}" ]; then
+    choose_public_access
+  fi
+  SIMPLE_INSTALL=true
+fi
+
+if [ "$ADVANCED" = true ]; then
+  run_direct_linux_install "$INSTALLER_PATH" quick "$@"
+  exit $?
+fi
+
+if [ "$SIMPLE_INSTALL" = true ]; then
+  run_simple_linux_install "$INSTALLER_PATH" "$@"
+  exit $?
+fi
+
+die "未选择安装操作。"

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -83,6 +83,7 @@ func TestUnifiedInstallerEntriesReplaceLegacyNames(t *testing.T) {
 	for _, path := range []string{
 		"install.sh",
 		"install-linux-platform.sh",
+		"uninstall-linux.sh",
 		"install-macos-platform.sh",
 		"install.ps1",
 	} {
@@ -111,6 +112,7 @@ func TestUnifiedInstallerEntriesReplaceLegacyNames(t *testing.T) {
 	entry := string(data)
 	for _, want := range []string{
 		"install-linux-platform.sh",
+		"uninstall-linux.sh",
 		"install-macos-platform.sh",
 		"AGENTDOCK_INSTALLER_BASE_URL",
 		"verify_checksum",

--- a/scripts/test-install-entry.sh
+++ b/scripts/test-install-entry.sh
@@ -172,6 +172,33 @@ if command -v setsid >/dev/null 2>&1; then
   grep -Fq 'AgentDock 已卸载' "$NO_TTY_ROOT/stderr.log"
 fi
 
+# 安装器由其他 AgentDock 实例启动时，父进程的实例目录不能泄漏到新部署的 Skill bootstrap。
+SERVICE_HOME_ROOT="$TMP_ROOT/service-user-home"
+SERVICE_ENV_OUTPUT="$TMP_ROOT/service-user-env"
+mkdir -p "$SERVICE_HOME_ROOT"
+cat >"$FAKE_BIN/capture-service-env" <<'SH'
+#!/bin/sh
+set -eu
+: "${TEST_SERVICE_ENV_OUTPUT:?}"
+{
+  printf 'HOME=%s\n' "${HOME:-}"
+  printf 'AGENTDOCK_HOME=%s\n' "${AGENTDOCK_HOME:-}"
+  printf 'AGENTDOCK_DEFAULT_DIR=%s\n' "${AGENTDOCK_DEFAULT_DIR:-}"
+} >"$TEST_SERVICE_ENV_OUTPUT"
+SH
+chmod +x "$FAKE_BIN/capture-service-env"
+TEST_SERVICE_ENV_OUTPUT="$SERVICE_ENV_OUTPUT" \
+  AGENTDOCK_HOME="$TMP_ROOT/inherited/.agentdock" \
+  AGENTDOCK_DEFAULT_DIR="$TMP_ROOT/inherited/AgentDock" \
+  bash -c '
+    set -Eeuo pipefail
+    source "$1"
+    run_as_service_user "$(id -un)" "$2" "$3"
+  ' bash "$ROOT_DIR/scripts/install-linux-platform.sh" "$SERVICE_HOME_ROOT" "$FAKE_BIN/capture-service-env"
+assert_line "HOME=$SERVICE_HOME_ROOT" "$SERVICE_ENV_OUTPUT"
+assert_line "AGENTDOCK_HOME=$SERVICE_HOME_ROOT/.agentdock" "$SERVICE_ENV_OUTPUT"
+assert_line "AGENTDOCK_DEFAULT_DIR=$SERVICE_HOME_ROOT/AgentDock" "$SERVICE_ENV_OUTPUT"
+
 # 首次安装默认只需选择公网模式，并完整保留平台参数。
 LINUX_OUTPUT="$TMP_ROOT/linux.args"
 LINUX_ENV_OUTPUT="$TMP_ROOT/linux.env"

--- a/scripts/test-install-entry.sh
+++ b/scripts/test-install-entry.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdock-install-entry-test.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
+export AGENTDOCK_TTY_IN=/dev/stdin
+export AGENTDOCK_TTY_OUT=/dev/stderr
+
 RELEASE_DIR="$TMP_ROOT/release"
 FAKE_BIN="$TMP_ROOT/bin"
 ENTRY="$TMP_ROOT/install.sh"
@@ -12,25 +15,78 @@ mkdir -p "$RELEASE_DIR" "$FAKE_BIN"
 cp "$ROOT_DIR/scripts/install.sh" "$ENTRY"
 chmod +x "$ENTRY"
 
-cat > "$FAKE_BIN/uname" <<'EOF'
+cat > "$FAKE_BIN/uname" <<'SH'
 #!/bin/sh
 printf '%s\n' "${TEST_UNAME:?}"
-EOF
+SH
 chmod +x "$FAKE_BIN/uname"
 
-cat > "$FAKE_BIN/zsh" <<'EOF'
+cat > "$FAKE_BIN/zsh" <<'SH'
 #!/bin/sh
 exec /bin/sh "$@"
-EOF
+SH
 chmod +x "$FAKE_BIN/zsh"
+
+cat > "$FAKE_BIN/systemctl" <<'SH'
+#!/bin/sh
+if [ -n "${TEST_SYSTEMCTL_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$TEST_SYSTEMCTL_LOG"
+fi
+exit 0
+SH
+chmod +x "$FAKE_BIN/systemctl"
+
+for command_name in rc-service rc-update; do
+  cat > "$FAKE_BIN/$command_name" <<'SH'
+#!/bin/sh
+exit 0
+SH
+  chmod +x "$FAKE_BIN/$command_name"
+done
 
 write_installer() {
   asset="$1"
-  cat > "$RELEASE_DIR/$asset" <<'EOF'
+  cat > "$RELEASE_DIR/$asset" <<'SH'
 #!/bin/sh
-: "${TEST_OUTPUT:?}"
-printf '%s\n' "$@" > "$TEST_OUTPUT"
-EOF
+set -eu
+if [ -n "${TEST_OUTPUT:-}" ]; then
+  printf '%s\n' "$@" > "$TEST_OUTPUT"
+fi
+existing_server_url=''
+if [ -n "${AGENTDOCK_ENV_FILE:-}" ] && [ -f "$AGENTDOCK_ENV_FILE" ]; then
+  existing_server_url="$(awk -F= '$1 == "AGENTDOCK_SERVER_URL" {value=substr($0, index($0, "=") + 1)} END {print value}' "$AGENTDOCK_ENV_FILE")"
+fi
+if [ -n "${TEST_ENV_OUTPUT:-}" ]; then
+  {
+    printf 'noninteractive=%s\n' "${AGENTDOCK_NONINTERACTIVE:-}"
+    printf 'tunnel_mode=%s\n' "${AGENTDOCK_TUNNEL_MODE:-}"
+    printf 'server_url=%s\n' "${AGENTDOCK_SERVER_URL:-}"
+    printf 'tunnel_token=%s\n' "${AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN:-}"
+    printf 'existing_server_url=%s\n' "$existing_server_url"
+  } > "$TEST_ENV_OUTPUT"
+fi
+if [ "${TEST_FAIL_RATE_LIMIT:-false}" = "true" ]; then
+  printf '%s\n' 'error code: 1015 status_code="429 Too Many Requests"' >&2
+  exit 1
+fi
+if [ "${TEST_WRITE_ENV:-false}" = "true" ]; then
+  : "${AGENTDOCK_ENV_FILE:?}"
+  config_dir="$(dirname "$AGENTDOCK_ENV_FILE")"
+  mkdir -p "$config_dir"
+  public_url="${AGENTDOCK_SERVER_URL:-}"
+  if [ "${AGENTDOCK_TUNNEL_MODE:-none}" = "quick" ]; then
+    public_url="https://quick-test.trycloudflare.com"
+  fi
+  cat > "$AGENTDOCK_ENV_FILE" <<ENV
+AGENTDOCK_HOST=127.0.0.1
+AGENTDOCK_PORT=8765
+AGENTDOCK_AUTH_TOKEN=test-bearer-token
+AGENTDOCK_OAUTH_PASSWORD=test-oauth-password
+AGENTDOCK_SERVER_URL=$public_url
+ENV
+  printf 'AGENTDOCK_TUNNEL_MODE=%s\n' "${AGENTDOCK_TUNNEL_MODE:-none}" > "$config_dir/cloudflared.env"
+fi
+SH
   chmod +x "$RELEASE_DIR/$asset"
   if command -v sha256sum >/dev/null 2>&1; then
     (cd "$RELEASE_DIR" && sha256sum "$asset" > "$asset.sha256")
@@ -47,14 +103,219 @@ assert_args() {
   [ "$second" = "value with spaces" ]
 }
 
+assert_line() {
+  expected="$1"
+  file="$2"
+  grep -Fqx "$expected" "$file"
+}
+
 write_installer install-linux-platform.sh
 LINUX_OUTPUT="$TMP_ROOT/linux.args"
-PATH="$FAKE_BIN:$PATH" \
+LINUX_ENV_OUTPUT="$TMP_ROOT/linux.env"
+printf '\n' | PATH="$FAKE_BIN:$PATH" \
 TEST_UNAME=Linux \
 TEST_OUTPUT="$LINUX_OUTPUT" \
+TEST_ENV_OUTPUT="$LINUX_ENV_OUTPUT" \
+AGENTDOCK_ENV_FILE="$TMP_ROOT/linux-config/agentdock.env" \
 AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" --mode "value with spaces"
 assert_args "$LINUX_OUTPUT"
+assert_line 'noninteractive=true' "$LINUX_ENV_OUTPUT"
+assert_line 'tunnel_mode=none' "$LINUX_ENV_OUTPUT"
+
+LOCAL_ROOT="$TMP_ROOT/local"
+mkdir -p "$LOCAL_ROOT"
+cp "$ENTRY" "$LOCAL_ROOT/install.sh"
+cp "$RELEASE_DIR/install-linux-platform.sh" "$LOCAL_ROOT/install-linux-platform.sh"
+printf '\n' | PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+TEST_ENV_OUTPUT="$LOCAL_ROOT/platform.env" \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$LOCAL_ROOT/config/agentdock.env" \
+AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER=true \
+  sh "$LOCAL_ROOT/install.sh"
+assert_line 'noninteractive=true' "$LOCAL_ROOT/platform.env"
+assert_line 'tunnel_mode=none' "$LOCAL_ROOT/platform.env"
+
+QUICK_ROOT="$TMP_ROOT/quick"
+QUICK_ENV_OUTPUT="$QUICK_ROOT/platform.env"
+QUICK_SYSTEMD="$QUICK_ROOT/systemd"
+mkdir -p "$QUICK_ROOT"
+printf '2\n' | PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+TEST_ENV_OUTPUT="$QUICK_ENV_OUTPUT" \
+TEST_WRITE_ENV=true \
+TEST_SYSTEMCTL_LOG="$QUICK_ROOT/systemctl.log" \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$QUICK_ROOT/config/agentdock.env" \
+AGENTDOCK_SYSTEMD_DIR="$QUICK_SYSTEMD" \
+AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+assert_line 'noninteractive=true' "$QUICK_ENV_OUTPUT"
+assert_line 'tunnel_mode=quick' "$QUICK_ENV_OUTPUT"
+QUICK_GUARD="$QUICK_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf"
+[ -f "$QUICK_GUARD" ]
+grep -Fq 'StartLimitBurst=3' "$QUICK_GUARD"
+grep -Fq 'RestartSec=30' "$QUICK_GUARD"
+
+UPDATE_ROOT="$TMP_ROOT/update"
+mkdir -p "$UPDATE_ROOT/config"
+printf '%s\n' \
+  'AGENTDOCK_HOST=127.0.0.1' \
+  'AGENTDOCK_PORT=8765' \
+  'AGENTDOCK_AUTH_TOKEN=preserved-token' \
+  > "$UPDATE_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=quick\n' > "$UPDATE_ROOT/config/cloudflared.env"
+printf '\n' | PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+TEST_ENV_OUTPUT="$UPDATE_ROOT/platform.env" \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd" \
+AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+assert_line 'noninteractive=true' "$UPDATE_ROOT/platform.env"
+assert_line 'tunnel_mode=' "$UPDATE_ROOT/platform.env"
+[ -f "$UPDATE_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf" ]
+
+echo 'AGENTDOCK_SERVER_URL=https://old.example.com' >> "$UPDATE_ROOT/config/agentdock.env"
+printf '2\n3\nhttps://new.example.com\nnew-tunnel-token\n' | PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+TEST_ENV_OUTPUT="$UPDATE_ROOT/reconfigure.env" \
+TEST_WRITE_ENV=true \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd-named" \
+AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+assert_line 'tunnel_mode=named' "$UPDATE_ROOT/reconfigure.env"
+assert_line 'server_url=https://new.example.com' "$UPDATE_ROOT/reconfigure.env"
+assert_line 'tunnel_token=new-tunnel-token' "$UPDATE_ROOT/reconfigure.env"
+[ ! -d "$UPDATE_ROOT/systemd-named/agentdock-cloudflared.service.d" ]
+
+NONE_SYSTEMD="$UPDATE_ROOT/systemd-none"
+mkdir -p "$NONE_SYSTEMD/agentdock-cloudflared.service.d"
+printf 'stale\n' > "$NONE_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf"
+printf 'custom\n' > "$NONE_SYSTEMD/agentdock-cloudflared.service.d/custom.conf"
+printf 'AGENTDOCK_TUNNEL_MODE=quick\n' > "$UPDATE_ROOT/config/cloudflared.env"
+printf '2\n1\n' | PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+TEST_ENV_OUTPUT="$UPDATE_ROOT/none.env" \
+TEST_WRITE_ENV=true \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+AGENTDOCK_SYSTEMD_DIR="$NONE_SYSTEMD" \
+AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+assert_line 'tunnel_mode=none' "$UPDATE_ROOT/none.env"
+assert_line 'existing_server_url=' "$UPDATE_ROOT/none.env"
+[ ! -e "$NONE_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf" ]
+[ -f "$NONE_SYSTEMD/agentdock-cloudflared.service.d/custom.conf" ]
+
+RESTORE_ROOT="$TMP_ROOT/restore"
+mkdir -p "$RESTORE_ROOT/config"
+printf '%s\n' \
+  'AGENTDOCK_HOST=127.0.0.1' \
+  'AGENTDOCK_SERVER_URL=https://preserve.example.com' \
+  > "$RESTORE_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=named\n' > "$RESTORE_ROOT/config/cloudflared.env"
+if printf '2\n1\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_FAIL_RATE_LIMIT=true \
+  TEST_SYSTEMCTL_LOG="$RESTORE_ROOT/systemctl.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$RESTORE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$RESTORE_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ENTRY" >"$RESTORE_ROOT/stdout.log" 2>"$RESTORE_ROOT/stderr.log"; then
+  printf 'failed reconfiguration unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fqx 'AGENTDOCK_SERVER_URL=https://preserve.example.com' "$RESTORE_ROOT/config/agentdock.env"
+
+RATE_ROOT="$TMP_ROOT/rate-limit"
+mkdir -p "$RATE_ROOT"
+if printf '2\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_FAIL_RATE_LIMIT=true \
+  TEST_SYSTEMCTL_LOG="$RATE_ROOT/systemctl.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$RATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$RATE_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ENTRY" >"$RATE_ROOT/stdout.log" 2>"$RATE_ROOT/stderr.log"; then
+  printf 'rate-limited installer unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq '429/1015' "$RATE_ROOT/stderr.log"
+grep -Fq 'disable --now agentdock-cloudflared' "$RATE_ROOT/systemctl.log"
+
+UNINSTALL_ROOT="$TMP_ROOT/uninstall"
+mkdir -p \
+  "$UNINSTALL_ROOT/config" \
+  "$UNINSTALL_ROOT/source" \
+  "$UNINSTALL_ROOT/data" \
+  "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d" \
+  "$UNINSTALL_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' > "$UNINSTALL_ROOT/config/agentdock.env"
+printf 'unit\n' > "$UNINSTALL_ROOT/systemd/agentdock.service"
+printf 'unit\n' > "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service"
+printf 'dropin\n' > "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf"
+printf 'service\n' > "$UNINSTALL_ROOT/openrc/agentdock"
+printf 'service\n' > "$UNINSTALL_ROOT/openrc/agentdock-cloudflared"
+PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$UNINSTALL_ROOT/config/agentdock.env" \
+AGENTDOCK_SOURCE_DIR="$UNINSTALL_ROOT/source" \
+AGENTDOCK_DATA_DIR="$UNINSTALL_ROOT/data" \
+AGENTDOCK_SYSTEMD_DIR="$UNINSTALL_ROOT/systemd" \
+AGENTDOCK_OPENRC_DIR="$UNINSTALL_ROOT/openrc" \
+  sh "$ENTRY" --uninstall --purge-config
+[ ! -d "$UNINSTALL_ROOT/config" ]
+[ -d "$UNINSTALL_ROOT/source" ]
+[ -d "$UNINSTALL_ROOT/data" ]
+[ ! -e "$UNINSTALL_ROOT/systemd/agentdock.service" ]
+[ ! -e "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service" ]
+[ ! -d "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d" ]
+
+PURGE_ROOT="$TMP_ROOT/purge"
+mkdir -p "$PURGE_ROOT/config" "$PURGE_ROOT/source" "$PURGE_ROOT/data" "$PURGE_ROOT/systemd" "$PURGE_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' > "$PURGE_ROOT/config/agentdock.env"
+PATH="$FAKE_BIN:$PATH" \
+TEST_UNAME=Linux \
+AGENTDOCK_NO_SUDO=true \
+AGENTDOCK_ENV_FILE="$PURGE_ROOT/config/agentdock.env" \
+AGENTDOCK_SOURCE_DIR="$PURGE_ROOT/source" \
+AGENTDOCK_DATA_DIR="$PURGE_ROOT/data" \
+AGENTDOCK_SYSTEMD_DIR="$PURGE_ROOT/systemd" \
+AGENTDOCK_OPENRC_DIR="$PURGE_ROOT/openrc" \
+  sh "$ENTRY" --uninstall --purge-data
+[ ! -d "$PURGE_ROOT/config" ]
+[ ! -d "$PURGE_ROOT/source" ]
+[ ! -d "$PURGE_ROOT/data" ]
+
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE=/agentdock.env \
+    sh "$ENTRY" --uninstall --purge-config >"$TMP_ROOT/dangerous.out" 2>"$TMP_ROOT/dangerous.err"; then
+  printf 'uninstaller accepted a dangerous config path\n' >&2
+  exit 1
+fi
+grep -Fq '拒绝删除危险路径' "$TMP_ROOT/dangerous.err"
+
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$TMP_ROOT/safe-config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR=/opt/agentdock/../.. \
+  AGENTDOCK_DATA_DIR="$TMP_ROOT/safe-data" \
+    sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/traversal.out" 2>"$TMP_ROOT/traversal.err"; then
+  printf 'uninstaller accepted a traversal path\n' >&2
+  exit 1
+fi
+grep -Fq '路径跳转' "$TMP_ROOT/traversal.err"
 
 write_installer install-macos-platform.sh
 MACOS_OUTPUT="$TMP_ROOT/macos.args"

--- a/scripts/test-install-entry.sh
+++ b/scripts/test-install-entry.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdock-install-entry-test.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
@@ -15,45 +15,93 @@ mkdir -p "$RELEASE_DIR" "$FAKE_BIN"
 cp "$ROOT_DIR/scripts/install.sh" "$ENTRY"
 chmod +x "$ENTRY"
 
-cat > "$FAKE_BIN/uname" <<'SH'
+checksum_asset() {
+  asset="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$RELEASE_DIR" && sha256sum "$asset" >"$asset.sha256")
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$RELEASE_DIR" && shasum -a 256 "$asset" >"$asset.sha256")
+  else
+    digest="$(openssl dgst -sha256 "$RELEASE_DIR/$asset" | awk '{print $NF}')"
+    printf '%s  %s\n' "$digest" "$asset" >"$RELEASE_DIR/$asset.sha256"
+  fi
+}
+
+assert_line() {
+  expected="$1"
+  file="$2"
+  grep -Fqx "$expected" "$file"
+}
+
+assert_args() {
+  output="$1"
+  [ "$(sed -n '1p' "$output")" = "--mode" ]
+  [ "$(sed -n '2p' "$output")" = "value with spaces" ]
+}
+
+cat >"$FAKE_BIN/uname" <<'SH'
 #!/bin/sh
 printf '%s\n' "${TEST_UNAME:?}"
 SH
 chmod +x "$FAKE_BIN/uname"
 
-cat > "$FAKE_BIN/zsh" <<'SH'
+cat >"$FAKE_BIN/zsh" <<'SH'
 #!/bin/sh
 exec /bin/sh "$@"
 SH
 chmod +x "$FAKE_BIN/zsh"
 
-cat > "$FAKE_BIN/systemctl" <<'SH'
+cat >"$FAKE_BIN/systemctl" <<'SH'
 #!/bin/sh
 if [ -n "${TEST_SYSTEMCTL_LOG:-}" ]; then
-  printf '%s\n' "$*" >> "$TEST_SYSTEMCTL_LOG"
+  printf '%s\n' "$*" >>"$TEST_SYSTEMCTL_LOG"
 fi
 exit 0
 SH
 chmod +x "$FAKE_BIN/systemctl"
 
-for command_name in rc-service rc-update; do
-  cat > "$FAKE_BIN/$command_name" <<'SH'
+cat >"$FAKE_BIN/journalctl" <<'SH'
 #!/bin/sh
+if [ -n "${TEST_JOURNAL_CONTENT:-}" ]; then
+  printf '%s\n' "$TEST_JOURNAL_CONTENT"
+fi
+exit 0
+SH
+chmod +x "$FAKE_BIN/journalctl"
+
+cat >"$FAKE_BIN/sudo" <<'SH'
+#!/bin/sh
+if [ -n "${TEST_SUDO_LOG:-}" ]; then
+  printf '%s\n' "$*" >>"$TEST_SUDO_LOG"
+fi
+exec "$@"
+SH
+chmod +x "$FAKE_BIN/sudo"
+
+for command_name in rc-service rc-update; do
+  cat >"$FAKE_BIN/$command_name" <<'SH'
+#!/bin/sh
+if [ -n "${TEST_OPENRC_LOG:-}" ]; then
+  printf '%s %s\n' "$(basename "$0")" "$*" >>"$TEST_OPENRC_LOG"
+fi
 exit 0
 SH
   chmod +x "$FAKE_BIN/$command_name"
 done
 
-write_installer() {
+write_fake_platform() {
   asset="$1"
-  cat > "$RELEASE_DIR/$asset" <<'SH'
+  cat >"$RELEASE_DIR/$asset" <<'SH'
 #!/bin/sh
 set -eu
+
 if [ -n "${TEST_OUTPUT:-}" ]; then
-  printf '%s\n' "$@" > "$TEST_OUTPUT"
+  printf '%s\n' "$@" >"$TEST_OUTPUT"
 fi
+
 existing_server_url=''
 if [ -n "${AGENTDOCK_ENV_FILE:-}" ] && [ -f "$AGENTDOCK_ENV_FILE" ]; then
+  # shellcheck disable=SC2016
   existing_server_url="$(awk -F= '$1 == "AGENTDOCK_SERVER_URL" {value=substr($0, index($0, "=") + 1)} END {print value}' "$AGENTDOCK_ENV_FILE")"
 fi
 if [ -n "${TEST_ENV_OUTPUT:-}" ]; then
@@ -63,12 +111,9 @@ if [ -n "${TEST_ENV_OUTPUT:-}" ]; then
     printf 'server_url=%s\n' "${AGENTDOCK_SERVER_URL:-}"
     printf 'tunnel_token=%s\n' "${AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN:-}"
     printf 'existing_server_url=%s\n' "$existing_server_url"
-  } > "$TEST_ENV_OUTPUT"
+  } >"$TEST_ENV_OUTPUT"
 fi
-if [ "${TEST_FAIL_RATE_LIMIT:-false}" = "true" ]; then
-  printf '%s\n' 'error code: 1015 status_code="429 Too Many Requests"' >&2
-  exit 1
-fi
+
 if [ "${TEST_WRITE_ENV:-false}" = "true" ]; then
   : "${AGENTDOCK_ENV_FILE:?}"
   config_dir="$(dirname "$AGENTDOCK_ENV_FILE")"
@@ -77,229 +122,393 @@ if [ "${TEST_WRITE_ENV:-false}" = "true" ]; then
   if [ "${AGENTDOCK_TUNNEL_MODE:-none}" = "quick" ]; then
     public_url="https://quick-test.trycloudflare.com"
   fi
-  cat > "$AGENTDOCK_ENV_FILE" <<ENV
+  cat >"$AGENTDOCK_ENV_FILE" <<ENV
 AGENTDOCK_HOST=127.0.0.1
 AGENTDOCK_PORT=8765
 AGENTDOCK_AUTH_TOKEN=test-bearer-token
 AGENTDOCK_OAUTH_PASSWORD=test-oauth-password
 AGENTDOCK_SERVER_URL=$public_url
 ENV
-  printf 'AGENTDOCK_TUNNEL_MODE=%s\n' "${AGENTDOCK_TUNNEL_MODE:-none}" > "$config_dir/cloudflared.env"
+  {
+    printf 'AGENTDOCK_TUNNEL_MODE=%s\n' "${AGENTDOCK_TUNNEL_MODE:-none}"
+    printf 'TUNNEL_TOKEN=%s\n' "${AGENTDOCK_CLOUDFLARE_TUNNEL_TOKEN:-}"
+  } >"$config_dir/cloudflared.env"
+fi
+
+if [ "${TEST_FAIL_RATE_LIMIT:-false}" = "true" ]; then
+  printf '%s\n' 'error code: 1015 status_code="429 Too Many Requests"' >&2
+  exit 1
+fi
+if [ "${TEST_FAIL_GENERIC:-false}" = "true" ]; then
+  printf '%s\n' 'simulated installer failure' >&2
+  exit 2
 fi
 SH
   chmod +x "$RELEASE_DIR/$asset"
-  if command -v sha256sum >/dev/null 2>&1; then
-    (cd "$RELEASE_DIR" && sha256sum "$asset" > "$asset.sha256")
-  else
-    (cd "$RELEASE_DIR" && shasum -a 256 "$asset" > "$asset.sha256")
-  fi
+  checksum_asset "$asset"
 }
 
-assert_args() {
-  output="$1"
-  first="$(sed -n '1p' "$output")"
-  second="$(sed -n '2p' "$output")"
-  [ "$first" = "--mode" ]
-  [ "$second" = "value with spaces" ]
-}
+write_fake_platform install-linux-platform.sh
+cp "$ROOT_DIR/scripts/uninstall-linux.sh" "$RELEASE_DIR/uninstall-linux.sh"
+chmod +x "$RELEASE_DIR/uninstall-linux.sh"
+checksum_asset uninstall-linux.sh
 
-assert_line() {
-  expected="$1"
-  file="$2"
-  grep -Fqx "$expected" "$file"
-}
-
-write_installer install-linux-platform.sh
+# 首次安装默认只需选择公网模式，并完整保留平台参数。
 LINUX_OUTPUT="$TMP_ROOT/linux.args"
 LINUX_ENV_OUTPUT="$TMP_ROOT/linux.env"
 printf '\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_OUTPUT="$LINUX_OUTPUT" \
-TEST_ENV_OUTPUT="$LINUX_ENV_OUTPUT" \
-AGENTDOCK_ENV_FILE="$TMP_ROOT/linux-config/agentdock.env" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  TEST_UNAME=Linux \
+  TEST_OUTPUT="$LINUX_OUTPUT" \
+  TEST_ENV_OUTPUT="$LINUX_ENV_OUTPUT" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$TMP_ROOT/linux-config/agentdock.env" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" --mode "value with spaces"
 assert_args "$LINUX_OUTPUT"
 assert_line 'noninteractive=true' "$LINUX_ENV_OUTPUT"
 assert_line 'tunnel_mode=none' "$LINUX_ENV_OUTPUT"
 
+# 本地开发模式必须从同一目录读取平台安装器和卸载器。
 LOCAL_ROOT="$TMP_ROOT/local"
 mkdir -p "$LOCAL_ROOT"
 cp "$ENTRY" "$LOCAL_ROOT/install.sh"
 cp "$RELEASE_DIR/install-linux-platform.sh" "$LOCAL_ROOT/install-linux-platform.sh"
+cp "$RELEASE_DIR/uninstall-linux.sh" "$LOCAL_ROOT/uninstall-linux.sh"
 printf '\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_ENV_OUTPUT="$LOCAL_ROOT/platform.env" \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$LOCAL_ROOT/config/agentdock.env" \
-AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER=true \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$LOCAL_ROOT/platform.env" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$LOCAL_ROOT/config/agentdock.env" \
+  AGENTDOCK_USE_LOCAL_PLATFORM_INSTALLER=true \
   sh "$LOCAL_ROOT/install.sh"
 assert_line 'noninteractive=true' "$LOCAL_ROOT/platform.env"
 assert_line 'tunnel_mode=none' "$LOCAL_ROOT/platform.env"
 
-QUICK_ROOT="$TMP_ROOT/quick"
-QUICK_ENV_OUTPUT="$QUICK_ROOT/platform.env"
-QUICK_SYSTEMD="$QUICK_ROOT/systemd"
-mkdir -p "$QUICK_ROOT"
-printf '2\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_ENV_OUTPUT="$QUICK_ENV_OUTPUT" \
-TEST_WRITE_ENV=true \
-TEST_SYSTEMCTL_LOG="$QUICK_ROOT/systemctl.log" \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$QUICK_ROOT/config/agentdock.env" \
-AGENTDOCK_SYSTEMD_DIR="$QUICK_SYSTEMD" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+# 显式非交互模式不能进入菜单，参数仍需透传。
+NONINTERACTIVE_ROOT="$TMP_ROOT/noninteractive"
+mkdir -p "$NONINTERACTIVE_ROOT"
+PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_OUTPUT="$NONINTERACTIVE_ROOT/args" \
+  TEST_ENV_OUTPUT="$NONINTERACTIVE_ROOT/env" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_NONINTERACTIVE=true \
+  AGENTDOCK_TUNNEL_MODE=none \
+  AGENTDOCK_ENV_FILE="$NONINTERACTIVE_ROOT/config/agentdock.env" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --mode "value with spaces"
+assert_args "$NONINTERACTIVE_ROOT/args"
+assert_line 'noninteractive=true' "$NONINTERACTIVE_ROOT/env"
+
+# 普通用户通过 sudo 读取已有配置时，仍应识别当前 Tunnel 模式。
+SUDO_ROOT="$TMP_ROOT/sudo-read"
+mkdir -p "$SUDO_ROOT/config" "$SUDO_ROOT/systemd"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' >"$SUDO_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=quick\n' >"$SUDO_ROOT/config/cloudflared.env"
+printf '\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$SUDO_ROOT/platform.env" \
+  TEST_SUDO_LOG="$SUDO_ROOT/sudo.log" \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$SUDO_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$SUDO_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY"
-assert_line 'noninteractive=true' "$QUICK_ENV_OUTPUT"
-assert_line 'tunnel_mode=quick' "$QUICK_ENV_OUTPUT"
+assert_line 'noninteractive=true' "$SUDO_ROOT/platform.env"
+if [ "$(id -u)" -ne 0 ]; then
+  grep -Fq "test -f $SUDO_ROOT/config/agentdock.env" "$SUDO_ROOT/sudo.log"
+  grep -Fq 'awk -F= -v key=AGENTDOCK_TUNNEL_MODE' "$SUDO_ROOT/sudo.log"
+  grep -Fq "$SUDO_ROOT/config/cloudflared.env" "$SUDO_ROOT/sudo.log"
+fi
+
+# Quick Tunnel 在 systemd 下安装有限重试 drop-in。
+QUICK_ROOT="$TMP_ROOT/quick"
+QUICK_SYSTEMD="$QUICK_ROOT/systemd"
+mkdir -p "$QUICK_SYSTEMD"
+printf '2\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$QUICK_ROOT/platform.env" \
+  TEST_WRITE_ENV=true \
+  TEST_SYSTEMCTL_LOG="$QUICK_ROOT/systemctl.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$QUICK_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$QUICK_SYSTEMD" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+assert_line 'tunnel_mode=quick' "$QUICK_ROOT/platform.env"
 QUICK_GUARD="$QUICK_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf"
 [ -f "$QUICK_GUARD" ]
 grep -Fq 'StartLimitBurst=3' "$QUICK_GUARD"
 grep -Fq 'RestartSec=30' "$QUICK_GUARD"
 
+# 二次运行默认更新/修复，并沿用已有 Quick Tunnel 模式。
 UPDATE_ROOT="$TMP_ROOT/update"
-mkdir -p "$UPDATE_ROOT/config"
+mkdir -p "$UPDATE_ROOT/config" "$UPDATE_ROOT/systemd"
 printf '%s\n' \
   'AGENTDOCK_HOST=127.0.0.1' \
   'AGENTDOCK_PORT=8765' \
   'AGENTDOCK_AUTH_TOKEN=preserved-token' \
-  > "$UPDATE_ROOT/config/agentdock.env"
-printf 'AGENTDOCK_TUNNEL_MODE=quick\n' > "$UPDATE_ROOT/config/cloudflared.env"
+  >"$UPDATE_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=quick\nTUNNEL_TOKEN=\n' >"$UPDATE_ROOT/config/cloudflared.env"
 printf '\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_ENV_OUTPUT="$UPDATE_ROOT/platform.env" \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
-AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$UPDATE_ROOT/platform.env" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY"
 assert_line 'noninteractive=true' "$UPDATE_ROOT/platform.env"
 assert_line 'tunnel_mode=' "$UPDATE_ROOT/platform.env"
 [ -f "$UPDATE_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf" ]
 
-echo 'AGENTDOCK_SERVER_URL=https://old.example.com' >> "$UPDATE_ROOT/config/agentdock.env"
+# none、quick、named 可重复切换；Named 必须接受新地址和新 Token。
+echo 'AGENTDOCK_SERVER_URL=https://old.example.com' >>"$UPDATE_ROOT/config/agentdock.env"
+mkdir -p "$UPDATE_ROOT/systemd-named"
 printf '2\n3\nhttps://new.example.com\nnew-tunnel-token\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_ENV_OUTPUT="$UPDATE_ROOT/reconfigure.env" \
-TEST_WRITE_ENV=true \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
-AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd-named" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$UPDATE_ROOT/reconfigure.env" \
+  TEST_WRITE_ENV=true \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$UPDATE_ROOT/systemd-named" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY"
 assert_line 'tunnel_mode=named' "$UPDATE_ROOT/reconfigure.env"
 assert_line 'server_url=https://new.example.com' "$UPDATE_ROOT/reconfigure.env"
 assert_line 'tunnel_token=new-tunnel-token' "$UPDATE_ROOT/reconfigure.env"
-[ ! -d "$UPDATE_ROOT/systemd-named/agentdock-cloudflared.service.d" ]
+assert_line 'TUNNEL_TOKEN=new-tunnel-token' "$UPDATE_ROOT/config/cloudflared.env"
+
+# Named Token 替换失败时，同时恢复旧 URL、模式和 Token。
+ROLLBACK_ROOT="$TMP_ROOT/named-rollback"
+mkdir -p "$ROLLBACK_ROOT/config" "$ROLLBACK_ROOT/systemd"
+printf 'AGENTDOCK_SERVER_URL=https://stable.example.com\nCUSTOM_SETTING=keep\n' >"$ROLLBACK_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=named\nTUNNEL_TOKEN=stable-token\n' >"$ROLLBACK_ROOT/config/cloudflared.env"
+cp "$ROLLBACK_ROOT/config/agentdock.env" "$ROLLBACK_ROOT/agentdock.expected"
+cp "$ROLLBACK_ROOT/config/cloudflared.env" "$ROLLBACK_ROOT/cloudflared.expected"
+if printf '2\n3\nhttps://broken.example.com\nbroken-token\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_WRITE_ENV=true \
+  TEST_FAIL_GENERIC=true \
+  TEST_SYSTEMCTL_LOG="$ROLLBACK_ROOT/systemctl.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$ROLLBACK_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$ROLLBACK_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" >"$ROLLBACK_ROOT/stdout.log" 2>"$ROLLBACK_ROOT/stderr.log"; then
+  printf 'failed Named reconfiguration unexpectedly succeeded\n' >&2
+  exit 1
+fi
+cmp "$ROLLBACK_ROOT/agentdock.expected" "$ROLLBACK_ROOT/config/agentdock.env"
+cmp "$ROLLBACK_ROOT/cloudflared.expected" "$ROLLBACK_ROOT/config/cloudflared.env"
+grep -Fq '已恢复原公网配置' "$ROLLBACK_ROOT/stderr.log"
+grep -Fq 'restart agentdock' "$ROLLBACK_ROOT/systemctl.log"
+grep -Fq 'enable --now agentdock-cloudflared' "$ROLLBACK_ROOT/systemctl.log"
 
 NONE_SYSTEMD="$UPDATE_ROOT/systemd-none"
 mkdir -p "$NONE_SYSTEMD/agentdock-cloudflared.service.d"
-printf 'stale\n' > "$NONE_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf"
-printf 'custom\n' > "$NONE_SYSTEMD/agentdock-cloudflared.service.d/custom.conf"
-printf 'AGENTDOCK_TUNNEL_MODE=quick\n' > "$UPDATE_ROOT/config/cloudflared.env"
+printf 'stale\n' >"$NONE_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf"
+printf 'custom\n' >"$NONE_SYSTEMD/agentdock-cloudflared.service.d/custom.conf"
+printf 'AGENTDOCK_TUNNEL_MODE=quick\nTUNNEL_TOKEN=\n' >"$UPDATE_ROOT/config/cloudflared.env"
 printf '2\n1\n' | PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-TEST_ENV_OUTPUT="$UPDATE_ROOT/none.env" \
-TEST_WRITE_ENV=true \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
-AGENTDOCK_SYSTEMD_DIR="$NONE_SYSTEMD" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  TEST_UNAME=Linux \
+  TEST_ENV_OUTPUT="$UPDATE_ROOT/none.env" \
+  TEST_WRITE_ENV=true \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$NONE_SYSTEMD" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY"
 assert_line 'tunnel_mode=none' "$UPDATE_ROOT/none.env"
 assert_line 'existing_server_url=' "$UPDATE_ROOT/none.env"
 [ ! -e "$NONE_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf" ]
 [ -f "$NONE_SYSTEMD/agentdock-cloudflared.service.d/custom.conf" ]
 
-RESTORE_ROOT="$TMP_ROOT/restore"
-mkdir -p "$RESTORE_ROOT/config"
-printf '%s\n' \
-  'AGENTDOCK_HOST=127.0.0.1' \
-  'AGENTDOCK_SERVER_URL=https://preserve.example.com' \
-  > "$RESTORE_ROOT/config/agentdock.env"
-printf 'AGENTDOCK_TUNNEL_MODE=named\n' > "$RESTORE_ROOT/config/cloudflared.env"
-if printf '2\n1\n' | PATH="$FAKE_BIN:$PATH" \
+REPEAT_QUICK_SYSTEMD="$UPDATE_ROOT/systemd-quick-again"
+mkdir -p "$REPEAT_QUICK_SYSTEMD"
+printf '2\n2\n' | PATH="$FAKE_BIN:$PATH" \
   TEST_UNAME=Linux \
-  TEST_FAIL_RATE_LIMIT=true \
-  TEST_SYSTEMCTL_LOG="$RESTORE_ROOT/systemctl.log" \
+  TEST_ENV_OUTPUT="$UPDATE_ROOT/quick-again.env" \
+  TEST_WRITE_ENV=true \
   AGENTDOCK_NO_SUDO=true \
-  AGENTDOCK_ENV_FILE="$RESTORE_ROOT/config/agentdock.env" \
-  AGENTDOCK_SYSTEMD_DIR="$RESTORE_ROOT/systemd" \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_ENV_FILE="$UPDATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$REPEAT_QUICK_SYSTEMD" \
   AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
-    sh "$ENTRY" >"$RESTORE_ROOT/stdout.log" 2>"$RESTORE_ROOT/stderr.log"; then
-  printf 'failed reconfiguration unexpectedly succeeded\n' >&2
-  exit 1
-fi
-grep -Fqx 'AGENTDOCK_SERVER_URL=https://preserve.example.com' "$RESTORE_ROOT/config/agentdock.env"
+  sh "$ENTRY"
+assert_line 'tunnel_mode=quick' "$UPDATE_ROOT/quick-again.env"
+[ -f "$REPEAT_QUICK_SYSTEMD/agentdock-cloudflared.service.d/retry-limit.conf" ]
 
+# 简洁、--advanced 和 OpenRC 路径都必须识别 429/1015 并停服。
 RATE_ROOT="$TMP_ROOT/rate-limit"
-mkdir -p "$RATE_ROOT"
+mkdir -p "$RATE_ROOT/systemd"
 if printf '2\n' | PATH="$FAKE_BIN:$PATH" \
   TEST_UNAME=Linux \
   TEST_FAIL_RATE_LIMIT=true \
   TEST_SYSTEMCTL_LOG="$RATE_ROOT/systemctl.log" \
   AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
   AGENTDOCK_ENV_FILE="$RATE_ROOT/config/agentdock.env" \
   AGENTDOCK_SYSTEMD_DIR="$RATE_ROOT/systemd" \
   AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
-    sh "$ENTRY" >"$RATE_ROOT/stdout.log" 2>"$RATE_ROOT/stderr.log"; then
+  sh "$ENTRY" >"$RATE_ROOT/stdout.log" 2>"$RATE_ROOT/stderr.log"; then
   printf 'rate-limited installer unexpectedly succeeded\n' >&2
   exit 1
 fi
 grep -Fq '429/1015' "$RATE_ROOT/stderr.log"
 grep -Fq 'disable --now agentdock-cloudflared' "$RATE_ROOT/systemctl.log"
 
+ADVANCED_RATE_ROOT="$TMP_ROOT/advanced-rate-limit"
+mkdir -p "$ADVANCED_RATE_ROOT/systemd"
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_FAIL_RATE_LIMIT=true \
+  TEST_SYSTEMCTL_LOG="$ADVANCED_RATE_ROOT/systemctl.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=systemd \
+  AGENTDOCK_TUNNEL_MODE=quick \
+  AGENTDOCK_ENV_FILE="$ADVANCED_RATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$ADVANCED_RATE_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --advanced >"$ADVANCED_RATE_ROOT/stdout.log" 2>"$ADVANCED_RATE_ROOT/stderr.log"; then
+  printf 'advanced rate-limited installer unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq '429/1015' "$ADVANCED_RATE_ROOT/stderr.log"
+grep -Fq 'disable --now agentdock-cloudflared' "$ADVANCED_RATE_ROOT/systemctl.log"
+
+OPENRC_RATE_ROOT="$TMP_ROOT/openrc-rate-limit"
+mkdir -p "$OPENRC_RATE_ROOT/openrc" "$OPENRC_RATE_ROOT/systemd"
+if printf '2\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  TEST_FAIL_RATE_LIMIT=true \
+  TEST_OPENRC_LOG="$OPENRC_RATE_ROOT/openrc.log" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_MANAGER=openrc \
+  AGENTDOCK_ENV_FILE="$OPENRC_RATE_ROOT/config/agentdock.env" \
+  AGENTDOCK_OPENRC_DIR="$OPENRC_RATE_ROOT/openrc" \
+  AGENTDOCK_SYSTEMD_DIR="$OPENRC_RATE_ROOT/systemd" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" >"$OPENRC_RATE_ROOT/stdout.log" 2>"$OPENRC_RATE_ROOT/stderr.log"; then
+  printf 'OpenRC rate-limited installer unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq 'rc-service agentdock-cloudflared stop' "$OPENRC_RATE_ROOT/openrc.log"
+grep -Fq 'rc-update del agentdock-cloudflared default' "$OPENRC_RATE_ROOT/openrc.log"
+[ ! -e "$OPENRC_RATE_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf" ]
+
+# 菜单卸载默认只移除服务并保留配置、程序和数据。
+MENU_UNINSTALL_ROOT="$TMP_ROOT/menu-uninstall"
+mkdir -p "$MENU_UNINSTALL_ROOT/config" "$MENU_UNINSTALL_ROOT/source" "$MENU_UNINSTALL_ROOT/data" \
+  "$MENU_UNINSTALL_ROOT/systemd" "$MENU_UNINSTALL_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' >"$MENU_UNINSTALL_ROOT/config/agentdock.env"
+printf 'unit\n' >"$MENU_UNINSTALL_ROOT/systemd/agentdock.service"
+printf '3\n1\n' | PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$MENU_UNINSTALL_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$MENU_UNINSTALL_ROOT/source" \
+  AGENTDOCK_DATA_DIR="$MENU_UNINSTALL_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$MENU_UNINSTALL_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$MENU_UNINSTALL_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY"
+[ -f "$MENU_UNINSTALL_ROOT/config/agentdock.env" ]
+[ -d "$MENU_UNINSTALL_ROOT/source" ]
+[ -d "$MENU_UNINSTALL_ROOT/data" ]
+[ ! -e "$MENU_UNINSTALL_ROOT/systemd/agentdock.service" ]
+
+# 清配置只删 AgentDock 管理文件，不误删自定义目录中的其他内容。
 UNINSTALL_ROOT="$TMP_ROOT/uninstall"
-mkdir -p \
-  "$UNINSTALL_ROOT/config" \
-  "$UNINSTALL_ROOT/source" \
-  "$UNINSTALL_ROOT/data" \
-  "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d" \
-  "$UNINSTALL_ROOT/openrc"
-printf 'AGENTDOCK_HOST=127.0.0.1\n' > "$UNINSTALL_ROOT/config/agentdock.env"
-printf 'unit\n' > "$UNINSTALL_ROOT/systemd/agentdock.service"
-printf 'unit\n' > "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service"
-printf 'dropin\n' > "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf"
-printf 'service\n' > "$UNINSTALL_ROOT/openrc/agentdock"
-printf 'service\n' > "$UNINSTALL_ROOT/openrc/agentdock-cloudflared"
+mkdir -p "$UNINSTALL_ROOT/config" "$UNINSTALL_ROOT/source" "$UNINSTALL_ROOT/data" \
+  "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d" "$UNINSTALL_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' >"$UNINSTALL_ROOT/config/agentdock.env"
+printf 'AGENTDOCK_TUNNEL_MODE=named\nTUNNEL_TOKEN=token\n' >"$UNINSTALL_ROOT/config/cloudflared.env"
+printf '{}\n' >"$UNINSTALL_ROOT/config/desktop-runtime.json"
+printf 'keep\n' >"$UNINSTALL_ROOT/config/custom.keep"
+printf 'unit\n' >"$UNINSTALL_ROOT/systemd/agentdock.service"
+printf 'unit\n' >"$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service"
+printf 'dropin\n' >"$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d/retry-limit.conf"
+printf 'service\n' >"$UNINSTALL_ROOT/openrc/agentdock"
+printf 'service\n' >"$UNINSTALL_ROOT/openrc/agentdock-cloudflared"
 PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$UNINSTALL_ROOT/config/agentdock.env" \
-AGENTDOCK_SOURCE_DIR="$UNINSTALL_ROOT/source" \
-AGENTDOCK_DATA_DIR="$UNINSTALL_ROOT/data" \
-AGENTDOCK_SYSTEMD_DIR="$UNINSTALL_ROOT/systemd" \
-AGENTDOCK_OPENRC_DIR="$UNINSTALL_ROOT/openrc" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$UNINSTALL_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$UNINSTALL_ROOT/source" \
+  AGENTDOCK_DATA_DIR="$UNINSTALL_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$UNINSTALL_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$UNINSTALL_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" --uninstall --purge-config
-[ ! -d "$UNINSTALL_ROOT/config" ]
+[ -d "$UNINSTALL_ROOT/config" ]
+[ -f "$UNINSTALL_ROOT/config/custom.keep" ]
+[ ! -e "$UNINSTALL_ROOT/config/agentdock.env" ]
+[ ! -e "$UNINSTALL_ROOT/config/cloudflared.env" ]
+[ ! -e "$UNINSTALL_ROOT/config/desktop-runtime.json" ]
 [ -d "$UNINSTALL_ROOT/source" ]
 [ -d "$UNINSTALL_ROOT/data" ]
 [ ! -e "$UNINSTALL_ROOT/systemd/agentdock.service" ]
 [ ! -e "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service" ]
 [ ! -d "$UNINSTALL_ROOT/systemd/agentdock-cloudflared.service.d" ]
 
-PURGE_ROOT="$TMP_ROOT/purge"
-mkdir -p "$PURGE_ROOT/config" "$PURGE_ROOT/source" "$PURGE_ROOT/data" "$PURGE_ROOT/systemd" "$PURGE_ROOT/openrc"
-printf 'AGENTDOCK_HOST=127.0.0.1\n' > "$PURGE_ROOT/config/agentdock.env"
+# 完全卸载支持路径中的空格，并删除空配置目录、程序和数据。
+PURGE_ROOT="$TMP_ROOT/purge with spaces"
+mkdir -p "$PURGE_ROOT/config" "$PURGE_ROOT/source/bin" "$PURGE_ROOT/data/.agentdock" "$PURGE_ROOT/systemd" "$PURGE_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' >"$PURGE_ROOT/config/agentdock.env"
+printf 'binary\n' >"$PURGE_ROOT/source/bin/agentdock"
 PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Linux \
-AGENTDOCK_NO_SUDO=true \
-AGENTDOCK_ENV_FILE="$PURGE_ROOT/config/agentdock.env" \
-AGENTDOCK_SOURCE_DIR="$PURGE_ROOT/source" \
-AGENTDOCK_DATA_DIR="$PURGE_ROOT/data" \
-AGENTDOCK_SYSTEMD_DIR="$PURGE_ROOT/systemd" \
-AGENTDOCK_OPENRC_DIR="$PURGE_ROOT/openrc" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$PURGE_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$PURGE_ROOT/source" \
+  AGENTDOCK_DATA_DIR="$PURGE_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$PURGE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$PURGE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" --uninstall --purge-data
 [ ! -d "$PURGE_ROOT/config" ]
 [ ! -d "$PURGE_ROOT/source" ]
 [ ! -d "$PURGE_ROOT/data" ]
 
+# 共享数据父目录中的非 AgentDock 文件必须保留。
+SHARED_ROOT="$TMP_ROOT/shared-data"
+mkdir -p "$SHARED_ROOT/config" "$SHARED_ROOT/source/bin" "$SHARED_ROOT/data/.agentdock" \
+  "$SHARED_ROOT/data/AgentDock" "$SHARED_ROOT/systemd" "$SHARED_ROOT/openrc"
+printf 'AGENTDOCK_HOST=127.0.0.1\n' >"$SHARED_ROOT/config/agentdock.env"
+printf 'binary\n' >"$SHARED_ROOT/source/bin/agentdock"
+printf 'keep\n' >"$SHARED_ROOT/data/custom.keep"
+PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$SHARED_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$SHARED_ROOT/source" \
+  AGENTDOCK_DATA_DIR="$SHARED_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$SHARED_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SHARED_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-data
+[ ! -d "$SHARED_ROOT/source" ]
+[ -f "$SHARED_ROOT/data/custom.keep" ]
+[ ! -e "$SHARED_ROOT/data/.agentdock" ]
+[ ! -e "$SHARED_ROOT/data/AgentDock" ]
+
+# 危险、相对、跳转和软链接路径必须在停服前拒绝。
+SAFE_SERVICE_ROOT="$TMP_ROOT/safe-services"
+mkdir -p "$SAFE_SERVICE_ROOT/systemd" "$SAFE_SERVICE_ROOT/openrc"
 if PATH="$FAKE_BIN:$PATH" \
   TEST_UNAME=Linux \
   AGENTDOCK_NO_SUDO=true \
   AGENTDOCK_ENV_FILE=/agentdock.env \
-    sh "$ENTRY" --uninstall --purge-config >"$TMP_ROOT/dangerous.out" 2>"$TMP_ROOT/dangerous.err"; then
+  AGENTDOCK_SYSTEMD_DIR="$SAFE_SERVICE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SAFE_SERVICE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-config >"$TMP_ROOT/dangerous.out" 2>"$TMP_ROOT/dangerous.err"; then
   printf 'uninstaller accepted a dangerous config path\n' >&2
   exit 1
 fi
@@ -311,26 +520,100 @@ if PATH="$FAKE_BIN:$PATH" \
   AGENTDOCK_ENV_FILE="$TMP_ROOT/safe-config/agentdock.env" \
   AGENTDOCK_SOURCE_DIR=/opt/agentdock/../.. \
   AGENTDOCK_DATA_DIR="$TMP_ROOT/safe-data" \
-    sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/traversal.out" 2>"$TMP_ROOT/traversal.err"; then
+  AGENTDOCK_SYSTEMD_DIR="$SAFE_SERVICE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SAFE_SERVICE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/traversal.out" 2>"$TMP_ROOT/traversal.err"; then
   printf 'uninstaller accepted a traversal path\n' >&2
   exit 1
 fi
 grep -Fq '路径跳转' "$TMP_ROOT/traversal.err"
 
-write_installer install-macos-platform.sh
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$TMP_ROOT/safe-config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR=relative/source \
+  AGENTDOCK_DATA_DIR="$TMP_ROOT/safe-data" \
+  AGENTDOCK_SYSTEMD_DIR="$SAFE_SERVICE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SAFE_SERVICE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/relative.out" 2>"$TMP_ROOT/relative.err"; then
+  printf 'uninstaller accepted a relative path\n' >&2
+  exit 1
+fi
+grep -Fq '必须是绝对路径' "$TMP_ROOT/relative.err"
+
+SYMLINK_ROOT="$TMP_ROOT/symlink"
+mkdir -p "$SYMLINK_ROOT/target" "$SYMLINK_ROOT/data" "$SYMLINK_ROOT/config"
+ln -s "$SYMLINK_ROOT/target" "$SYMLINK_ROOT/source-link"
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$SYMLINK_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$SYMLINK_ROOT/source-link" \
+  AGENTDOCK_DATA_DIR="$SYMLINK_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$SAFE_SERVICE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SAFE_SERVICE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/symlink.out" 2>"$TMP_ROOT/symlink.err"; then
+  printf 'uninstaller accepted a symlink removal path\n' >&2
+  exit 1
+fi
+grep -Fq '软链接或非规范路径' "$TMP_ROOT/symlink.err"
+[ -d "$SYMLINK_ROOT/target" ]
+
+UNRECOGNIZED_ROOT="$TMP_ROOT/unrecognized-source"
+mkdir -p "$UNRECOGNIZED_ROOT/config" "$UNRECOGNIZED_ROOT/source" "$UNRECOGNIZED_ROOT/data/.agentdock" \
+  "$UNRECOGNIZED_ROOT/systemd" "$UNRECOGNIZED_ROOT/openrc"
+printf 'do-not-delete\n' >"$UNRECOGNIZED_ROOT/source/custom.keep"
+printf 'unit\n' >"$UNRECOGNIZED_ROOT/systemd/agentdock.service"
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$UNRECOGNIZED_ROOT/config/agentdock.env" \
+  AGENTDOCK_SOURCE_DIR="$UNRECOGNIZED_ROOT/source" \
+  AGENTDOCK_DATA_DIR="$UNRECOGNIZED_ROOT/data" \
+  AGENTDOCK_SYSTEMD_DIR="$UNRECOGNIZED_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$UNRECOGNIZED_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall --purge-data >"$TMP_ROOT/unrecognized.out" 2>"$TMP_ROOT/unrecognized.err"; then
+  printf 'uninstaller accepted an unrecognized source directory\n' >&2
+  exit 1
+fi
+grep -Fq '无法识别为 AgentDock' "$TMP_ROOT/unrecognized.err"
+[ -f "$UNRECOGNIZED_ROOT/source/custom.keep" ]
+[ -f "$UNRECOGNIZED_ROOT/systemd/agentdock.service" ]
+
+if PATH="$FAKE_BIN:$PATH" \
+  TEST_UNAME=Linux \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_SERVICE_NAME='../unsafe' \
+  AGENTDOCK_ENV_FILE="$TMP_ROOT/safe-config/agentdock.env" \
+  AGENTDOCK_SYSTEMD_DIR="$SAFE_SERVICE_ROOT/systemd" \
+  AGENTDOCK_OPENRC_DIR="$SAFE_SERVICE_ROOT/openrc" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  sh "$ENTRY" --uninstall >"$TMP_ROOT/service-name.out" 2>"$TMP_ROOT/service-name.err"; then
+  printf 'uninstaller accepted an unsafe service name\n' >&2
+  exit 1
+fi
+grep -Fq '服务名包含不安全字符' "$TMP_ROOT/service-name.err"
+
+write_fake_platform install-macos-platform.sh
 MACOS_OUTPUT="$TMP_ROOT/macos.args"
 PATH="$FAKE_BIN:$PATH" \
-TEST_UNAME=Darwin \
-TEST_OUTPUT="$MACOS_OUTPUT" \
-AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
+  TEST_UNAME=Darwin \
+  TEST_OUTPUT="$MACOS_OUTPUT" \
+  AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" --mode "value with spaces"
 assert_args "$MACOS_OUTPUT"
 
 printf '%s\n' '0000000000000000000000000000000000000000000000000000000000000000  install-linux-platform.sh' \
-  > "$RELEASE_DIR/install-linux-platform.sh.sha256"
+  >"$RELEASE_DIR/install-linux-platform.sh.sha256"
 if PATH="$FAKE_BIN:$PATH" \
   TEST_UNAME=Linux \
-  TEST_OUTPUT="$TMP_ROOT/invalid.args" \
+  AGENTDOCK_NO_SUDO=true \
+  AGENTDOCK_ENV_FILE="$TMP_ROOT/invalid/config/agentdock.env" \
   AGENTDOCK_INSTALLER_BASE_URL="file://$RELEASE_DIR" \
   sh "$ENTRY" >/dev/null 2>&1; then
   printf 'installer accepted an invalid checksum\n' >&2

--- a/scripts/test-install-entry.sh
+++ b/scripts/test-install-entry.sh
@@ -153,6 +153,25 @@ cp "$ROOT_DIR/scripts/uninstall-linux.sh" "$RELEASE_DIR/uninstall-linux.sh"
 chmod +x "$RELEASE_DIR/uninstall-linux.sh"
 checksum_asset uninstall-linux.sh
 
+# CI、容器和管道执行时 /dev/tty 可能存在但无法打开，必须自动回退到标准流。
+if command -v setsid >/dev/null 2>&1; then
+  NO_TTY_ROOT="$TMP_ROOT/no-tty"
+  mkdir -p "$NO_TTY_ROOT/systemd" "$NO_TTY_ROOT/openrc"
+  (
+    unset AGENTDOCK_TTY_IN AGENTDOCK_TTY_OUT
+    PATH="$FAKE_BIN:$PATH" \
+      AGENTDOCK_NO_SUDO=true \
+      AGENTDOCK_ENV_FILE="$NO_TTY_ROOT/config/agentdock.env" \
+      AGENTDOCK_SOURCE_DIR="$NO_TTY_ROOT/source" \
+      AGENTDOCK_DATA_DIR="$NO_TTY_ROOT/data" \
+      AGENTDOCK_SYSTEMD_DIR="$NO_TTY_ROOT/systemd" \
+      AGENTDOCK_OPENRC_DIR="$NO_TTY_ROOT/openrc" \
+      setsid sh "$RELEASE_DIR/uninstall-linux.sh" --services-only </dev/null \
+        >"$NO_TTY_ROOT/stdout.log" 2>"$NO_TTY_ROOT/stderr.log"
+  )
+  grep -Fq 'AgentDock 已卸载' "$NO_TTY_ROOT/stderr.log"
+fi
+
 # 首次安装默认只需选择公网模式，并完整保留平台参数。
 LINUX_OUTPUT="$TMP_ROOT/linux.args"
 LINUX_ENV_OUTPUT="$TMP_ROOT/linux.env"

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -1,0 +1,368 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+TTY_IN="${AGENTDOCK_TTY_IN:-/dev/tty}"
+TTY_OUT="${AGENTDOCK_TTY_OUT:-/dev/tty}"
+
+if [ ! -r "$TTY_IN" ]; then
+  TTY_IN="/dev/stdin"
+fi
+if [ ! -w "$TTY_OUT" ]; then
+  TTY_OUT="/dev/stderr"
+fi
+
+log() { printf '==> %s\n' "$*" >&2; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+is_true() {
+  case "${1:-false}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_root() {
+  if is_true "${AGENTDOCK_NO_SUDO:-false}" || [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    die "需要 root 权限，请安装 sudo 或使用 root 运行。"
+  fi
+}
+
+usage() {
+  cat <<'USAGE'
+AgentDock Linux 卸载器。
+
+用法：
+  sh uninstall-linux.sh                 交互选择卸载范围
+  sh uninstall-linux.sh --services-only 仅移除服务，保留程序、配置和数据
+  sh uninstall-linux.sh --purge-config  移除服务并清除 AgentDock 配置文件
+  sh uninstall-linux.sh --purge-data    完全清除程序、配置和数据
+USAGE
+}
+
+prompt_choice() {
+  label="$1"
+  default_value="$2"
+  answer=""
+  printf '%s [%s]: ' "$label" "$default_value" >>"$TTY_OUT"
+  IFS= read -r answer <"$TTY_IN" || true
+  printf '%s' "${answer:-$default_value}"
+}
+
+validate_service_name() {
+  service_name="$1"
+  case "$service_name" in
+    ""|.*|*[!A-Za-z0-9_.@-]*)
+      die "服务名包含不安全字符：$service_name"
+      ;;
+  esac
+}
+
+trim_trailing_slashes() {
+  value="$1"
+  while [ "$value" != "/" ] && [ "${value%/}" != "$value" ]; do
+    value="${value%/}"
+  done
+  printf '%s' "$value"
+}
+
+validate_absolute_path() {
+  label="$1"
+  path="$2"
+  case "$path" in
+    /*) ;;
+    *) die "$label 必须是绝对路径：$path" ;;
+  esac
+  case "$path" in
+    *"/../"*|*"/.."|*"/./"*|*"/.")
+      die "拒绝使用包含路径跳转的目录（$label）：$path"
+      ;;
+  esac
+}
+
+canonical_existing_path() {
+  path="$1"
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$path"
+    return
+  fi
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "$path"
+    return
+  fi
+  if [ -d "$path" ]; then
+    (CDPATH='' cd -P -- "$path" && pwd -P)
+    return
+  fi
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  canonical_parent="$(CDPATH='' cd -P -- "$parent" && pwd -P)"
+  printf '%s/%s' "${canonical_parent%/}" "$base"
+}
+
+require_safe_removal_path() {
+  label="$1"
+  path="$2"
+  validate_absolute_path "$label" "$path"
+  normalized_path="$(trim_trailing_slashes "$path")"
+
+  case "$normalized_path" in
+    /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/var)
+      die "拒绝删除危险路径（$label）：$path"
+      ;;
+  esac
+
+  case "$normalized_path" in
+    /home/*|/Users/*)
+      account_relative="${normalized_path#/*/}"
+      case "$account_relative" in
+        */*) ;;
+        *) die "拒绝删除用户主目录（$label）：$path" ;;
+      esac
+      ;;
+  esac
+
+  if [ -e "$normalized_path" ] || [ -L "$normalized_path" ]; then
+    canonical_path="$(canonical_existing_path "$normalized_path")" || \
+      die "无法解析待删除路径（$label）：$path"
+    [ "$canonical_path" = "$normalized_path" ] || \
+      die "拒绝删除经过软链接或非规范路径指向的目录（$label）：$path -> $canonical_path"
+  fi
+
+  printf '%s' "$normalized_path"
+}
+
+paths_overlap() {
+  first="${1%/}"
+  second="${2%/}"
+  [ "$first" = "$second" ] && return 0
+  case "$first/" in
+    "$second/"*) return 0 ;;
+  esac
+  case "$second/" in
+    "$first/"*) return 0 ;;
+  esac
+  return 1
+}
+
+path_contains() {
+  parent="${1%/}"
+  child="${2%/}"
+  [ "$parent" = "$child" ] && return 0
+  case "$child/" in
+    "$parent/"*) return 0 ;;
+  esac
+  return 1
+}
+
+validate_managed_source() {
+  source_dir="$1"
+  [ -e "$source_dir" ] || return 0
+  [ -d "$source_dir" ] || die "安装目录不是目录：$source_dir"
+
+  [ -f "$source_dir/bin/agentdock" ] && return 0
+  if [ -f "$source_dir/go.mod" ] && [ -d "$source_dir/cmd/agentdock" ]; then
+    return 0
+  fi
+  die "拒绝清除无法识别为 AgentDock 的安装目录：$source_dir"
+}
+
+validate_service_directory() {
+  label="$1"
+  path="$2"
+  validate_absolute_path "$label" "$path"
+  normalized_path="$(trim_trailing_slashes "$path")"
+  if [ -e "$normalized_path" ] || [ -L "$normalized_path" ]; then
+    canonical_path="$(canonical_existing_path "$normalized_path")" || \
+      die "无法解析服务目录（$label）：$path"
+    [ "$canonical_path" = "$normalized_path" ] || \
+      die "拒绝使用经过软链接或非规范路径指向的服务目录（$label）：$path -> $canonical_path"
+  fi
+}
+
+remove_systemd_services() {
+  service_name="$1"
+  tunnel_service_name="$2"
+  systemd_dir="$3"
+
+  service_unit="$systemd_dir/$service_name.service"
+  tunnel_unit="$systemd_dir/$tunnel_service_name.service"
+  tunnel_dropin="$systemd_dir/$tunnel_service_name.service.d"
+
+  if command -v systemctl >/dev/null 2>&1; then
+    run_root systemctl disable --now "$tunnel_service_name" >/dev/null 2>&1 || true
+    run_root systemctl disable --now "$service_name" >/dev/null 2>&1 || true
+  fi
+
+  run_root rm -f "$service_unit" "$tunnel_unit"
+  run_root rm -rf "$tunnel_dropin"
+
+  if command -v systemctl >/dev/null 2>&1; then
+    run_root systemctl daemon-reload >/dev/null 2>&1 || true
+    run_root systemctl reset-failed "$service_name" "$tunnel_service_name" >/dev/null 2>&1 || true
+  fi
+}
+
+remove_openrc_services() {
+  service_name="$1"
+  tunnel_service_name="$2"
+  openrc_dir="$3"
+
+  if command -v rc-service >/dev/null 2>&1; then
+    run_root rc-service "$tunnel_service_name" stop >/dev/null 2>&1 || true
+    run_root rc-service "$service_name" stop >/dev/null 2>&1 || true
+  fi
+  if command -v rc-update >/dev/null 2>&1; then
+    run_root rc-update del "$tunnel_service_name" default >/dev/null 2>&1 || true
+    run_root rc-update del "$service_name" default >/dev/null 2>&1 || true
+  fi
+
+  run_root rm -f "$openrc_dir/$tunnel_service_name" "$openrc_dir/$service_name"
+}
+
+remove_managed_config() {
+  env_file="$1"
+  config_dir="$2"
+
+  # 自定义配置目录可能与其他服务共用，只删除 AgentDock 管理的文件。
+  run_root rm -f \
+    "$env_file" \
+    "$config_dir/cloudflared.env" \
+    "$config_dir/desktop-runtime.json"
+
+  if run_root rmdir "$config_dir" >/dev/null 2>&1; then
+    log "已移除空配置目录：$config_dir"
+  else
+    log "配置目录仍包含其他文件，已保留：$config_dir"
+  fi
+}
+
+remove_managed_data() {
+  data_dir="$1"
+
+  # 自定义数据目录可能与其他程序共用，只删除 AgentDock 管理的子目录。
+  run_root rm -rf "$data_dir/.agentdock" "$data_dir/AgentDock"
+  if run_root rmdir "$data_dir" >/dev/null 2>&1; then
+    log "已移除空数据目录：$data_dir"
+  else
+    log "数据目录仍包含其他文件，已保留：$data_dir"
+  fi
+}
+
+choose_scope() {
+  cat >>"$TTY_OUT" <<'CHOICE'
+
+卸载范围：
+1) 仅移除服务，保留配置和数据
+2) 同时清除 AgentDock 配置文件
+3) 完全清除程序、配置和数据
+CHOICE
+  choice="$(prompt_choice '选择' 1)"
+  case "$choice" in
+    1) PURGE_CONFIG=false; PURGE_DATA=false ;;
+    2) PURGE_CONFIG=true; PURGE_DATA=false ;;
+    3) PURGE_CONFIG=true; PURGE_DATA=true ;;
+    *) die "无效选择：$choice" ;;
+  esac
+}
+
+PURGE_CONFIG=false
+PURGE_DATA=false
+INTERACTIVE=false
+EXPLICIT_SCOPE=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --interactive)
+      INTERACTIVE=true
+      shift
+      ;;
+    --services-only)
+      PURGE_CONFIG=false
+      PURGE_DATA=false
+      EXPLICIT_SCOPE=true
+      shift
+      ;;
+    --purge-config)
+      PURGE_CONFIG=true
+      PURGE_DATA=false
+      EXPLICIT_SCOPE=true
+      shift
+      ;;
+    --purge-data)
+      PURGE_CONFIG=true
+      PURGE_DATA=true
+      EXPLICIT_SCOPE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "未知参数：$1"
+      ;;
+  esac
+done
+
+if [ "$INTERACTIVE" = true ]; then
+  [ "$EXPLICIT_SCOPE" = false ] || die "--interactive 不能与卸载范围参数同时使用。"
+  choose_scope
+elif [ "$EXPLICIT_SCOPE" = false ]; then
+  choose_scope
+fi
+
+service_name="${AGENTDOCK_SERVICE_NAME:-agentdock}"
+tunnel_service_name="$service_name-cloudflared"
+systemd_dir="${AGENTDOCK_SYSTEMD_DIR:-/etc/systemd/system}"
+openrc_dir="${AGENTDOCK_OPENRC_DIR:-/etc/init.d}"
+env_file="${AGENTDOCK_ENV_FILE:-/etc/agentdock/agentdock.env}"
+config_dir="$(dirname "$env_file")"
+source_dir="${AGENTDOCK_SOURCE_DIR:-/opt/agentdock}"
+data_dir="${AGENTDOCK_DATA_DIR:-/srv/agentdock}"
+
+validate_service_name "$service_name"
+validate_service_directory "systemd 目录" "$systemd_dir"
+validate_service_directory "OpenRC 目录" "$openrc_dir"
+validate_absolute_path "环境变量文件" "$env_file"
+
+# 先完成全部路径校验，再停止服务或删除任何文件，避免参数错误造成半卸载状态。
+if is_true "$PURGE_CONFIG"; then
+  require_safe_removal_path "配置目录" "$config_dir" >/dev/null
+fi
+if is_true "$PURGE_DATA"; then
+  source_dir="$(require_safe_removal_path "安装目录" "$source_dir")"
+  data_dir="$(require_safe_removal_path "数据目录" "$data_dir")"
+  validate_managed_source "$source_dir"
+  paths_overlap "$source_dir" "$data_dir" && \
+    die "拒绝清除互相重叠的安装目录和数据目录：$source_dir、$data_dir"
+  path_contains "$source_dir" "$config_dir" && \
+    die "拒绝清除与配置目录重叠的安装目录：$source_dir、$config_dir"
+  path_contains "$data_dir" "$config_dir" && \
+    die "拒绝清除与配置目录重叠的数据目录：$data_dir、$config_dir"
+fi
+
+remove_systemd_services "$service_name" "$tunnel_service_name" "$systemd_dir"
+remove_openrc_services "$service_name" "$tunnel_service_name" "$openrc_dir"
+
+if is_true "$PURGE_CONFIG"; then
+  remove_managed_config "$env_file" "$config_dir"
+fi
+if is_true "$PURGE_DATA"; then
+  run_root rm -rf "$source_dir"
+  remove_managed_data "$data_dir"
+fi
+
+printf '\nAgentDock 已卸载。\n' >>"$TTY_OUT"
+if ! is_true "$PURGE_CONFIG"; then
+  printf '已保留配置：%s\n' "$config_dir" >>"$TTY_OUT"
+fi
+if ! is_true "$PURGE_DATA"; then
+  printf '已保留程序和数据：%s、%s\n' "$source_dir" "$data_dir" >>"$TTY_OUT"
+fi
+printf 'cloudflared 未删除，避免影响其他服务。\n' >>"$TTY_OUT"

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -6,10 +6,10 @@ umask 077
 TTY_IN="${AGENTDOCK_TTY_IN:-/dev/tty}"
 TTY_OUT="${AGENTDOCK_TTY_OUT:-/dev/tty}"
 
-if [ ! -r "$TTY_IN" ]; then
+if ! ( : <"$TTY_IN" ) 2>/dev/null; then
   TTY_IN="/dev/stdin"
 fi
-if [ ! -w "$TTY_OUT" ]; then
+if ! ( : >"$TTY_OUT" ) 2>/dev/null; then
   TTY_OUT="/dev/stderr"
 fi
 


### PR DESCRIPTION
## 变更

- 默认 Linux 安装只询问公网访问方式，其余采用稳定默认值
- 已安装环境提供更新/修复、修改公网、卸载和高级安装菜单
- 支持安全卸载、清除配置和完全清除三种范围
- 切换公网模式时允许重新输入 Named Tunnel 地址和 Token
- 切换到仅本机时清除旧公网地址，失败自动恢复原配置
- Quick Tunnel 遇到 429/1015 时停止服务，并通过 systemd drop-in 限制重试频率
- 保留 `--advanced` 和非交互模式兼容性

## 验证

- `sh -n scripts/install.sh scripts/test-install-entry.sh`
- `dash -n scripts/install.sh scripts/test-install-entry.sh`
- `bash -n scripts/install.sh scripts/test-install-entry.sh`
- `./scripts/test-install-entry.sh`

Closes #15