### PR TITLE
fix(windows): 可靠终止命令会话进程树

### DIFF
--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -1,0 +1,99 @@
+//go:build windows
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
+	runtime, root := newCodeToolsRuntime(t)
+	defer runtime.Close()
+	nodePath, err := exec.LookPath("node.exe")
+	if err != nil {
+		t.Skip("node.exe is not installed")
+	}
+	port := reserveAppWindowsPort(t)
+	pidPath := filepath.Join(root, "node-session-kill.pid")
+	nodeScript := fmt.Sprintf(
+		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		port,
+	)
+	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+	started, err := runtime.execCommand(context.Background(), map[string]any{
+		"cmd": command, "execution_mode": "async", "timeout_ms": 60000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID, _ := started["session_id"].(string)
+	nodePID := waitForAppWindowsNode(t, pidPath, port)
+	defer func() {
+		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+			_ = process.Kill()
+		}
+	}()
+
+	result, err := runtime.sessionAct(map[string]any{"action": "kill", "session_id": sessionID})
+	if err != nil {
+		t.Fatalf("session_act(kill) error = %v", err)
+	}
+	if result["status"] != "killed" {
+		t.Fatalf("kill result = %#v", result)
+	}
+	if err := waitForAppWindowsPort(port, false, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reserveAppWindowsPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForAppWindowsNode(t *testing.T, pidPath string, port int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil && waitForAppWindowsPort(port, true, 100*time.Millisecond) == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("Node server did not start")
+	return 0
+}
+
+func waitForAppWindowsPort(port int, wantOpen bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 50*time.Millisecond)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		if (err == nil) == wantOpen {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("port %d open state did not become %t", port, wantOpen)
+}

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -15,8 +16,11 @@ import (
 // Controller owns a Windows Job Object. Closing the job terminates any descendants
 // that outlive the direct child, which keeps command, Skill and browser process trees bounded.
 type Controller struct {
-	mu  sync.Mutex
-	job windows.Handle
+	mu           sync.Mutex
+	job          windows.Handle
+	pid          uint32
+	terminated   bool
+	terminateErr error
 }
 
 // Configure 在后台子进程启动前禁用控制台窗口，同时保留调用方已有的创建标志。
@@ -78,7 +82,7 @@ func AttachPID(pid int) (*Controller, error) {
 		return nil, fmt.Errorf("assign child process to Job Object: %w", err)
 	}
 	closeJob = false
-	return &Controller{job: job}, nil
+	return &Controller{job: job, pid: uint32(pid)}, nil
 }
 
 func (c *Controller) Terminate() error {
@@ -90,10 +94,27 @@ func (c *Controller) Terminate() error {
 	if c.job == 0 {
 		return nil
 	}
-	if err := windows.TerminateJobObject(c.job, 1); err != nil {
-		return fmt.Errorf("terminate Windows Job Object: %w", err)
+	if c.terminated {
+		return c.terminateErr
 	}
-	return nil
+	c.terminated = true
+
+	// PowerShell 和部分 launcher 在嵌套 Job 环境中启动 native child 时，
+	// 后代进程不一定会进入 AgentDock 新建的 Job。先按父子关系固定这些进程的
+	// handle，再终止 Job 中的 wrapper，避免 wrapper 退出后子进程重新挂接而丢失。
+	descendants, snapshotErr := descendantProcessIDs(c.pid)
+	handles, openErr := openProcessesForTermination(descendants)
+	defer closeProcessHandles(handles)
+
+	var terminateErr error
+	if err := windows.TerminateJobObject(c.job, 1); err != nil {
+		terminateErr = fmt.Errorf("terminate Windows Job Object: %w", err)
+	}
+	if err := terminateProcessHandles(handles); err != nil {
+		terminateErr = errors.Join(terminateErr, err)
+	}
+	c.terminateErr = errors.Join(snapshotErr, openErr, terminateErr)
+	return c.terminateErr
 }
 
 func (c *Controller) Close() error {
@@ -111,4 +132,105 @@ func (c *Controller) Close() error {
 		return fmt.Errorf("close Windows Job Object: %w", err)
 	}
 	return nil
+}
+
+type processHandle struct {
+	pid    uint32
+	handle windows.Handle
+}
+
+func descendantProcessIDs(root uint32) ([]uint32, error) {
+	if root == 0 {
+		return nil, nil
+	}
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot Windows process tree: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	children := make(map[uint32][]uint32)
+	entry := windows.ProcessEntry32{Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{}))}
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read Windows process snapshot: %w", err)
+	}
+	for {
+		children[entry.ParentProcessID] = append(children[entry.ParentProcessID], entry.ProcessID)
+		entry.Size = uint32(unsafe.Sizeof(windows.ProcessEntry32{}))
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, fmt.Errorf("read Windows process snapshot: %w", err)
+		}
+	}
+
+	// 后序遍历让更深的后代先终止；visited 同时防御异常父子环。
+	visited := map[uint32]bool{root: true}
+	result := make([]uint32, 0)
+	var visit func(uint32)
+	visit = func(parent uint32) {
+		for _, child := range children[parent] {
+			if child == 0 || visited[child] {
+				continue
+			}
+			visited[child] = true
+			visit(child)
+			result = append(result, child)
+		}
+	}
+	visit(root)
+	return result, nil
+}
+
+func openProcessesForTermination(pids []uint32) ([]processHandle, error) {
+	handles := make([]processHandle, 0, len(pids))
+	var result error
+	for _, pid := range pids {
+		handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE|windows.SYNCHRONIZE, false, pid)
+		if err != nil {
+			// 进程可能在快照和 OpenProcess 之间正常退出。
+			if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+				continue
+			}
+			result = errors.Join(result, fmt.Errorf("open descendant process %d: %w", pid, err))
+			continue
+		}
+		handles = append(handles, processHandle{pid: pid, handle: handle})
+	}
+	return handles, result
+}
+
+func terminateProcessHandles(processes []processHandle) error {
+	var result error
+	for _, process := range processes {
+		state, err := windows.WaitForSingleObject(process.handle, 0)
+		if err != nil {
+			result = errors.Join(result, fmt.Errorf("inspect descendant process %d: %w", process.pid, err))
+			continue
+		}
+		if state == windows.WAIT_OBJECT_0 {
+			continue
+		}
+		if err := windows.TerminateProcess(process.handle, 1); err != nil {
+			result = errors.Join(result, fmt.Errorf("terminate descendant process %d: %w", process.pid, err))
+			continue
+		}
+		state, err = windows.WaitForSingleObject(process.handle, 2000)
+		if err != nil {
+			result = errors.Join(result, fmt.Errorf("wait for descendant process %d: %w", process.pid, err))
+		} else if state != windows.WAIT_OBJECT_0 {
+			result = errors.Join(result, fmt.Errorf("descendant process %d did not stop", process.pid))
+		}
+	}
+	return result
+}
+
+func closeProcessHandles(processes []processHandle) {
+	for _, process := range processes {
+		_ = windows.CloseHandle(process.handle)
+	}
 }

