### PR TITLE
fix(mcp): 收紧 instructions 文件读取边界

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/uvwt/agentdock/internal/fs/securepath"
 )
@@ -192,14 +194,39 @@ func (c *Config) Normalize() error {
 		if !filepath.IsAbs(c.InstructionsFile) {
 			return fmt.Errorf("InstructionsFile must resolve to an absolute path: %s", c.InstructionsFile)
 		}
-		data, err := os.ReadFile(c.InstructionsFile)
+
+		file, err := os.Open(c.InstructionsFile)
+		if err != nil {
+			return fmt.Errorf("open InstructionsFile %s: %w", c.InstructionsFile, err)
+		}
+		defer file.Close()
+
+		info, err := file.Stat()
+		if err != nil {
+			return fmt.Errorf("stat InstructionsFile %s: %w", c.InstructionsFile, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("InstructionsFile must be a regular file: %s", c.InstructionsFile)
+		}
+		if info.Size() > maxInstructionsFileBytes {
+			return fmt.Errorf("InstructionsFile %s exceeds %d bytes", c.InstructionsFile, maxInstructionsFileBytes)
+		}
+
+		// Stat 只能约束打开瞬间的文件大小；读取仍限制为 max+1，避免文件并发增长时突破边界。
+		data, err := io.ReadAll(io.LimitReader(file, int64(maxInstructionsFileBytes)+1))
 		if err != nil {
 			return fmt.Errorf("read InstructionsFile %s: %w", c.InstructionsFile, err)
 		}
 		if len(data) > maxInstructionsFileBytes {
 			return fmt.Errorf("InstructionsFile %s exceeds %d bytes", c.InstructionsFile, maxInstructionsFileBytes)
 		}
+		if !utf8.Valid(data) {
+			return fmt.Errorf("InstructionsFile must contain valid UTF-8: %s", c.InstructionsFile)
+		}
 		c.Instructions = strings.TrimSpace(string(data))
+		if c.Instructions == "" {
+			return fmt.Errorf("InstructionsFile must contain non-empty instructions: %s", c.InstructionsFile)
+		}
 	}
 	if err := c.normalizeACP(); err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,13 +195,8 @@ func (c *Config) Normalize() error {
 			return fmt.Errorf("InstructionsFile must resolve to an absolute path: %s", c.InstructionsFile)
 		}
 
-		file, err := os.Open(c.InstructionsFile)
-		if err != nil {
-			return fmt.Errorf("open InstructionsFile %s: %w", c.InstructionsFile, err)
-		}
-		defer file.Close()
-
-		info, err := file.Stat()
+		// 先检查文件类型再打开，避免误配设备或命名管道时在 Open 阶段阻塞。
+		info, err := os.Stat(c.InstructionsFile)
 		if err != nil {
 			return fmt.Errorf("stat InstructionsFile %s: %w", c.InstructionsFile, err)
 		}
@@ -212,7 +207,13 @@ func (c *Config) Normalize() error {
 			return fmt.Errorf("InstructionsFile %s exceeds %d bytes", c.InstructionsFile, maxInstructionsFileBytes)
 		}
 
-		// Stat 只能约束打开瞬间的文件大小；读取仍限制为 max+1，避免文件并发增长时突破边界。
+		file, err := os.Open(c.InstructionsFile)
+		if err != nil {
+			return fmt.Errorf("open InstructionsFile %s: %w", c.InstructionsFile, err)
+		}
+		defer file.Close()
+
+		// Stat 只能约束检查瞬间的文件大小；读取仍限制为 max+1，避免文件并发增长时突破边界。
 		data, err := io.ReadAll(io.LimitReader(file, int64(maxInstructionsFileBytes)+1))
 		if err != nil {
 			return fmt.Errorf("read InstructionsFile %s: %w", c.InstructionsFile, err)

--- a/internal/config/instructions_test.go
+++ b/internal/config/instructions_test.go
@@ -51,3 +51,92 @@ func TestNormalizeFailsWhenInstructionsFileMissing(t *testing.T) {
 		t.Fatal("Normalize() accepted a missing instructions file")
 	}
 }
+
+func TestNormalizeAcceptsInstructionsFileAtSizeLimit(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "instructions.md")
+	content := strings.Repeat("a", maxInstructionsFileBytes)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if cfg.Instructions != content {
+		t.Fatalf("Instructions length = %d, want %d", len(cfg.Instructions), len(content))
+	}
+}
+
+func TestNormalizeRejectsInstructionsFileOverSizeLimit(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "instructions.md")
+	if err := os.WriteFile(path, []byte(strings.Repeat("a", maxInstructionsFileBytes+1)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("Normalize() error = %v, want size limit error", err)
+	}
+}
+
+func TestNormalizeRejectsEmptyInstructionsFile(t *testing.T) {
+	for _, content := range []string{"", " \n\t "} {
+		t.Run(strings.ReplaceAll(content, "\n", "\\n"), func(t *testing.T) {
+			setTestUserHome(t, t.TempDir())
+			path := filepath.Join(t.TempDir(), "instructions.md")
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv() error = %v", err)
+			}
+			if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "non-empty") {
+				t.Fatalf("Normalize() error = %v, want non-empty instructions error", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeRejectsInvalidUTF8InstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "instructions.md")
+	if err := os.WriteFile(path, []byte{0xff, 0xfe}, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("Normalize() error = %v, want UTF-8 error", err)
+	}
+}
+
+func TestNormalizeRejectsNonRegularInstructionsFile(t *testing.T) {
+	setTestUserHome(t, t.TempDir())
+	t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", t.TempDir())
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("Normalize() error = %v, want regular file error", err)
+	}
+}

--- a/internal/config/instructions_test.go
+++ b/internal/config/instructions_test.go
@@ -91,11 +91,17 @@ func TestNormalizeRejectsInstructionsFileOverSizeLimit(t *testing.T) {
 }
 
 func TestNormalizeRejectsEmptyInstructionsFile(t *testing.T) {
-	for _, content := range []string{"", " \n\t "} {
-		t.Run(strings.ReplaceAll(content, "\n", "\\n"), func(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: ""},
+		{name: "whitespace only", content: " \n\t "},
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			setTestUserHome(t, t.TempDir())
 			path := filepath.Join(t.TempDir(), "instructions.md")
-			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
 				t.Fatalf("WriteFile() error = %v", err)
 			}
 			t.Setenv("AGENTDOCK_INSTRUCTIONS_FILE", path)


### PR DESCRIPTION
修复 PR #18 合并后发现的边界问题：

- 读取前拒绝目录、设备、命名管道等非普通文件，并预检 64 KiB 大小；
- 实际读取使用 `LimitReader(max+1)`，避免文件并发增长突破限制；
- 拒绝非法 UTF-8；
- 拒绝空文件和纯空白文件，保证配置后不会静默不生效；
- 补齐 64 KiB 临界值、超限、空内容、UTF-8、非普通文件测试。