### PR TITLE
fix(windows): preserve Program Files env in exec_command

### DIFF
--- a/internal/tool/command/command.go
+++ b/internal/tool/command/command.go
@@ -410,7 +410,7 @@ func (svc *Service) internalCommandEnv(extra map[string]string) ([]string, error
 
 func (svc *Service) baseCommandEnv() (map[string]string, error) {
 	env := map[string]string{}
-	for _, key := range []string{"PATH", "LANG", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR", "SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "TEMP", "TMP", "WSLENV"} {
+	for _, key := range []string{"PATH", "LANG", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR", "SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "TEMP", "TMP", "WSLENV", "PROGRAMFILES", "PROGRAMW6432"} {
 		if value := os.Getenv(key); value != "" {
 			env[key] = value
 		}

--- a/internal/tool/command/command_env_windows_test.go
+++ b/internal/tool/command/command_env_windows_test.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/uvwt/agentdock/internal/config"
+	"github.com/uvwt/agentdock/internal/envstore"
+)
+
+func TestCommandEnvPreservesWindowsProgramFilesVariables(t *testing.T) {
+	home := t.TempDir()
+	envs, err := envstore.New(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := New(
+		func() config.Config { return config.Config{AgentDockHome: home, AgentDockDefaultDir: home} },
+		nil,
+		envs,
+		NewSessionStore(),
+		nil,
+		nil,
+		nil,
+	)
+
+	t.Setenv("PROGRAMFILES", `C:\Program Files`)
+	t.Setenv("PROGRAMW6432", `C:\Program Files`)
+	got, err := svc.CommandEnv("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := map[string]string{}
+	for _, entry := range got {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	for _, key := range []string{"PROGRAMFILES", "PROGRAMW6432"} {
+		if values[key] != `C:\Program Files` {
+			t.Fatalf("%s = %q, want %q", key, values[key], `C:\Program Files`)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause

`exec_command` does **not** inherit the normal Windows process environment. `baseCommandEnv()` intentionally rebuilds a small allowlisted environment before starting commands.

On Windows, that allowlist currently omits two standard variables:

```text
PROGRAMFILES=C:\Program Files
PROGRAMW6432=C:\Program Files
```

As a result, a process started by AgentDock does not see the same baseline Windows environment as the exact same process started from Explorer, Task Scheduler, or a normal terminal.

This is not NVIDIA-specific. NVIDIA `nvidia-smi` is simply a concrete tool that exposes the problem reliably.

## Concrete reproduction

On the affected Windows machine, with AgentDock v0.7.6 and NVIDIA driver 610.88:

### Outside AgentDock

Running `nvidia-smi` as the same Windows user succeeds normally and reports the GPU, temperature, memory usage, utilization, power, and processes.

### Through AgentDock `exec_command`

The exact same executable exits immediately with:

```text
Failed to initialize NVML: Unknown Error
```

This initially looks like a broken NVIDIA driver or broken NVML installation, but additional checks show that is a false diagnosis:

- `nvml.dll` initializes successfully when called directly.
- NVML can read GPU name, temperature, memory, utilization, power, and clocks.
- CUDA/Paddle GPU workloads run successfully.
- `nvidia-smi.exe` and `nvml.dll` have valid signatures and matching driver versions.
- Running the same `nvidia-smi.exe` as the same Windows user outside AgentDock works.

Replacing the AgentDock child-process environment with a normal Windows environment makes `nvidia-smi` succeed immediately.

Testing the environment differences individually then isolates the failure to the missing Program Files variables: restoring either `PROGRAMFILES` or `PROGRAMW6432` is sufficient for `nvidia-smi` to start normally.

## Why this matters

Without this fix, AgentDock can make a healthy Windows installation look broken from inside `exec_command`.

That has several practical consequences:

1. **False hardware/driver diagnostics**
   - A tool may report that a driver, runtime, SDK, or component is missing or broken even though it works normally outside AgentDock.
   - In this case `nvidia-smi` falsely reported an NVML initialization failure while NVML itself was healthy.

2. **Incorrect automation decisions**
   - Agents or scripts may react to the false failure by reinstalling drivers, switching GPU workloads to CPU, restarting services, rebooting the machine, or taking other unnecessary recovery actions.

3. **Program discovery failures**
   - Native Windows applications and scripts commonly derive installation paths from Program Files environment variables.
   - A command may fail to locate an installed application, runtime, helper executable, plugin, SDK, or resource even though it exists on disk.

4. **Different behavior inside vs. outside AgentDock**
   - The same executable, same user, same machine, and same command can behave differently only because AgentDock removed standard Windows environment state.
   - This makes bugs difficult to diagnose because users naturally investigate the target application instead of the command runner.

5. **Misleading health checks**
   - GPU, SDK, compiler, runtime, installer, and system-diagnostic checks can return false negatives when they depend on these standard paths.

The NVIDIA failure is therefore a reproducible symptom of a more general Windows command-environment compatibility issue.

## Fix

Preserve these two standard Windows variables in `baseCommandEnv()`:

```text
PROGRAMFILES
PROGRAMW6432
```

A Windows-only regression test verifies that both survive command environment construction.

## Why this fix is intentionally small

This PR does **not** change AgentDock to inherit the full host environment.

The existing allowlist/security model remains intact. Only two standard Windows installation-root variables that are already part of a normal Windows process environment are added.

So the behavior becomes more Windows-compatible without expanding command execution to arbitrary host environment variables.

## Verification

Verified on Windows with AgentDock v0.7.6 / commit `fed8dafcb1b0` and NVIDIA driver 610.88:

- `go test ./internal/tool/command` passes.
- `go test ./internal/envstore` passes.
- Rebuilt AgentDock with this change.
- Confirmed `PROGRAMFILES` and `PROGRAMW6432` are present inside `exec_command`.
- Confirmed `nvidia-smi` now succeeds directly through AgentDock `exec_command`.
- No NVIDIA driver reinstall or NVIDIA configuration change was required.