### PR TITLE
feat(nexus): 支持分块读取本地 Artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ AgentDock can optionally pair with NexusDock as a multi-device aggregation entry
 - Workflow templates
 - Private notes
 - Multi-device state coordination
+- Temporary signed Artifact downloads proxied by NexusDock while the source node is online
 
 ## Runtime directories
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/uvwt/agentdock/internal/app"
 	"github.com/uvwt/agentdock/internal/buildinfo"
 	"github.com/uvwt/agentdock/internal/config"
+	"github.com/uvwt/agentdock/internal/publicartifacts"
 )
 
 type Server struct {
@@ -95,6 +97,35 @@ func (s *Server) Invoke(ctx context.Context, name string, arguments map[string]a
 	}
 	result, err := s.runtime.Call(ctx, name, arguments)
 	return toolEnvelope(name, result, err), nil
+}
+
+// ReadArtifactChunk serves the private Bridge operation used by NexusDock's
+// signed download proxy. It is not exposed as an MCP tool.
+func (s *Server) ReadArtifactChunk(artifactID string, offset int64, maxBytes int) (map[string]any, error) {
+	if s == nil {
+		return nil, errors.New("AgentDock MCP server is not initialized")
+	}
+	store := publicartifacts.New(s.cfg.AgentDockHome, s.cfg.OAuthServerURL, s.cfg.Port)
+	meta, data, eof, err := store.ReadChunk(artifactID, offset, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"artifact_id": meta.ArtifactID,
+		"filename":    meta.Filename,
+		"mime_type":   meta.MimeType,
+		"size_bytes":  meta.Size,
+		"sha256":      meta.SHA256,
+		"created_at":  meta.CreatedAt,
+		"expires_at":  meta.ExpiresAt,
+		"archive":     meta.Archive,
+		"width":       meta.Width,
+		"height":      meta.Height,
+		"offset":      offset,
+		"next_offset": offset + int64(len(data)),
+		"data_base64": base64.StdEncoding.EncodeToString(data),
+		"eof":         eof,
+	}, nil
 }
 
 func (s *Server) HTTPHandler() http.Handler {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,27 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/uvwt/agentdock/internal/app"
 	"github.com/uvwt/agentdock/internal/config"
+	"github.com/uvwt/agentdock/internal/publicartifacts"
 )
