### PR TITLE
fix: preserve exact patch line boundaries

### DIFF
--- a/internal/tool/file/patch.go
+++ b/internal/tool/file/patch.go
@@ -302,11 +302,11 @@ func applyUpdateHunks(content string, hunks [][]string, path string) (string, er
 	if strings.Contains(content, "\r\n") {
 		lineEnding = "\r\n"
 	}
-	lines := strings.Split(strings.TrimSuffix(strings.ReplaceAll(content, "\r\n", "\n"), "\n"), "\n")
-	if content == "" {
-		lines = []string{}
-	}
-	trailing := strings.HasSuffix(content, "\n")
+	// Split on LF only and keep the trailing empty element. This makes the
+	// final newline an ordinary patchable line instead of state restored from
+	// the pre-patch file. It also preserves Unicode line-boundary characters
+	// such as U+2028 as file content rather than treating them as newlines.
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
 	for hunkIndex, hunk := range hunks {
 		oldLines, newLines, err := parseUpdateHunk(hunk)
 		if err != nil {
@@ -327,9 +327,6 @@ func applyUpdateHunks(content string, hunks [][]string, path string) (string, er
 		lines = updated
 	}
 	result := strings.Join(lines, lineEnding)
-	if trailing || len(lines) > 0 {
-		result += lineEnding
-	}
 	if hasBOM {
 		result = "\ufeff" + result
 	}
@@ -344,7 +341,12 @@ func parseUpdateHunk(hunk []string) ([]string, []string, error) {
 			continue
 		}
 		if raw == "" {
-			return nil, nil, toolError("PATCH_FAILED", "invalid empty patch line", "validation")
+			// V4A represents an empty context line as a single space, but model
+			// output and intermediate transports may strip that trailing space.
+			// Treat an empty raw hunk line as unchanged empty context.
+			oldLines = append(oldLines, "")
+			newLines = append(newLines, "")
+			continue
 		}
 		marker := raw[0]
 		value := raw[1:]

--- a/internal/tool/file/patch_semantics_test.go
+++ b/internal/tool/file/patch_semantics_test.go
@@ -1,0 +1,63 @@
+package file
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyUpdateHunksPreservesUnicodeLineBoundaries(t *testing.T) {
+	content := "alpha\u2028beta\nend\n"
+	updated, err := applyUpdateHunks(content, [][]string{{" alpha\u2028beta", "-end", "+done"}}, "unicode.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != "alpha\u2028beta\ndone\n" {
+		t.Fatalf("updated content = %q", updated)
+	}
+}
+
+func TestApplyUpdateHunksFinalNewlineIsControlledByHunk(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		hunk    []string
+		want    string
+	}{
+		{
+			name:    "remove final newline",
+			content: "before\n",
+			hunk:    []string{"-before", "+after", "-"},
+			want:    "after",
+		},
+		{
+			name:    "add final newline",
+			content: "before",
+			hunk:    []string{"-before", "+after", "+"},
+			want:    "after\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated, err := applyUpdateHunks(tt.content, [][]string{tt.hunk}, "newline.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated != tt.want {
+				t.Fatalf("updated content = %q, want %q", updated, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseUpdateHunkAcceptsStrippedEmptyContextLine(t *testing.T) {
+	oldLines, newLines, err := parseUpdateHunk([]string{"", "-before", "+after"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(oldLines, []string{"", "before"}) {
+		t.Fatalf("old lines = %#v", oldLines)
+	}
+	if !reflect.DeepEqual(newLines, []string{"", "after"}) {
+		t.Fatalf("new lines = %#v", newLines)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the trailing empty line when patching so a hunk can explicitly add or remove the final newline
- accept a stripped empty hunk line as unchanged empty context
- lock the existing LF-only split behavior with a U+2028 regression test

## Why

The previous implementation trimmed the final LF before matching and then restored newline state from the pre-patch file. That made final-newline state effectively immutable and could add a newline to a file that did not have one. It also rejected empty context lines after model/transport whitespace stripping.

The semantics are adapted from the patch correctness work in `xyTom/coding-tools-mcp` v0.3.0 (Apache-2.0), translated to AgentDock's Go implementation rather than copying its runtime.

## Compatibility

- no MCP tool/schema changes
- no permission or path-boundary changes
- existing transaction, conflict and rollback machinery is unchanged
- new tests cover U+2028 preservation, final-newline add/remove and stripped empty context