### PR TITLE
merge(mcp): 合并 PR #18 initialize instructions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ const (
 	PathModel       = "host"
 	RecallTimeoutMS = 30000
 
+	maxInstructionsFileBytes = 64 << 10
+
 	defaultOAuthAccessTokenTTLSeconds = int64(time.Hour / time.Second)
 	maxOAuthAccessTokenTTLSeconds     = int64(999999 * 24 * 60 * 60)
 )
@@ -50,6 +52,8 @@ type Config struct {
 	ACPInteractionMS             int
 	Stdio                        bool
 	TrustedProxyCIDRs            []string
+	InstructionsFile             string
+	Instructions                 string
 }
 
 func FromEnv() (Config, error) {
@@ -130,6 +134,7 @@ func FromEnv() (Config, error) {
 		ACPInteractionMS:             acpInteractionMS,
 		Stdio:                        stdio,
 		TrustedProxyCIDRs:            splitCommaSeparated(os.Getenv("AGENTDOCK_TRUSTED_PROXY_CIDRS")),
+		InstructionsFile:             strings.TrimSpace(os.Getenv("AGENTDOCK_INSTRUCTIONS_FILE")),
 	}, nil
 }
 
@@ -180,6 +185,21 @@ func (c *Config) Normalize() error {
 		if !filepath.IsAbs(c.BrowserExecutablePath) {
 			return fmt.Errorf("BrowserExecutablePath must resolve to an absolute path: %s", c.BrowserExecutablePath)
 		}
+	}
+	c.InstructionsFile = strings.TrimSpace(c.InstructionsFile)
+	if c.InstructionsFile != "" {
+		c.InstructionsFile = filepath.Clean(c.InstructionsFile)
+		if !filepath.IsAbs(c.InstructionsFile) {
+			return fmt.Errorf("InstructionsFile must resolve to an absolute path: %s", c.InstructionsFile)
+		}
+		data, err := os.ReadFile(c.InstructionsFile)
+		if err != nil {
+			return fmt.Errorf("read InstructionsFile %s: %w", c.InstructionsFile, err)
+		}
+		if len(data) > maxInstructionsFileBytes {
+			return fmt.Errorf("InstructionsFile %s exceeds %d bytes", c.InstructionsFile, maxInstructionsFileBytes)
+		}
+		c.Instructions = strings.TrimSpace(string(data))
 	}
 	if err := c.normalizeACP(); err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,8 @@ const (
 	BrowserArtifactDir = "browser-artifacts"
 	RecallTimeoutMS    = 30000
 
+	maxInstructionsFileBytes = 64 << 10
+
 	defaultOAuthAccessTokenTTLSeconds = int64(time.Hour / time.Second)
 	maxOAuthAccessTokenTTLSeconds     = int64(999999 * 24 * 60 * 60)
 )
@@ -54,6 +56,8 @@ type Config struct {
 	ACPInteractionMS             int
 	Stdio                        bool
 	TrustedProxyCIDRs            []string
+	InstructionsFile             string
+	Instructions                 string
 }
 
 func FromEnv() (Config, error) {
@@ -135,6 +139,7 @@ func FromEnv() (Config, error) {
 		ACPInteractionMS:             acpInteractionMS,
 		Stdio:                        stdio,
 		TrustedProxyCIDRs:            splitCommaSeparated(os.Getenv("AGENTDOCK_TRUSTED_PROXY_CIDRS")),
+		InstructionsFile:             strings.TrimSpace(os.Getenv("AGENTDOCK_INSTRUCTIONS_FILE")),
 	}, nil
 }
 
@@ -193,6 +198,21 @@ func (c *Config) Normalize() error {
 		if !filepath.IsAbs(c.BrowserNodePath) {
 			return fmt.Errorf("BrowserNodePath must resolve to an absolute path: %s", c.BrowserNodePath)
 		}
+	}
+	c.InstructionsFile = strings.TrimSpace(c.InstructionsFile)
+	if c.InstructionsFile != "" {
+		c.InstructionsFile = filepath.Clean(c.InstructionsFile)
+		if !filepath.IsAbs(c.InstructionsFile) {
+			return fmt.Errorf("InstructionsFile must resolve to an absolute path: %s", c.InstructionsFile)
+		}
+		data, err := os.ReadFile(c.InstructionsFile)
+		if err != nil {
+			return fmt.Errorf("read InstructionsFile %s: %w", c.InstructionsFile, err)
+		}
+		if len(data) > maxInstructionsFileBytes {
+			return fmt.Errorf("InstructionsFile %s exceeds %d bytes", c.InstructionsFile, maxInstructionsFileBytes)
+		}
+		c.Instructions = strings.TrimSpace(string(data))
 	}
 	if err := c.normalizeACP(); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -432,5 +433,50 @@ func TestValidateAuthTreatsEmptyHostAsWildcard(t *testing.T) {
 	cfg := Config{Host: ""}
 	if err := cfg.ValidateAuth(); err == nil || !strings.Contains(err.Error(), "requires AGENTDOCK_AUTH_TOKEN or OAuth") {
 		t.Fatalf("ValidateAuth() error = %v, want wildcard authentication error", err)
+	}
+}
+
+func TestFromEnvLoadsInstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "instructions.md")
+	if err := os.WriteFile(path, []byte("\n# Guide\n\nUse absolute paths.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if cfg.Instructions != "# Guide\n\nUse absolute paths." {
+		t.Fatalf("Instructions = %q", cfg.Instructions)
+	}
+}
+
+func TestNormalizeRejectsRelativeInstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", "relative/instructions.md")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	err = cfg.Normalize()
+	if err == nil || !strings.Contains(err.Error(), "InstructionsFile") {
+		t.Fatalf("Normalize() error = %v, want InstructionsFile", err)
+	}
+}
+
+func TestNormalizeFailsWhenInstructionsFileMissing(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", filepath.Join(t.TempDir(), "missing.md"))
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err == nil {
+		t.Fatal("Normalize() accepted a missing instructions file")
 	}
 }

