### PR TITLE
fix(windows): 可靠终止命令会话进程树并处理竞态

### DIFF
--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -1,0 +1,99 @@
+//go:build windows
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
+	runtime, root := newCodeToolsRuntime(t)
+	defer runtime.Close()
+	nodePath, err := exec.LookPath("node.exe")
+	if err != nil {
+		t.Skip("node.exe is not installed")
+	}
+	port := reserveAppWindowsPort(t)
+	pidPath := filepath.Join(root, "node-session-kill.pid")
+	nodeScript := fmt.Sprintf(
+		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		port,
+	)
+	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+	started, err := runtime.execCommand(context.Background(), map[string]any{
+		"cmd": command, "execution_mode": "async", "timeout_ms": 60000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID, _ := started["session_id"].(string)
+	nodePID := waitForAppWindowsNode(t, pidPath, port)
+	defer func() {
+		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+			_ = process.Kill()
+		}
+	}()
+
+	result, err := runtime.sessionAct(map[string]any{"action": "kill", "session_id": sessionID})
+	if err != nil {
+		t.Fatalf("session_act(kill) error = %v", err)
+	}
+	if result["status"] != "killed" {
+		t.Fatalf("kill result = %#v", result)
+	}
+	if err := waitForAppWindowsPort(port, false, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reserveAppWindowsPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForAppWindowsNode(t *testing.T, pidPath string, port int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil && waitForAppWindowsPort(port, true, 100*time.Millisecond) == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("Node server did not start")
+	return 0
+}
+
+func waitForAppWindowsPort(port int, wantOpen bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 50*time.Millisecond)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		if (err == nil) == wantOpen {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("port %d open state did not become %t", port, wantOpen)
+}

--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -25,9 +25,9 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 	port := reserveAppWindowsPort(t)
 	pidPath := filepath.Join(root, "node-session-kill.pid")
 	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
-		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(%d,'127.0.0.1',()=>fs.writeFileSync('%s',String(process.pid)))",
 		port,
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
 	)
 	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
 	started, err := runtime.execCommand(context.Background(), map[string]any{
@@ -37,7 +37,7 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessionID, _ := started["session_id"].(string)
-	nodePID := waitForAppWindowsNode(t, pidPath, port)
+	nodePID := waitForAppWindowsNode(t, runtime, sessionID, pidPath, port)
 	defer func() {
 		if process, findErr := os.FindProcess(nodePID); findErr == nil {
 			_ = process.Kill()
@@ -66,9 +66,9 @@ func reserveAppWindowsPort(t *testing.T) int {
 	return listener.Addr().(*net.TCPAddr).Port
 }
 
-func waitForAppWindowsNode(t *testing.T, pidPath string, port int) int {
+func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, pidPath string, port int) int {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(pidPath)
 		if err == nil && waitForAppWindowsPort(port, true, 100*time.Millisecond) == nil {
@@ -79,7 +79,10 @@ func waitForAppWindowsNode(t *testing.T, pidPath string, port int) int {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	t.Fatal("Node server did not start")
+	status, observeErr := runtime.sessionObserve(map[string]any{
+		"action": "status", "session_id": sessionID, "max_output_bytes": 4096,
+	})
+	t.Fatalf("Node server did not start: status=%#v observe_err=%v", status, observeErr)
 	return 0
 }
 

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -215,14 +215,22 @@ func terminateProcessHandles(processes []processHandle) error {
 		if state == windows.WAIT_OBJECT_0 {
 			continue
 		}
-		if err := windows.TerminateProcess(process.handle, 1); err != nil {
-			result = errors.Join(result, fmt.Errorf("terminate descendant process %d: %w", process.pid, err))
+
+		terminateErr := windows.TerminateProcess(process.handle, 1)
+
+		// TerminateJobObject 可能已经开始结束同一个后代。这个竞态窗口里，
+		// 上面的零等待仍可能看到进程存活，而 TerminateProcess 会返回 Access Denied。
+		// 不按错误码猜测结果，只认预先固定的同一个 process handle 是否最终退出。
+		state, waitErr := windows.WaitForSingleObject(process.handle, 2000)
+		if state == windows.WAIT_OBJECT_0 && waitErr == nil {
 			continue
 		}
-		state, err = windows.WaitForSingleObject(process.handle, 2000)
-		if err != nil {
-			result = errors.Join(result, fmt.Errorf("wait for descendant process %d: %w", process.pid, err))
-		} else if state != windows.WAIT_OBJECT_0 {
+		if terminateErr != nil {
+			result = errors.Join(result, fmt.Errorf("terminate descendant process %d: %w", process.pid, terminateErr))
+		}
+		if waitErr != nil {
+			result = errors.Join(result, fmt.Errorf("wait for descendant process %d: %w", process.pid, waitErr))
+		} else if state != windows.WAIT_OBJECT_0 && terminateErr == nil {
 			result = errors.Join(result, fmt.Errorf("descendant process %d did not stop", process.pid))
 		}
 	}

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -15,8 +16,11 @@ import (
 // Controller owns a Windows Job Object. Closing the job terminates any descendants
 // that outlive the direct child, which keeps command, Skill and browser process trees bounded.
 type Controller struct {
-	mu  sync.Mutex
-	job windows.Handle
+	mu           sync.Mutex
+	job          windows.Handle
+	pid          uint32
+	terminated   bool
+	terminateErr error
 }
 
 // Configure 在后台子进程启动前禁用控制台窗口，同时保留调用方已有的创建标志。
@@ -78,7 +82,7 @@ func AttachPID(pid int) (*Controller, error) {
 		return nil, fmt.Errorf("assign child process to Job Object: %w", err)
 	}
 	closeJob = false
-	return &Controller{job: job}, nil
+	return &Controller{job: job, pid: uint32(pid)}, nil
 }
 
 func (c *Controller) Terminate() error {
@@ -90,10 +94,27 @@ func (c *Controller) Terminate() error {
 	if c.job == 0 {
 		return nil
 	}
-	if err := windows.TerminateJobObject(c.job, 1); err != nil {
-		return fmt.Errorf("terminate Windows Job Object: %w", err)
+	if c.terminated {
+		return c.terminateErr
 	}
-	return nil
+	c.terminated = true
+
+	// PowerShell 和部分 launcher 在嵌套 Job 环境中启动 native child 时，
+	// 后代进程不一定会进入 AgentDock 新建的 Job。先按父子关系固定这些进程的
+	// handle，再终止 Job 中的 wrapper，避免 wrapper 退出后子进程重新挂接而丢失。
+	descendants, snapshotErr := descendantProcessIDs(c.pid)
+	handles, openErr := openProcessesForTermination(descendants)
+	defer closeProcessHandles(handles)
+
+	var terminateErr error
+	if err := windows.TerminateJobObject(c.job, 1); err != nil {
+		terminateErr = fmt.Errorf("terminate Windows Job Object: %w", err)
+	}
+	if err := terminateProcessHandles(handles); err != nil {
+		terminateErr = errors.Join(terminateErr, err)
+	}
+	c.terminateErr = errors.Join(snapshotErr, openErr, terminateErr)
+	return c.terminateErr
 }
 
 func (c *Controller) Close() error {
@@ -111,4 +132,105 @@ func (c *Controller) Close() error {
 		return fmt.Errorf("close Windows Job Object: %w", err)
 	}
 	return nil
+}
+
+type processHandle struct {
+	pid    uint32
+	handle windows.Handle
+}
+
+func descendantProcessIDs(root uint32) ([]uint32, error) {
+	if root == 0 {
+		return nil, nil
+	}
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot Windows process tree: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	children := make(map[uint32][]uint32)
+	entry := windows.ProcessEntry32{Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{}))}
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read Windows process snapshot: %w", err)
+	}
+	for {
+		children[entry.ParentProcessID] = append(children[entry.ParentProcessID], entry.ProcessID)
+		entry.Size = uint32(unsafe.Sizeof(windows.ProcessEntry32{}))
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, fmt.Errorf("read Windows process snapshot: %w", err)
+		}
+	}
+
+	// 后序遍历让更深的后代先终止；visited 同时防御异常父子环。
+	visited := map[uint32]bool{root: true}
+	result := make([]uint32, 0)
+	var visit func(uint32)
+	visit = func(parent uint32) {
+		for _, child := range children[parent] {
+			if child == 0 || visited[child] {
+				continue
+			}
+			visited[child] = true
+			visit(child)
+			result = append(result, child)
+		}
+	}
+	visit(root)
+	return result, nil
+}
+
+func openProcessesForTermination(pids []uint32) ([]processHandle, error) {
+	handles := make([]processHandle, 0, len(pids))
+	var result error
+	for _, pid := range pids {
+		handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE|windows.SYNCHRONIZE, false, pid)
+		if err != nil {
+			// 进程可能在快照和 OpenProcess 之间正常退出。
+			if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+				continue
+			}
+			result = errors.Join(result, fmt.Errorf("open descendant process %d: %w", pid, err))
+			continue
+		}
+		handles = append(handles, processHandle{pid: pid, handle: handle})
+	}
+	return handles, result
+}
+
+func terminateProcessHandles(processes []processHandle) error {
+	var result error
+	for _, process := range processes {
+		state, err := windows.WaitForSingleObject(process.handle, 0)
+		if err != nil {
+			result = errors.Join(result, fmt.Errorf("inspect descendant process %d: %w", process.pid, err))
+			continue
+		}
+		if state == windows.WAIT_OBJECT_0 {
+			continue
+		}
+		if err := windows.TerminateProcess(process.handle, 1); err != nil {
+			result = errors.Join(result, fmt.Errorf("terminate descendant process %d: %w", process.pid, err))
+			continue
+		}
+		state, err = windows.WaitForSingleObject(process.handle, 2000)
+		if err != nil {
+			result = errors.Join(result, fmt.Errorf("wait for descendant process %d: %w", process.pid, err))
+		} else if state != windows.WAIT_OBJECT_0 {
+			result = errors.Join(result, fmt.Errorf("descendant process %d did not stop", process.pid))
+		}
+	}
+	return result
+}
+
+func closeProcessHandles(processes []processHandle) {
+	for _, process := range processes {
+		_ = windows.CloseHandle(process.handle)
+	}
 }

--- a/internal/tool/command/command.go
+++ b/internal/tool/command/command.go
@@ -244,7 +244,15 @@ func (svc *Service) killSession(args map[string]any) (Result, error) {
 		return svc.consumeCompletedSession(s, commandOutputLimit(args)), nil
 	default:
 	}
-	s.Kill()
+	_, killErr := s.Kill()
+	if killErr != nil {
+		return nil, toolErrorDetails(
+			"SESSION_KILL_FAILED",
+			"failed to terminate the session process tree",
+			"runtime",
+			map[string]any{"session_id": s.ID, "reason": killErr.Error()},
+		)
+	}
 	if !waitForSessionCompletion(s, sessionKillWait) {
 		return nil, toolErrorDetails(
 			"SESSION_KILL_TIMEOUT",
@@ -266,6 +274,7 @@ func (svc *Service) KillAll(args map[string]any) (Result, error) {
 	sessions := svc.sessions.List()
 	running := make([]*session.Session, 0, len(sessions))
 	items := make([]map[string]any, 0, len(sessions))
+	killFailures := make([]map[string]any, 0)
 	for _, s := range sessions {
 		select {
 		case <-s.Done:
@@ -274,15 +283,30 @@ func (svc *Service) KillAll(args map[string]any) (Result, error) {
 			svc.sessions.Delete(s.ID)
 			items = append(items, map[string]any{"session_id": s.ID, "status": summary.Status})
 		default:
-			s.Kill()
+			_, killErr := s.Kill()
+			if killErr != nil {
+				killFailures = append(killFailures, map[string]any{"session_id": s.ID, "reason": killErr.Error()})
+			}
 			running = append(running, s)
 		}
 	}
-
 	completed, timedOut := waitForSessionsCompletion(running, sessionKillWait)
 	for _, s := range completed {
 		svc.sessions.Delete(s.ID)
 		items = append(items, map[string]any{"session_id": s.ID, "status": "killed"})
+	}
+	if len(killFailures) > 0 {
+		details := map[string]any{"sessions": killFailures}
+		if len(timedOut) > 0 {
+			details["timed_out_session_ids"] = timedOut
+			details["wait_ms"] = sessionKillWait.Milliseconds()
+		}
+		return nil, toolErrorDetails(
+			"SESSION_KILL_FAILED",
+			"failed to terminate one or more session process trees",
+			"runtime",
+			details,
+		)
 	}
 	if len(timedOut) > 0 {
 		return nil, toolErrorDetails(

--- a/internal/tool/command/session/session.go
+++ b/internal/tool/command/session/session.go
@@ -354,20 +354,20 @@ func (s *Session) WaitError() error {
 	return s.waitErr
 }
 
-func (s *Session) Kill() bool {
+func (s *Session) Kill() (bool, error) {
 	s.mu.Lock()
 	if s.completed {
 		s.mu.Unlock()
-		return false
+		return false, nil
 	}
 	runner := s.runner
 	s.mu.Unlock()
 	if runner == nil {
-		return false
+		return false, nil
 	}
-	_ = runner.Kill()
+	err := runner.Kill()
 	s.Cancel()
-	return true
+	return true, err
 }
 
 func (s *Session) Snapshot(status string, maxBytes int) map[string]any {

--- a/internal/tool/command/session/session_test.go
+++ b/internal/tool/command/session/session_test.go
@@ -19,7 +19,7 @@ func TestKillSkipsCompletedSession(t *testing.T) {
 		Cancel:    func() { canceled = true },
 		completed: true,
 	}
-	if killed := s.Kill(); killed {
+	if killed, err := s.Kill(); killed || err != nil {
 		t.Fatal("Kill() reported a signal for a completed session")
 	}
 	if canceled {

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -4,7 +4,12 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,4 +71,95 @@ func TestWindowsTTYUsesConPTYAndAcceptsInput(t *testing.T) {
 	if !strings.Contains(stdout, "received:hello") {
 		t.Fatalf("stdout = %q", stdout)
 	}
+}
+
+func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
+	nodePath, err := exec.LookPath("node.exe")
+	if err != nil {
+		t.Skip("node.exe is not installed")
+	}
+	root := t.TempDir()
+	port := reserveWindowsTestPort(t)
+	pidPath := filepath.Join(root, "node.pid")
+	nodeScript := fmt.Sprintf(
+		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		port,
+	)
+	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+
+	s, _, err := Start(context.Background(), command, root, os.Environ(), time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Cancel()
+	defer func() {
+		if s.Command != nil && s.Command.Process != nil {
+			_ = s.Command.Process.Kill()
+		}
+	}()
+	nodePID := waitForWindowsTestNode(t, pidPath, port)
+	defer func() {
+		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+			_ = process.Kill()
+		}
+	}()
+
+	killed, err := s.Kill()
+	if err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	if !killed {
+		t.Fatal("Kill() did not report a running session")
+	}
+	select {
+	case <-s.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not finish after killing its process tree")
+	}
+	if err := waitForWindowsTestPort(port, false, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reserveWindowsTestPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForWindowsTestNode(t *testing.T, pidPath string, port int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil && waitForWindowsTestPort(port, true, 100*time.Millisecond) == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("Node server did not start")
+	return 0
+}
+
+func waitForWindowsTestPort(port int, wantOpen bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 50*time.Millisecond)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		if (err == nil) == wantOpen {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("port %d open state did not become %t", port, wantOpen)
 }

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -82,9 +82,9 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 	port := reserveWindowsTestPort(t)
 	pidPath := filepath.Join(root, "node.pid")
 	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); fs.writeFileSync('%s',String(process.pid)); require('http').createServer((req,res)=>res.end('ok')).listen(%d,'127.0.0.1')",
-		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(%d,'127.0.0.1',()=>fs.writeFileSync('%s',String(process.pid)))",
 		port,
+		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
 	)
 	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
 
@@ -98,7 +98,7 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 			_ = s.Command.Process.Kill()
 		}
 	}()
-	nodePID := waitForWindowsTestNode(t, pidPath, port)
+	nodePID := waitForWindowsTestNode(t, s, pidPath, port)
 	defer func() {
 		if process, findErr := os.FindProcess(nodePID); findErr == nil {
 			_ = process.Kill()
@@ -132,9 +132,9 @@ func reserveWindowsTestPort(t *testing.T) int {
 	return listener.Addr().(*net.TCPAddr).Port
 }
 
-func waitForWindowsTestNode(t *testing.T, pidPath string, port int) int {
+func waitForWindowsTestNode(t *testing.T, s *Session, pidPath string, port int) int {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(pidPath)
 		if err == nil && waitForWindowsTestPort(port, true, 100*time.Millisecond) == nil {
@@ -145,7 +145,8 @@ func waitForWindowsTestNode(t *testing.T, pidPath string, port int) int {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	t.Fatal("Node server did not start")
+	status := s.Peek("running", 4096)
+	t.Fatalf("Node server did not start: stdout=%q stderr=%q", status["stdout"], status["stderr"])
 	return 0
 }
 


### PR DESCRIPTION
Closes #33
Supersedes #34 after CI validation; this branch preserves the original #34 commit by @pmwl and adds the maintainer-side CI fix.

## 原问题

Windows 下 PowerShell/launcher 的 native child 可能逃逸 AgentDock Job Object，导致 `session_act(kill)` 返回后仍遗留子进程和监听端口。

## 本分支额外修复

- 更新到最新 `main`，包含 macOS selfupdate CI 修复；
- 修复 `TerminateJobObject` 与后续 `TerminateProcess` 的竞态：不按 `ERROR_ACCESS_DENIED` 错误码直接吞错，而是用预先打开的同一 process handle 确认进程是否最终退出；
- 如果进程仍存活且无法终止，继续返回真实 kill 错误；
- Windows Node 回归测试改为监听成功后再写 PID，启动等待扩展到 10 秒；
- 启动失败时输出 session stdout/stderr 或 status，便于 CI 诊断。

## 本地验证

- `gofmt` / `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./...`
- Windows 交叉编译：`internal/process`、`internal/tool/command/session`、`internal/app` 测试包

最终以 GitHub Actions `windows-latest` 原生运行结果作为合并门禁。