--- a/internal/tool/command/command.go
+++ b/internal/tool/command/command.go
@@ -244,7 +244,15 @@ func (svc *Service) killSession(args map[string]any) (Result, error) {
 		return svc.consumeCompletedSession(s, commandOutputLimit(args)), nil
 	default:
 	}
-	s.Kill()
+	_, killErr := s.Kill()
+	if killErr != nil {
+		return nil, toolErrorDetails(
+			"SESSION_KILL_FAILED",
+			"failed to terminate the session process tree",
+			"runtime",
+			map[string]any{"session_id": s.ID, "reason": killErr.Error()},
+		)
+	}
 	if !waitForSessionCompletion(s, sessionKillWait) {
 		return nil, toolErrorDetails(
 			"SESSION_KILL_TIMEOUT",
@@ -266,6 +274,7 @@ func (svc *Service) KillAll(args map[string]any) (Result, error) {
 	sessions := svc.sessions.List()
 	running := make([]*session.Session, 0, len(sessions))
 	items := make([]map[string]any, 0, len(sessions))
+	killFailures := make([]map[string]any, 0)
 	for _, s := range sessions {
 		select {
 		case <-s.Done:
@@ -274,15 +283,30 @@ func (svc *Service) KillAll(args map[string]any) (Result, error) {
 			svc.sessions.Delete(s.ID)
 			items = append(items, map[string]any{"session_id": s.ID, "status": summary.Status})
 		default:
-			s.Kill()
+			_, killErr := s.Kill()
+			if killErr != nil {
+				killFailures = append(killFailures, map[string]any{"session_id": s.ID, "reason": killErr.Error()})
+			}
 			running = append(running, s)
 		}
 	}
-
 	completed, timedOut := waitForSessionsCompletion(running, sessionKillWait)
 	for _, s := range completed {
 		svc.sessions.Delete(s.ID)
 		items = append(items, map[string]any{"session_id": s.ID, "status": "killed"})
+	}
+	if len(killFailures) > 0 {
+		details := map[string]any{"sessions": killFailures}
+		if len(timedOut) > 0 {
+			details["timed_out_session_ids"] = timedOut
+			details["wait_ms"] = sessionKillWait.Milliseconds()
+		}
+		return nil, toolErrorDetails(
+			"SESSION_KILL_FAILED",
+			"failed to terminate one or more session process trees",
+			"runtime",
+			details,
+		)
 	}
 	if len(timedOut) > 0 {
 		return nil, toolErrorDetails(

--- a/internal/tool/command/session/session.go
+++ b/internal/tool/command/session/session.go
@@ -354,20 +354,20 @@ func (s *Session) WaitError() error {
 	return s.waitErr
 }
 
-func (s *Session) Kill() bool {
+func (s *Session) Kill() (bool, error) {
 	s.mu.Lock()
 	if s.completed {
 		s.mu.Unlock()
-		return false
+		return false, nil
 	}
 	runner := s.runner
 	s.mu.Unlock()
 	if runner == nil {
-		return false
+		return false, nil
 	}
-	_ = runner.Kill()
+	err := runner.Kill()
 	s.Cancel()
-	return true
+	return true, err
 }
 
 func (s *Session) Snapshot(status string, maxBytes int) map[string]any {

--- a/internal/tool/command/session/session_test.go
+++ b/internal/tool/command/session/session_test.go
@@ -19,7 +19,7 @@ func TestKillSkipsCompletedSession(t *testing.T) {
 		Cancel:    func() { canceled = true },
 		completed: true,
 	}
-	if killed := s.Kill(); killed {
+	if killed, err := s.Kill(); killed || err != nil {
 		t.Fatal("Kill() reported a signal for a completed session")
 	}
 	if canceled {

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -4,7 +4,12 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,4 +71,95 @@ func TestWindowsTTYUsesConPTYAndAcceptsInput(t *testing.T) {
 	if !strings.Contains(stdout, "received:hello") {
 		t.Fatalf("stdout = %q", stdout)
 	}
+}
+
+func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
+	nodePath, err := exec.LookPath("node.exe")
+	if err != nil {
+		t.Skip("node.exe is not installed")
+	}
+	root := t.TempDir()
+	port := reserveWindowsTestPort(t)
+	pidPath := filepath.Join(root, "node.pid")
+	nodeScript := fmt.Sprintf(
+		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		port,
+	)
+	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+
+	s, _, err := Start(context.Background(), command, root, os.Environ(), time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Cancel()
+	defer func() {
+		if s.Command != nil && s.Command.Process != nil {
+			_ = s.Command.Process.Kill()
+		}
+	}()
+	nodePID := waitForWindowsTestNode(t, pidPath, port)
+	defer func() {
+		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+			_ = process.Kill()
+		}
+	}()
+
+	killed, err := s.Kill()
+	if err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	if !killed {
+		t.Fatal("Kill() did not report a running session")
+	}
+	select {
+	case <-s.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not finish after killing its process tree")
+	}
+	if err := waitForWindowsTestPort(port, false, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reserveWindowsTestPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForWindowsTestNode(t *testing.T, pidPath string, port int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil && waitForWindowsTestPort(port, true, 100*time.Millisecond) == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("Node server did not start")
+	return 0
+}
+
+func waitForWindowsTestPort(port int, wantOpen bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 50*time.Millisecond)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		if (err == nil) == wantOpen {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("port %d open state did not become %t", port, wantOpen)
 }


### PR DESCRIPTION
Closes #33

## 问题

Windows 上的 PowerShell/launcher 可能产生未被 AgentDock Job Object 完整覆盖的 native child。原实现只终止 Job/wrapper，`session_act(action="kill")` 因而可能等待超时，并遗留仍在监听端口的子进程。

## 改动

- 在终止 Job 前用 Toolhelp32 快照 wrapper 的完整后代树；
- 预先打开后代 process handle，避免 wrapper 退出后父子关系丢失；
- 终止 Job 后补充终止逃逸后代，并等待其退出；
- 将底层 kill 错误传播到 `kill`/`kill_all`，新增 `SESSION_KILL_FAILED`；
- 保持重复终止调用幂等；
- 增加 PowerShell wrapper、Node HTTP server 和 session 错误传播回归测试。

## 验证

- `go test ./...`
- `go vet ./...`
- Windows 上连续 5 次启动 Node HTTP server → `session_act(kill)`，均返回 `killed`，端口均释放