--- a/internal/config/instructions_test.go
+++ b/internal/config/instructions_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFromEnvLoadsInstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "instructions.md")
+	if err := os.WriteFile(path, []byte("\n# Guide\n\nUse absolute paths.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if cfg.Instructions != "# Guide\n\nUse absolute paths." {
+		t.Fatalf("Instructions = %q", cfg.Instructions)
+	}
+}
+
+func TestNormalizeRejectsRelativeInstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", "relative/instructions.md")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	err = cfg.Normalize()
+	if err == nil || !strings.Contains(err.Error(), "InstructionsFile") {
+		t.Fatalf("Normalize() error = %v, want InstructionsFile", err)
+	}
+}
+
+func TestNormalizeFailsWhenInstructionsFileMissing(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", filepath.Join(t.TempDir(), "missing.md"))
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err == nil {
+		t.Fatal("Normalize() accepted a missing instructions file")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -25,9 +25,14 @@ type Server struct {
 
 func NewServer(runtime *app.Runtime, cfg config.Config) *Server {
 	server := &Server{runtime: runtime}
+	serverOptions := &mcpsdk.ServerOptions{Capabilities: &mcpsdk.ServerCapabilities{}}
+	if cfg.Instructions != "" {
+		// 可选说明文字随 initialize 响应下发，由支持 MCP instructions 的客户端注入模型上下文。
+		serverOptions.Instructions = cfg.Instructions
+	}
 	server.sdk = mcpsdk.NewServer(
 		&mcpsdk.Implementation{Name: config.ServerName, Version: buildinfo.Version},
-		&mcpsdk.ServerOptions{Capabilities: &mcpsdk.ServerCapabilities{}},
+		serverOptions,
 	)
 	if runtime != nil {
 		for _, name := range runtime.ToolNames() {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -24,9 +24,14 @@ type Server struct {
 
 func NewServer(runtime *app.Runtime, cfg config.Config) *Server {
 	server := &Server{runtime: runtime}
+	serverOptions := &mcpsdk.ServerOptions{Capabilities: &mcpsdk.ServerCapabilities{}}
+	if cfg.Instructions != "" {
+		// 可选说明文字随 initialize 响应下发，由支持 MCP instructions 的客户端注入模型上下文。
+		serverOptions.Instructions = cfg.Instructions
+	}
 	server.sdk = mcpsdk.NewServer(
 		&mcpsdk.Implementation{Name: config.ServerName, Version: config.Version},
-		&mcpsdk.ServerOptions{Capabilities: &mcpsdk.ServerCapabilities{}},
+		serverOptions,
 	)
 	if runtime != nil {
 		for _, name := range runtime.ToolNames() {

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -55,3 +55,39 @@ func TestServeStdioRejectsUninitializedServer(t *testing.T) {
 		t.Fatal("ServeStdio() accepted an uninitialized server")
 	}
 }
+
+func TestServeStdioAdvertisesInstructions(t *testing.T) {
+	server := NewServer(nil, config.Config{Instructions: "Use absolute paths under /srv."})
+	clientInput, serverOutput := io.Pipe()
+	serverInput, clientOutput := io.Pipe()
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- server.ServeStdio(serverInput, serverOutput)
+	}()
+
+	client := mcpsdk.NewClient(
+		&mcpsdk.Implementation{Name: "agentdock-test", Version: "1.0.0"},
+		&mcpsdk.ClientOptions{Capabilities: &mcpsdk.ClientCapabilities{}},
+	)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	session, err := client.Connect(ctx, &mcpsdk.IOTransport{Reader: clientInput, Writer: clientOutput}, nil)
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	result := session.InitializeResult()
+	if result == nil || result.Instructions != "Use absolute paths under /srv." {
+		t.Fatalf("InitializeResult() = %#v, want instructions", result)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("ServeStdio() error = %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("ServeStdio() did not stop after client close")
+	}
+}


### PR DESCRIPTION
解决 PR #18 与最新 main 的冲突，保留当前纯 Go 浏览器配置和 buildinfo 版本逻辑，并集成 AGENTDOCK_INSTRUCTIONS_FILE 与 MCP initialize instructions。该分支保留原 PR HEAD 作为合并父提交。