+
+func TestReadArtifactChunkServesPrivateBridgePayload(t *testing.T) {
+	home := t.TempDir()
+	store := publicartifacts.New(home, "", 0)
+	published, err := store.PublishBytes(publicartifacts.PublishBytesRequest{Filename: "result.txt", Data: []byte("bridge payload")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(nil, config.Config{AgentDockHome: home})
+	result, err := server.ReadArtifactChunk(published.ArtifactID, 0, publicartifacts.MaxBridgeChunkBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := result["data_base64"].(string)
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || string(data) != "bridge payload" || result["eof"] != true {
+		t.Fatalf("Bridge Artifact result = %#v decoded=%q err=%v", result, data, err)
+	}
+}
 
 func TestToolDescriptorsExposeSafetyAnnotations(t *testing.T) {
 	descriptors := toolDescriptorsForNames([]string{"read_file", "skill_package", "task_manage", "file_publish"}, config.Config{})

--- a/internal/nexusbridge/client.go
+++ b/internal/nexusbridge/client.go
@@ -24,6 +24,11 @@ import (
 
 const maxMessageBytes = 8 << 20
 
+const (
+	artifactReadCapability = "bridge.artifact.read.v1"
+	operationArtifactRead  = "artifact.read"
+)
+
 type Client struct {
 	identity Identity
 	server   *mcp.Server
@@ -82,6 +87,7 @@ func (c *Client) connect(ctx context.Context) error {
 	socket.SetReadLimit(maxMessageBytes)
 
 	tools := c.server.ToolNames()
+	capabilities := append(append([]string(nil), tools...), artifactReadCapability)
 	descriptors, err := bridgeToolDescriptors(c.server.ToolDescriptors())
 	if err != nil {
 		return err
@@ -90,7 +96,7 @@ func (c *Client) connect(ctx context.Context) error {
 		Type: protocol.MessageNodeHello, ProtocolVersion: protocol.ConnectionProtocolVersion,
 		Hello: &protocol.Hello{
 			DeviceID: c.identity.DeviceID, Version: buildinfo.Version, ProtocolVersion: protocol.ConnectionProtocolVersion,
-			OS: runtime.GOOS, Arch: runtime.GOARCH, Capabilities: tools, ToolContractHash: c.server.ToolContractHash(),
+			OS: runtime.GOOS, Arch: runtime.GOARCH, Capabilities: capabilities, ToolContractHash: c.server.ToolContractHash(),
 			Tools: descriptors, UIResources: c.server.UIResources(),
 		},
 	}); err != nil {
@@ -170,6 +176,17 @@ func (c *Client) invoke(parent context.Context, socket *websocket.Conn, incoming
 			err = fmt.Errorf("解析 MCP App resource 请求: %w", decodeErr)
 		} else {
 			result, err = c.server.ReadAppResource(request.URI)
+		}
+	case operationArtifactRead:
+		var request struct {
+			ArtifactID string `json:"artifact_id"`
+			Offset     int64  `json:"offset"`
+			MaxBytes   int    `json:"max_bytes"`
+		}
+		if decodeErr := json.Unmarshal(incoming.Arguments, &request); decodeErr != nil {
+			err = fmt.Errorf("解析 Artifact 读取请求: %w", decodeErr)
+		} else {
+			result, err = c.server.ReadArtifactChunk(request.ArtifactID, request.Offset, request.MaxBytes)
 		}
 	default:
 		err = fmt.Errorf("不支持的 NexusDock 节点操作: %s", incoming.Operation)

--- a/internal/publicartifacts/store.go
+++ b/internal/publicartifacts/store.go
@@ -29,6 +29,9 @@ import (
 const (
 	DefaultRetention = 24 * time.Hour
 	MaxRetention     = 7 * 24 * time.Hour
+	// MaxBridgeChunkBytes keeps one base64-encoded Nexus Bridge response well below
+	// the WebSocket message limit while avoiding tiny repeated reads.
+	MaxBridgeChunkBytes = 512 << 10
 )
 
 type Store struct {
@@ -328,6 +331,66 @@ func (s Store) Read(artifactID string, maxBytes int64) (Metadata, []byte, error)
 		return Metadata{}, nil, errors.New("artifact payload checksum does not match metadata")
 	}
 	return meta, data, nil
+}
+
+// ReadChunk returns one verified slice of an Artifact for the outbound-only
+// Nexus Bridge. A zero maxBytes performs a metadata-only read for HTTP HEAD.
+func (s Store) ReadChunk(artifactID string, offset int64, maxBytes int) (Metadata, []byte, bool, error) {
+	if offset < 0 {
+		return Metadata{}, nil, false, errors.New("artifact offset must not be negative")
+	}
+	if maxBytes < 0 || maxBytes > MaxBridgeChunkBytes {
+		return Metadata{}, nil, false, fmt.Errorf("artifact chunk size must be between 0 and %d bytes", MaxBridgeChunkBytes)
+	}
+	meta, err := s.readMetadata(artifactID)
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("read artifact metadata: %w", err)
+	}
+	if time.Now().UTC().After(meta.ExpiresAt) {
+		return Metadata{}, nil, false, errors.New("artifact has expired")
+	}
+	if offset > meta.Size {
+		return Metadata{}, nil, false, fmt.Errorf("artifact offset %d exceeds payload size %d", offset, meta.Size)
+	}
+
+	payload := filepath.Join(s.Root, artifactID, "payload")
+	file, err := os.Open(payload)
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("open artifact payload: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() != meta.Size {
+		return Metadata{}, nil, false, errors.New("artifact payload size does not match metadata")
+	}
+	if maxBytes == 0 {
+		return meta, nil, offset == meta.Size, nil
+	}
+	// The first chunk verifies the immutable snapshot before any bytes leave the
+	// node. Nexus additionally verifies the complete stream against this digest.
+	if offset == 0 {
+		payloadSHA, hashErr := streamSHA256(file)
+		if hashErr != nil || payloadSHA != meta.SHA256 {
+			return Metadata{}, nil, false, errors.New("artifact payload checksum does not match metadata")
+		}
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("seek artifact payload: %w", err)
+	}
+	remaining := meta.Size - offset
+	readBytes := int64(maxBytes)
+	if remaining < readBytes {
+		readBytes = remaining
+	}
+	data, err := io.ReadAll(io.LimitReader(file, readBytes))
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("read artifact chunk: %w", err)
+	}
+	if int64(len(data)) != readBytes {
+		return Metadata{}, nil, false, errors.New("artifact payload changed while it was being read")
+	}
+	nextOffset := offset + int64(len(data))
+	return meta, data, nextOffset == meta.Size, nil
 }
 
 func (s Store) Cleanup(now time.Time) error {

--- a/internal/publicartifacts/store_test.go
+++ b/internal/publicartifacts/store_test.go
@@ -83,6 +83,56 @@ func TestPublishWithoutBaseURLReturnsArtifactReferenceAndCanRead(t *testing.T) {
 	}
 }
 
+func TestReadChunkStreamsVerifiedArtifact(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	data := bytes.Repeat([]byte("chunked-artifact-"), 70000)
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.bin", Data: data})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metadata, empty, eof, err := store.ReadChunk(result.ArtifactID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Size != int64(len(data)) || len(empty) != 0 || eof {
+		t.Fatalf("metadata read = size:%d bytes:%d eof:%t", metadata.Size, len(empty), eof)
+	}
+
+	var restored []byte
+	for offset := int64(0); ; {
+		meta, chunk, chunkEOF, readErr := store.ReadChunk(result.ArtifactID, offset, MaxBridgeChunkBytes)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if meta.SHA256 != result.SHA256 || len(chunk) > MaxBridgeChunkBytes {
+			t.Fatalf("unexpected chunk metadata or size: %#v bytes=%d", meta, len(chunk))
+		}
+		restored = append(restored, chunk...)
+		offset += int64(len(chunk))
+		if chunkEOF {
+			break
+		}
+	}
+	if !bytes.Equal(restored, data) {
+		t.Fatal("chunked Artifact content changed")
+	}
+}
+
+func TestReadChunkRejectsTamperedArtifactBeforeFirstChunk(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.txt", Data: []byte("original")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Root, result.ArtifactID, "payload"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, MaxBridgeChunkBytes); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("tampered Artifact error = %v", err)
+	}
+}
+
 func TestPublishDirectoryCreatesTarGzSnapshot(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "bundle")


### PR DESCRIPTION
Related to uvwt/nexusdock#9

## 背景

Nexus fleet 模式下，AgentDock 节点通过出站 WebSocket 接入，不要求具备公网 HTTP 地址。`file_publish` 可以创建本地 immutable Artifact，但 Nexus 无法读取 payload，因此不能为 MCP Client 提供可访问的 signed URL。

本 PR 提供 Nexus 下载代理所需的最小节点侧私有能力；公开下载、签名与 HTTP 安全边界由 NexusDock 配套 PR 实现。

## 改动

- 节点握手声明 `bridge.artifact.read.v1` capability；
- 增加仅在 Nexus bridge 内分发的私有 `artifact.read` operation，不注册为公开 MCP tool；
- 支持 metadata-only 与最大 512 KiB 的 offset chunk 读取；
- 读取前校验 Artifact ID、有效期、payload 大小和完整 SHA-256；
- 返回 filename、MIME、size、SHA、expires、offset、next offset、EOF 与 base64 data；
- 为非法 offset、超限 chunk、过期/损坏 Artifact 增加测试；
- README 补充 fleet Artifact 下载能力说明。

## 安全边界

- 只能按 `artifact_id` 读取 `public-artifacts` 中已发布的 immutable snapshot；
- 不接受任意本地路径；
- operation 仅供已经认证的 Nexus Device WebSocket bridge 使用；
- Nexus 必须显式检查 capability 后才能调用。

## 验证

- `go test ./...`
- `go vet ./...`
- Windows、WSL、Linux 节点均完成 Nexus signed URL HEAD/GET 与 SHA-256 端到端校验

## 配套改动

- NexusDock PR：uvwt/nexusdock#10
