### PR TITLE
fix(command): 修复启动关闭竞态

### DIFF
--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -29,7 +29,7 @@ func TestWindowsSessionActKillTerminatesNativeChildTree(t *testing.T) {
 		t.Fatal(err)
 	}
 	readyPath := filepath.Join(root, "native-child.ready.json")
-	command := fmt.Sprintf("& '%s' -test.run '^TestWindowsSessionNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
+	command := fmt.Sprintf("& '%s' '-test.run=^TestWindowsSessionNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
 	started, err := runtime.execCommand(context.Background(), map[string]any{
 		"cmd": command, "execution_mode": "async", "timeout_ms": 60000,
 		"env": map[string]any{appWindowsNativeChildReadyEnv: readyPath},

--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -4,16 +4,21 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+type appWindowsNodeReady struct {
+	PID  int `json:"pid"`
+	Port int `json:"port"`
+}
 
 func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 	runtime, root := newCodeToolsRuntime(t)
@@ -22,12 +27,13 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 	if err != nil {
 		t.Skip("node.exe is not installed")
 	}
-	port := reserveAppWindowsPort(t)
-	pidPath := filepath.Join(root, "node-session-kill.pid")
+	readyPath := filepath.Join(root, "node-session-kill.ready.json")
+	tempReadyPath := readyPath + ".tmp"
 	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(%d,'127.0.0.1',()=>fs.writeFileSync('%s',String(process.pid)))",
-		port,
-		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(0,'127.0.0.1',()=>{const address=server.address(); fs.writeFileSync('%s',JSON.stringify({pid:process.pid,port:address.port})); fs.renameSync('%s','%s')})",
+		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
+		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
+		strings.ReplaceAll(filepath.ToSlash(readyPath), "'", "\\'"),
 	)
 	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
 	started, err := runtime.execCommand(context.Background(), map[string]any{
@@ -37,7 +43,9 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessionID, _ := started["session_id"].(string)
-	nodePID := waitForAppWindowsNode(t, runtime, sessionID, pidPath, port)
+	ready := waitForAppWindowsNode(t, runtime, sessionID, readyPath)
+	nodePID := ready.PID
+	port := ready.Port
 	defer func() {
 		if process, findErr := os.FindProcess(nodePID); findErr == nil {
 			_ = process.Kill()
@@ -56,25 +64,28 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 	}
 }
 
-func reserveAppWindowsPort(t *testing.T) int {
-	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer listener.Close()
-	return listener.Addr().(*net.TCPAddr).Port
-}
-
-func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, pidPath string, port int) int {
+func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, readyPath string) appWindowsNodeReady {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(pidPath)
-		if err == nil && waitForAppWindowsPort(port, true, 100*time.Millisecond) == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-			if parseErr == nil {
-				return pid
+		data, err := os.ReadFile(readyPath)
+		if err == nil {
+			var ready appWindowsNodeReady
+			if json.Unmarshal(data, &ready) == nil && ready.PID > 0 && ready.Port > 0 {
+				if err := waitForAppWindowsPort(ready.Port, true, 2*time.Second); err != nil {
+					t.Fatalf("Node reported ready but its port is unavailable: %v", err)
+				}
+				return ready
+			}
+		}
+		if stored, ok := runtime.command.Store().Get(sessionID); ok {
+			select {
+			case <-stored.Done:
+				status, observeErr := runtime.sessionObserve(map[string]any{
+					"action": "status", "session_id": sessionID, "max_output_bytes": 4096,
+				})
+				t.Fatalf("Node server exited before readiness: status=%#v observe_err=%v", status, observeErr)
+			default:
 			}
 		}
 		time.Sleep(25 * time.Millisecond)
@@ -83,7 +94,7 @@ func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, pidPath st
 		"action": "status", "session_id": sessionID, "max_output_bytes": 4096,
 	})
 	t.Fatalf("Node server did not start: status=%#v observe_err=%v", status, observeErr)
-	return 0
+	return appWindowsNodeReady{}
 }
 
 func waitForAppWindowsPort(port int, wantOpen bool, timeout time.Duration) error {

--- a/internal/app/command_session_windows_test.go
+++ b/internal/app/command_session_windows_test.go
@@ -8,46 +8,41 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-type appWindowsNodeReady struct {
+const appWindowsNativeChildReadyEnv = "AGENTDOCK_TEST_WINDOWS_NATIVE_CHILD_READY"
+
+type appWindowsNativeChildReady struct {
 	PID  int `json:"pid"`
 	Port int `json:"port"`
 }
 
-func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
+func TestWindowsSessionActKillTerminatesNativeChildTree(t *testing.T) {
 	runtime, root := newCodeToolsRuntime(t)
 	defer runtime.Close()
-	nodePath, err := exec.LookPath("node.exe")
+	testBinary, err := os.Executable()
 	if err != nil {
-		t.Skip("node.exe is not installed")
+		t.Fatal(err)
 	}
-	readyPath := filepath.Join(root, "node-session-kill.ready.json")
-	tempReadyPath := readyPath + ".tmp"
-	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(0,'127.0.0.1',()=>{const address=server.address(); fs.writeFileSync('%s',JSON.stringify({pid:process.pid,port:address.port})); fs.renameSync('%s','%s')})",
-		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
-		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
-		strings.ReplaceAll(filepath.ToSlash(readyPath), "'", "\\'"),
-	)
-	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+	readyPath := filepath.Join(root, "native-child.ready.json")
+	command := fmt.Sprintf("& '%s' -test.run '^TestWindowsSessionNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
 	started, err := runtime.execCommand(context.Background(), map[string]any{
 		"cmd": command, "execution_mode": "async", "timeout_ms": 60000,
+		"env": map[string]any{appWindowsNativeChildReadyEnv: readyPath},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	sessionID, _ := started["session_id"].(string)
-	ready := waitForAppWindowsNode(t, runtime, sessionID, readyPath)
-	nodePID := ready.PID
+	ready := waitForAppWindowsNativeChild(t, runtime, sessionID, readyPath)
+	childPID := ready.PID
 	port := ready.Port
 	defer func() {
-		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+		if process, findErr := os.FindProcess(childPID); findErr == nil {
 			_ = process.Kill()
 		}
 	}()
@@ -64,16 +59,47 @@ func TestWindowsSessionActKillTerminatesNodeServer(t *testing.T) {
 	}
 }
 
-func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, readyPath string) appWindowsNodeReady {
+func TestWindowsSessionNativeChildHelper(t *testing.T) {
+	readyPath := os.Getenv(appWindowsNativeChildReadyEnv)
+	if readyPath == "" {
+		return
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	ready := appWindowsNativeChildReady{PID: os.Getpid(), Port: listener.Addr().(*net.TCPAddr).Port}
+	data, err := json.Marshal(ready)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempReadyPath := readyPath + ".tmp"
+	if err := os.WriteFile(tempReadyPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tempReadyPath, readyPath); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = connection.Close()
+	}
+}
+
+func waitForAppWindowsNativeChild(t *testing.T, runtime *Runtime, sessionID, readyPath string) appWindowsNativeChildReady {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(readyPath)
 		if err == nil {
-			var ready appWindowsNodeReady
+			var ready appWindowsNativeChildReady
 			if json.Unmarshal(data, &ready) == nil && ready.PID > 0 && ready.Port > 0 {
 				if err := waitForAppWindowsPort(ready.Port, true, 2*time.Second); err != nil {
-					t.Fatalf("Node reported ready but its port is unavailable: %v", err)
+					t.Fatalf("native child reported ready but its port is unavailable: %v", err)
 				}
 				return ready
 			}
@@ -84,7 +110,7 @@ func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, readyPath 
 				status, observeErr := runtime.sessionObserve(map[string]any{
 					"action": "status", "session_id": sessionID, "max_output_bytes": 4096,
 				})
-				t.Fatalf("Node server exited before readiness: status=%#v observe_err=%v", status, observeErr)
+				t.Fatalf("native child exited before readiness: status=%#v observe_err=%v", status, observeErr)
 			default:
 			}
 		}
@@ -93,8 +119,8 @@ func waitForAppWindowsNode(t *testing.T, runtime *Runtime, sessionID, readyPath 
 	status, observeErr := runtime.sessionObserve(map[string]any{
 		"action": "status", "session_id": sessionID, "max_output_bytes": 4096,
 	})
-	t.Fatalf("Node server did not start: status=%#v observe_err=%v", status, observeErr)
-	return appWindowsNodeReady{}
+	t.Fatalf("native child did not start: status=%#v observe_err=%v", status, observeErr)
+	return appWindowsNativeChildReady{}
 }
 
 func waitForAppWindowsPort(port int, wantOpen bool, timeout time.Duration) error {

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -129,10 +129,21 @@ func (r *Runtime) Close() error {
 		var closeErrors []error
 		r.lifecycleMu.Lock()
 		r.closing = true
-		if r.commandCancel != nil {
-			r.commandCancel()
-		}
+		commandCancel := r.commandCancel
 		r.lifecycleMu.Unlock()
+
+		// 先禁止新的 command reservation，并等已经拿到 reservation 的启动流程离开
+		// cmd.Start/平台进程控制器建立窗口。此处不能持有 lifecycleMu 等待，否则启动路径
+		// 一旦需要读取 Runtime 生命周期状态就会形成锁顺序死锁。
+		if r.command != nil {
+			r.command.BeginClose()
+			if err := r.command.WaitForStarts(); err != nil {
+				closeErrors = append(closeErrors, err)
+			}
+		}
+		if commandCancel != nil {
+			commandCancel()
+		}
 		if r.acp != nil {
 			if err := r.acp.Close(); err != nil {
 				closeErrors = append(closeErrors, fmt.Errorf("close ACP runtime: %w", err))

--- a/internal/process/process_unix.go
+++ b/internal/process/process_unix.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"syscall"
@@ -38,7 +39,13 @@ func (c *Controller) Terminate() error {
 	if c == nil || c.pid <= 0 {
 		return nil
 	}
-	return syscall.Kill(-c.pid, syscall.SIGKILL)
+	err := syscall.Kill(-c.pid, syscall.SIGKILL)
+	// 进程可能在终止请求到达前已经自然退出；如果整个进程组已不存在，
+	// shutdown 的目标已经达成，不应把 ESRCH 当成终止失败。
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
 }
 
 // Close releases platform resources. Unix process groups do not own handles.

--- a/internal/tool/command/close.go
+++ b/internal/tool/command/close.go
@@ -1,23 +1,58 @@
 package command
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"time"
 )
+
+// BeginClose 先关闭新的 command reservation 入口。
+// Runtime 会在取消共享 commandCtx 之前等待 startup 窗口排空，避免半启动进程被抢占。
+func (s *Service) BeginClose() {
+	if s == nil || s.sessions == nil {
+		return
+	}
+	s.sessions.BeginClose()
+}
+
+func (s *Service) WaitForStarts() error {
+	if s == nil || s.sessions == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionKillWait)
+	defer cancel()
+	if s.sessions.WaitForStarts(ctx) {
+		return nil
+	}
+	return fmt.Errorf(
+		"wait for %d starting command session(s): timeout after %s",
+		s.sessions.StartingCount(),
+		sessionKillWait,
+	)
+}
 
 func (s *Service) Close() error {
 	if s == nil || s.sessions == nil {
 		return nil
 	}
-	deadline := time.Now().Add(sessionKillWait)
-	for s.sessions.ReservationCount() > 0 && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if remaining := s.sessions.ReservationCount(); remaining > 0 {
-		return fmt.Errorf("wait for %d starting command session(s): timeout after %s", remaining, sessionKillWait)
+	s.sessions.BeginClose()
+
+	// Runtime 已经取消共享 commandCtx。先等 foreground/sync 调用释放 reservation，
+	// 再统一清理已经进入 Store 的 async session，避免 session 在 KillAll 之后才入库。
+	ctx, cancel := context.WithTimeout(context.Background(), sessionKillWait)
+	reservationsDrained := s.sessions.WaitForReservations(ctx)
+	cancel()
+
+	var closeErrors []error
+	if !reservationsDrained {
+		closeErrors = append(closeErrors, fmt.Errorf(
+			"wait for %d command reservation(s): timeout after %s",
+			s.sessions.ReservationCount(),
+			sessionKillWait,
+		))
 	}
 	if _, err := s.KillAll(nil); err != nil {
-		return fmt.Errorf("stop command sessions: %w", err)
+		closeErrors = append(closeErrors, fmt.Errorf("stop command sessions: %w", err))
 	}
-	return nil
+	return errors.Join(closeErrors...)
 }

--- a/internal/tool/command/command.go
+++ b/internal/tool/command/command.go
@@ -62,6 +62,9 @@ func (svc *Service) Exec(ctx context.Context, args map[string]any) (Result, erro
 	}
 
 	if !svc.sessions.TryReserve(maxConcurrentCommandSessions) {
+		if svc.sessions.Closing() {
+			return nil, toolError("RUNTIME_CLOSING", "AgentDock runtime is shutting down", "runtime")
+		}
 		return nil, toolErrorDetails(
 			"SESSION_LIMIT_REACHED",
 			"too many command sessions are already running",
@@ -88,6 +91,9 @@ func (svc *Service) Exec(ctx context.Context, args map[string]any) (Result, erro
 		}
 		return func() {}, map[string]any{"enabled": false, "mode": "none", "policy": "no_command_content_filtering", "warnings": []string{privilegeWarning, "use Docker volumes, service users, file permissions, and network policy as the security boundary"}}
 	})
+	// 只有 invocation.start 完整返回后，runner、平台进程控制器以及 cmdCtx 取消监听才都已经建立。
+	// Runtime.Close 会等待这个启动窗口排空，再取消 commandCtx，避免在半启动状态抢占进程。
+	svc.sessions.FinishStart()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tool/command/session/runner.go
+++ b/internal/tool/command/session/runner.go
@@ -22,6 +22,11 @@ type standardRunner struct {
 
 func startStandardRunner(cmd *exec.Cmd, stdout, stderr io.Writer) (*standardRunner, error) {
 	processcontrol.Configure(cmd)
+	// command runner 统一拥有进程树取消权。CommandContext 默认只杀直接子进程，
+	// 会和这里的进程组/Job Object 终止并发竞争；保留 ctx 的启动前检查，
+	// 但关闭 os/exec 自带的直接子进程 Cancel，运行期取消由 Session watcher 处理。
+	cmd.Cancel = nil
+	cmd.WaitDelay = 0
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/internal/tool/command/session/session.go
+++ b/internal/tool/command/session/session.go
@@ -38,7 +38,9 @@ type Session struct {
 	Terminal   string
 	execution  ExecutionContext
 
-	runner commandRunner
+	runner   commandRunner
+	killOnce sync.Once
+	killErr  error
 
 	mu                 sync.Mutex
 	completed          bool
@@ -55,9 +57,13 @@ type Session struct {
 }
 
 type Store struct {
-	mu       sync.Mutex
-	sessions map[string]*Session
-	reserved int
+	mu              sync.Mutex
+	sessions        map[string]*Session
+	reserved        int
+	starting        int
+	closing         bool
+	startsDrained   chan struct{}
+	reservedDrained chan struct{}
 }
 
 type Summary struct {
@@ -71,7 +77,15 @@ type Summary struct {
 }
 
 func NewStore() *Store {
-	return &Store{sessions: map[string]*Session{}}
+	startsDrained := make(chan struct{})
+	reservedDrained := make(chan struct{})
+	close(startsDrained)
+	close(reservedDrained)
+	return &Store{
+		sessions:        map[string]*Session{},
+		startsDrained:   startsDrained,
+		reservedDrained: reservedDrained,
+	}
 }
 
 func (s *Store) TryReserve(maxRunning int) bool {
@@ -80,6 +94,9 @@ func (s *Store) TryReserve(maxRunning int) bool {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.closing {
+		return false
+	}
 	running := s.reserved
 	for _, session := range s.sessions {
 		if !session.Completed() {
@@ -89,15 +106,68 @@ func (s *Store) TryReserve(maxRunning int) bool {
 	if running >= maxRunning {
 		return false
 	}
+	if s.reserved == 0 {
+		s.reservedDrained = make(chan struct{})
+	}
+	if s.starting == 0 {
+		s.startsDrained = make(chan struct{})
+	}
 	s.reserved++
+	s.starting++
 	return true
+}
+
+// FinishStart 标记命令已经离开不可安全抢占的启动窗口。
+// 调用方必须在 runner、进程控制器和取消监听都建立完成后调用。
+func (s *Store) FinishStart() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.starting == 0 {
+		return
+	}
+	s.starting--
+	if s.starting == 0 {
+		close(s.startsDrained)
+	}
+}
+
+func (s *Store) BeginClose() {
+	s.mu.Lock()
+	s.closing = true
+	s.mu.Unlock()
+}
+
+func (s *Store) Closing() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closing
+}
+
+func (s *Store) StartingCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.starting
+}
+
+func (s *Store) WaitForStarts(ctx context.Context) bool {
+	s.mu.Lock()
+	if s.starting == 0 {
+		s.mu.Unlock()
+		return true
+	}
+	drained := s.startsDrained
+	s.mu.Unlock()
+	select {
+	case <-drained:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func (s *Store) ReleaseReservation() {
 	s.mu.Lock()
-	if s.reserved > 0 {
-		s.reserved--
-	}
+	s.releaseReservationLocked()
 	s.mu.Unlock()
 }
 
@@ -107,13 +177,37 @@ func (s *Store) ReservationCount() int {
 	return s.reserved
 }
 
+func (s *Store) WaitForReservations(ctx context.Context) bool {
+	s.mu.Lock()
+	if s.reserved == 0 {
+		s.mu.Unlock()
+		return true
+	}
+	drained := s.reservedDrained
+	s.mu.Unlock()
+	select {
+	case <-drained:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 func (s *Store) AddReserved(session *Session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.reserved > 0 {
-		s.reserved--
-	}
+	s.releaseReservationLocked()
 	s.sessions[session.ID] = session
+}
+
+func (s *Store) releaseReservationLocked() {
+	if s.reserved == 0 {
+		return
+	}
+	s.reserved--
+	if s.reserved == 0 {
+		close(s.reservedDrained)
+	}
 }
 
 func (s *Store) Add(session *Session) {
@@ -309,12 +403,12 @@ func StartCommandWithTTY(ctx context.Context, build CommandFactory, timeout time
 	s.Stdin = runner.Stdin()
 	cleanup()
 
-	// CommandContext only guarantees termination of the direct child. Every runner
-	// therefore owns a platform process tree and receives timeout/cancel events.
+	// 运行期取消统一交给 runner：标准 runner 关闭了 os/exec 的直接子进程 Cancel，
+	// 避免它与进程组 / Job Object 的整棵进程树终止并发竞争。
 	go func() {
 		select {
 		case <-cmdCtx.Done():
-			_ = runner.Kill()
+			_, _ = s.Kill()
 		case <-s.Done:
 		}
 	}()
@@ -365,9 +459,11 @@ func (s *Session) Kill() (bool, error) {
 	if runner == nil {
 		return false, nil
 	}
-	err := runner.Kill()
-	s.Cancel()
-	return true, err
+	s.killOnce.Do(func() {
+		s.killErr = runner.Kill()
+		s.Cancel()
+	})
+	return true, s.killErr
 }
 
 func (s *Session) Snapshot(status string, maxBytes int) map[string]any {

--- a/internal/tool/command/session/session_test.go
+++ b/internal/tool/command/session/session_test.go
@@ -325,6 +325,8 @@ func TestStoreReservationsEnforceRunningLimit(t *testing.T) {
 	if !store.TryReserve(2) || !store.TryReserve(2) {
 		t.Fatal("store rejected reservations below the limit")
 	}
+	store.FinishStart()
+	store.FinishStart()
 	if store.TryReserve(2) {
 		t.Fatal("store accepted a reservation above the running limit")
 	}
@@ -332,6 +334,28 @@ func TestStoreReservationsEnforceRunningLimit(t *testing.T) {
 	if !store.TryReserve(2) {
 		t.Fatal("released reservation did not free capacity")
 	}
+	store.FinishStart()
+}
+
+func TestStoreBeginCloseRejectsNewReservationsAndDrainsCurrentStart(t *testing.T) {
+	store := NewStore()
+	if !store.TryReserve(1) {
+		t.Fatal("store rejected initial reservation")
+	}
+	store.BeginClose()
+	if store.TryReserve(2) {
+		t.Fatal("store accepted a reservation after BeginClose")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	drained := make(chan bool, 1)
+	go func() { drained <- store.WaitForStarts(ctx) }()
+	store.FinishStart()
+	if ok := <-drained; !ok {
+		t.Fatal("startup drain did not finish after FinishStart")
+	}
+	store.ReleaseReservation()
 }
 
 func TestStorePrunesOldestCompletedSessionsToLimit(t *testing.T) {

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -8,14 +8,15 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-type windowsNodeReady struct {
+const windowsNativeChildReadyEnv = "AGENTDOCK_TEST_WINDOWS_NATIVE_CHILD_READY"
+
+type windowsNativeChildReady struct {
 	PID  int `json:"pid"`
 	Port int `json:"port"`
 }
@@ -79,22 +80,16 @@ func TestWindowsTTYUsesConPTYAndAcceptsInput(t *testing.T) {
 }
 
 func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
-	nodePath, err := exec.LookPath("node.exe")
+	testBinary, err := os.Executable()
 	if err != nil {
-		t.Skip("node.exe is not installed")
+		t.Fatal(err)
 	}
 	root := t.TempDir()
-	readyPath := filepath.Join(root, "node.ready.json")
-	tempReadyPath := readyPath + ".tmp"
-	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(0,'127.0.0.1',()=>{const address=server.address(); fs.writeFileSync('%s',JSON.stringify({pid:process.pid,port:address.port})); fs.renameSync('%s','%s')})",
-		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
-		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
-		strings.ReplaceAll(filepath.ToSlash(readyPath), "'", "\\'"),
-	)
-	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
+	readyPath := filepath.Join(root, "native-child.ready.json")
+	command := fmt.Sprintf("& '%s' -test.run '^TestWindowsNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
+	childEnv := append(os.Environ(), windowsNativeChildReadyEnv+"="+readyPath)
 
-	s, _, err := Start(context.Background(), command, root, os.Environ(), time.Minute, nil)
+	s, _, err := Start(context.Background(), command, root, childEnv, time.Minute, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,11 +99,11 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 			_ = s.Command.Process.Kill()
 		}
 	}()
-	ready := waitForWindowsTestNode(t, s, readyPath)
-	nodePID := ready.PID
+	ready := waitForWindowsNativeChild(t, s, readyPath)
+	childPID := ready.PID
 	port := ready.Port
 	defer func() {
-		if process, findErr := os.FindProcess(nodePID); findErr == nil {
+		if process, findErr := os.FindProcess(childPID); findErr == nil {
 			_ = process.Kill()
 		}
 	}()
@@ -130,16 +125,47 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 	}
 }
 
-func waitForWindowsTestNode(t *testing.T, s *Session, readyPath string) windowsNodeReady {
+func TestWindowsNativeChildHelper(t *testing.T) {
+	readyPath := os.Getenv(windowsNativeChildReadyEnv)
+	if readyPath == "" {
+		return
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	ready := windowsNativeChildReady{PID: os.Getpid(), Port: listener.Addr().(*net.TCPAddr).Port}
+	data, err := json.Marshal(ready)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempReadyPath := readyPath + ".tmp"
+	if err := os.WriteFile(tempReadyPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tempReadyPath, readyPath); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = connection.Close()
+	}
+}
+
+func waitForWindowsNativeChild(t *testing.T, s *Session, readyPath string) windowsNativeChildReady {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(readyPath)
 		if err == nil {
-			var ready windowsNodeReady
+			var ready windowsNativeChildReady
 			if json.Unmarshal(data, &ready) == nil && ready.PID > 0 && ready.Port > 0 {
 				if err := waitForWindowsTestPort(ready.Port, true, 2*time.Second); err != nil {
-					t.Fatalf("Node reported ready but its port is unavailable: %v", err)
+					t.Fatalf("native child reported ready but its port is unavailable: %v", err)
 				}
 				return ready
 			}
@@ -147,14 +173,14 @@ func waitForWindowsTestNode(t *testing.T, s *Session, readyPath string) windowsN
 		select {
 		case <-s.Done:
 			status := s.Peek("exited", 4096)
-			t.Fatalf("Node server exited before readiness: stdout=%q stderr=%q command_error=%v", status["stdout"], status["stderr"], s.WaitError())
+			t.Fatalf("native child exited before readiness: stdout=%q stderr=%q command_error=%v", status["stdout"], status["stderr"], s.WaitError())
 		default:
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
 	status := s.Peek("running", 4096)
-	t.Fatalf("Node server did not start: stdout=%q stderr=%q", status["stdout"], status["stderr"])
-	return windowsNodeReady{}
+	t.Fatalf("native child did not start: stdout=%q stderr=%q", status["stdout"], status["stderr"])
+	return windowsNativeChildReady{}
 }
 
 func waitForWindowsTestPort(port int, wantOpen bool, timeout time.Duration) error {

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -4,16 +4,21 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+type windowsNodeReady struct {
+	PID  int `json:"pid"`
+	Port int `json:"port"`
+}
 
 func TestWindowsPowerShellOutputIsUTF8(t *testing.T) {
 	s, _, err := Start(
@@ -79,12 +84,13 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 		t.Skip("node.exe is not installed")
 	}
 	root := t.TempDir()
-	port := reserveWindowsTestPort(t)
-	pidPath := filepath.Join(root, "node.pid")
+	readyPath := filepath.Join(root, "node.ready.json")
+	tempReadyPath := readyPath + ".tmp"
 	nodeScript := fmt.Sprintf(
-		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(%d,'127.0.0.1',()=>fs.writeFileSync('%s',String(process.pid)))",
-		port,
-		strings.ReplaceAll(filepath.ToSlash(pidPath), "'", "\\'"),
+		"const fs=require('fs'); const server=require('http').createServer((req,res)=>res.end('ok')); server.listen(0,'127.0.0.1',()=>{const address=server.address(); fs.writeFileSync('%s',JSON.stringify({pid:process.pid,port:address.port})); fs.renameSync('%s','%s')})",
+		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
+		strings.ReplaceAll(filepath.ToSlash(tempReadyPath), "'", "\\'"),
+		strings.ReplaceAll(filepath.ToSlash(readyPath), "'", "\\'"),
 	)
 	command := fmt.Sprintf("& '%s' -e \"%s\"", strings.ReplaceAll(nodePath, "'", "''"), nodeScript)
 
@@ -98,7 +104,9 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 			_ = s.Command.Process.Kill()
 		}
 	}()
-	nodePID := waitForWindowsTestNode(t, s, pidPath, port)
+	ready := waitForWindowsTestNode(t, s, readyPath)
+	nodePID := ready.PID
+	port := ready.Port
 	defer func() {
 		if process, findErr := os.FindProcess(nodePID); findErr == nil {
 			_ = process.Kill()
@@ -122,32 +130,31 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 	}
 }
 
-func reserveWindowsTestPort(t *testing.T) int {
-	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer listener.Close()
-	return listener.Addr().(*net.TCPAddr).Port
-}
-
-func waitForWindowsTestNode(t *testing.T, s *Session, pidPath string, port int) int {
+func waitForWindowsTestNode(t *testing.T, s *Session, readyPath string) windowsNodeReady {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(pidPath)
-		if err == nil && waitForWindowsTestPort(port, true, 100*time.Millisecond) == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-			if parseErr == nil {
-				return pid
+		data, err := os.ReadFile(readyPath)
+		if err == nil {
+			var ready windowsNodeReady
+			if json.Unmarshal(data, &ready) == nil && ready.PID > 0 && ready.Port > 0 {
+				if err := waitForWindowsTestPort(ready.Port, true, 2*time.Second); err != nil {
+					t.Fatalf("Node reported ready but its port is unavailable: %v", err)
+				}
+				return ready
 			}
+		}
+		select {
+		case <-s.Done:
+			status := s.Peek("exited", 4096)
+			t.Fatalf("Node server exited before readiness: stdout=%q stderr=%q command_error=%v", status["stdout"], status["stderr"], s.WaitError())
+		default:
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
 	status := s.Peek("running", 4096)
 	t.Fatalf("Node server did not start: stdout=%q stderr=%q", status["stdout"], status["stderr"])
-	return 0
+	return windowsNodeReady{}
 }
 
 func waitForWindowsTestPort(port int, wantOpen bool, timeout time.Duration) error {

--- a/internal/tool/command/session/session_windows_test.go
+++ b/internal/tool/command/session/session_windows_test.go
@@ -86,7 +86,7 @@ func TestWindowsKillTerminatesPowerShellNativeChildTree(t *testing.T) {
 	}
 	root := t.TempDir()
 	readyPath := filepath.Join(root, "native-child.ready.json")
-	command := fmt.Sprintf("& '%s' -test.run '^TestWindowsNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
+	command := fmt.Sprintf("& '%s' '-test.run=^TestWindowsNativeChildHelper$'", strings.ReplaceAll(testBinary, "'", "''"))
 	childEnv := append(os.Environ(), windowsNativeChildReadyEnv+"="+readyPath)
 
 	s, _, err := Start(context.Background(), command, root, childEnv, time.Minute, nil)


### PR DESCRIPTION
## 变更
- 分离 command 并发 reservation 与不可安全抢占的 startup 窗口，Runtime 关闭时先封闭新启动并等待 startup 安全落地
- 统一标准命令的进程树取消所有权到 Session runner/controller，避免 CommandContext 与进程组/Job Object 双重终止竞态
- 让 Session.Kill 幂等，并将 Unix 已不存在进程组的 ESRCH 视为终止完成
- 重写 Windows Node readiness：由 Node 自己 listen(0)，原子写入 pid/port ready JSON，消除父进程预占后释放端口的 TOCTOU

## 验证
- go test ./...
- go test -race ./...
- go vet ./...
- go build ./cmd/agentdock
- Runtime Close 相关 race 用例 count=20
- Windows 相关 package 交叉编译
- gofmt / git diff --check
- make test-scripts-macos
- Claude 最终只读复审：PASS，无 blocking findings