### PR TITLE
fix(nexus): 收敛 Artifact Bridge 契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ AgentDock can optionally pair with NexusDock as a multi-device aggregation entry
 - Workflow templates
 - Private notes
 - Multi-device state coordination
+- Temporary signed Artifact downloads proxied by NexusDock while the source node is online
 
 ## Runtime directories
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/rogpeppe/go-internal v1.15.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
-	github.com/uvwt/agentdock-protocol v0.3.0
+	github.com/uvwt/agentdock-protocol v0.4.0
 	golang.org/x/sys v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/tidwall/rtree v0.0.0-20180113144539-6cd427091e0e h1:+NL1GDIUOKxVfbp2K
 github.com/tidwall/rtree v0.0.0-20180113144539-6cd427091e0e/go.mod h1:/h+UnNGt0IhNNJLkGikcdcJqm66zGD/uJGMRxK/9+Ao=
 github.com/tidwall/tinyqueue v0.0.0-20180302190814-1e39f5511563 h1:Otn9S136ELckZ3KKDyCkxapfufrqDqwmGjcHfAyXRrE=
 github.com/tidwall/tinyqueue v0.0.0-20180302190814-1e39f5511563/go.mod h1:mLqSmt7Dv/CNneF2wfcChfN1rvapyQr01LGKnKex0DQ=
-github.com/uvwt/agentdock-protocol v0.3.0 h1:BZtGLaJ8dGE8LQ6vuP+WUse9FlmHCUNmONmr4Yy7lXw=
-github.com/uvwt/agentdock-protocol v0.3.0/go.mod h1:yoFrGa/mNuAr3b8fupHCFT0b1Kf4Ni/00T4KnwuiFRk=
+github.com/uvwt/agentdock-protocol v0.4.0 h1:cUbgtBTeFn1RXC1V0yA0pJiSRhKD/3ewC3zTJTVtUdg=
+github.com/uvwt/agentdock-protocol v0.4.0/go.mod h1:yoFrGa/mNuAr3b8fupHCFT0b1Kf4Ni/00T4KnwuiFRk=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/uvwt/agentdock/internal/app"
 	"github.com/uvwt/agentdock/internal/buildinfo"
 	"github.com/uvwt/agentdock/internal/config"
+	"github.com/uvwt/agentdock/internal/publicartifacts"
 )
 
 type Server struct {
@@ -95,6 +97,35 @@ func (s *Server) Invoke(ctx context.Context, name string, arguments map[string]a
 	}
 	result, err := s.runtime.Call(ctx, name, arguments)
 	return toolEnvelope(name, result, err), nil
+}
+
+// ReadArtifactChunk serves the private Bridge operation used by NexusDock's
+// signed download proxy. It is not exposed as an MCP tool.
+func (s *Server) ReadArtifactChunk(artifactID string, offset int64, maxBytes int) (map[string]any, error) {
+	if s == nil {
+		return nil, errors.New("AgentDock MCP server is not initialized")
+	}
+	store := publicartifacts.New(s.cfg.AgentDockHome, s.cfg.OAuthServerURL, s.cfg.Port)
+	meta, data, eof, err := store.ReadChunk(artifactID, offset, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"artifact_id": meta.ArtifactID,
+		"filename":    meta.Filename,
+		"mime_type":   meta.MimeType,
+		"size_bytes":  meta.Size,
+		"sha256":      meta.SHA256,
+		"created_at":  meta.CreatedAt,
+		"expires_at":  meta.ExpiresAt,
+		"archive":     meta.Archive,
+		"width":       meta.Width,
+		"height":      meta.Height,
+		"offset":      offset,
+		"next_offset": offset + int64(len(data)),
+		"data_base64": base64.StdEncoding.EncodeToString(data),
+		"eof":         eof,
+	}, nil
 }
 
 func (s *Server) HTTPHandler() http.Handler {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -110,22 +110,48 @@ func (s *Server) ReadArtifactChunk(artifactID string, offset int64, maxBytes int
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{
-		"artifact_id": meta.ArtifactID,
-		"filename":    meta.Filename,
-		"mime_type":   meta.MimeType,
-		"size_bytes":  meta.Size,
-		"sha256":      meta.SHA256,
-		"created_at":  meta.CreatedAt,
-		"expires_at":  meta.ExpiresAt,
-		"archive":     meta.Archive,
-		"width":       meta.Width,
-		"height":      meta.Height,
-		"offset":      offset,
-		"next_offset": offset + int64(len(data)),
-		"data_base64": base64.StdEncoding.EncodeToString(data),
-		"eof":         eof,
-	}, nil
+	result := artifactChunkResult{
+		ArtifactID: meta.ArtifactID,
+		Filename:   meta.Filename,
+		MIMEType:   meta.MimeType,
+		Size:       meta.Size,
+		SHA256:     meta.SHA256,
+		CreatedAt:  meta.CreatedAt,
+		ExpiresAt:  meta.ExpiresAt,
+		Archive:    meta.Archive,
+		Width:      meta.Width,
+		Height:     meta.Height,
+		Offset:     offset,
+		NextOffset: offset + int64(len(data)),
+		DataBase64: base64.StdEncoding.EncodeToString(data),
+		EOF:        eof,
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("编码 Artifact Bridge 结果: %w", err)
+	}
+	var mapped map[string]any
+	if err := json.Unmarshal(encoded, &mapped); err != nil {
+		return nil, fmt.Errorf("构造 Artifact Bridge 结果: %w", err)
+	}
+	return mapped, nil
+}
+
+type artifactChunkResult struct {
+	ArtifactID string    `json:"artifact_id"`
+	Filename   string    `json:"filename"`
+	MIMEType   string    `json:"mime_type"`
+	Size       int64     `json:"size_bytes"`
+	SHA256     string    `json:"sha256"`
+	CreatedAt  time.Time `json:"created_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	Archive    bool      `json:"archive"`
+	Width      int       `json:"width,omitempty"`
+	Height     int       `json:"height,omitempty"`
+	Offset     int64     `json:"offset"`
+	NextOffset int64     `json:"next_offset"`
+	DataBase64 string    `json:"data_base64"`
+	EOF        bool      `json:"eof"`
 }
 
 func (s *Server) HTTPHandler() http.Handler {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	protocol "github.com/uvwt/agentdock-protocol"
 	"github.com/uvwt/agentdock/internal/app"
 	"github.com/uvwt/agentdock/internal/config"
 	"github.com/uvwt/agentdock/internal/publicartifacts"
@@ -24,7 +25,7 @@ func TestReadArtifactChunkServesPrivateBridgePayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := NewServer(nil, config.Config{AgentDockHome: home})
-	result, err := server.ReadArtifactChunk(published.ArtifactID, 0, publicartifacts.MaxBridgeChunkBytes)
+	result, err := server.ReadArtifactChunk(published.ArtifactID, 0, protocol.MaxArtifactChunkBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,27 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/uvwt/agentdock/internal/app"
 	"github.com/uvwt/agentdock/internal/config"
+	"github.com/uvwt/agentdock/internal/publicartifacts"
 )
+
+func TestReadArtifactChunkServesPrivateBridgePayload(t *testing.T) {
+	home := t.TempDir()
+	store := publicartifacts.New(home, "", 0)
+	published, err := store.PublishBytes(publicartifacts.PublishBytesRequest{Filename: "result.txt", Data: []byte("bridge payload")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(nil, config.Config{AgentDockHome: home})
+	result, err := server.ReadArtifactChunk(published.ArtifactID, 0, publicartifacts.MaxBridgeChunkBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := result["data_base64"].(string)
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || string(data) != "bridge payload" || result["eof"] != true {
+		t.Fatalf("Bridge Artifact result = %#v decoded=%q err=%v", result, data, err)
+	}
+}
 
 func TestToolDescriptorsExposeSafetyAnnotations(t *testing.T) {
 	descriptors := toolDescriptorsForNames([]string{"read_file", "skill_package", "task_manage", "file_publish"}, config.Config{})

--- a/internal/nexusbridge/client.go
+++ b/internal/nexusbridge/client.go
@@ -24,11 +24,6 @@ import (
 
 const maxMessageBytes = 8 << 20
 
-const (
-	artifactReadCapability = "bridge.artifact.read.v1"
-	operationArtifactRead  = "artifact.read"
-)
-
 type Client struct {
 	identity Identity
 	server   *mcp.Server
@@ -87,18 +82,13 @@ func (c *Client) connect(ctx context.Context) error {
 	socket.SetReadLimit(maxMessageBytes)
 
 	tools := c.server.ToolNames()
-	capabilities := append(append([]string(nil), tools...), artifactReadCapability)
 	descriptors, err := bridgeToolDescriptors(c.server.ToolDescriptors())
 	if err != nil {
 		return err
 	}
 	if err := c.write(socket, protocol.Message{
 		Type: protocol.MessageNodeHello, ProtocolVersion: protocol.ConnectionProtocolVersion,
-		Hello: &protocol.Hello{
-			DeviceID: c.identity.DeviceID, Version: buildinfo.Version, ProtocolVersion: protocol.ConnectionProtocolVersion,
-			OS: runtime.GOOS, Arch: runtime.GOARCH, Capabilities: capabilities, ToolContractHash: c.server.ToolContractHash(),
-			Tools: descriptors, UIResources: c.server.UIResources(),
-		},
+		Hello: bridgeHello(c.identity, tools, descriptors, c.server.UIResources(), c.server.ToolContractHash()),
 	}); err != nil {
 		return err
 	}
@@ -131,6 +121,21 @@ func (c *Client) connect(ctx context.Context) error {
 			c.cancel(incoming.RequestID)
 		case protocol.MessageNodeHeartbeat:
 		}
+	}
+}
+
+func bridgeHello(identity Identity, tools []string, descriptors []protocol.ToolDescriptor, uiResources []protocol.UIResourceCapability, toolContractHash string) *protocol.Hello {
+	return &protocol.Hello{
+		DeviceID:           identity.DeviceID,
+		Version:            buildinfo.Version,
+		ProtocolVersion:    protocol.ConnectionProtocolVersion,
+		OS:                 runtime.GOOS,
+		Arch:               runtime.GOARCH,
+		Capabilities:       append([]string(nil), tools...),
+		BridgeCapabilities: []string{protocol.ArtifactReadCapability},
+		ToolContractHash:   toolContractHash,
+		Tools:              descriptors,
+		UIResources:        uiResources,
 	}
 }
 
@@ -177,7 +182,7 @@ func (c *Client) invoke(parent context.Context, socket *websocket.Conn, incoming
 		} else {
 			result, err = c.server.ReadAppResource(request.URI)
 		}
-	case operationArtifactRead:
+	case protocol.OperationArtifactRead:
 		var request struct {
 			ArtifactID string `json:"artifact_id"`
 			Offset     int64  `json:"offset"`

--- a/internal/nexusbridge/client.go
+++ b/internal/nexusbridge/client.go
@@ -24,6 +24,11 @@ import (
 
 const maxMessageBytes = 8 << 20
 
+const (
+	artifactReadCapability = "bridge.artifact.read.v1"
+	operationArtifactRead  = "artifact.read"
+)
+
 type Client struct {
 	identity Identity
 	server   *mcp.Server
@@ -82,6 +87,7 @@ func (c *Client) connect(ctx context.Context) error {
 	socket.SetReadLimit(maxMessageBytes)
 
 	tools := c.server.ToolNames()
+	capabilities := append(append([]string(nil), tools...), artifactReadCapability)
 	descriptors, err := bridgeToolDescriptors(c.server.ToolDescriptors())
 	if err != nil {
 		return err
@@ -90,7 +96,7 @@ func (c *Client) connect(ctx context.Context) error {
 		Type: protocol.MessageNodeHello, ProtocolVersion: protocol.ConnectionProtocolVersion,
 		Hello: &protocol.Hello{
 			DeviceID: c.identity.DeviceID, Version: buildinfo.Version, ProtocolVersion: protocol.ConnectionProtocolVersion,
-			OS: runtime.GOOS, Arch: runtime.GOARCH, Capabilities: tools, ToolContractHash: c.server.ToolContractHash(),
+			OS: runtime.GOOS, Arch: runtime.GOARCH, Capabilities: capabilities, ToolContractHash: c.server.ToolContractHash(),
 			Tools: descriptors, UIResources: c.server.UIResources(),
 		},
 	}); err != nil {
@@ -170,6 +176,17 @@ func (c *Client) invoke(parent context.Context, socket *websocket.Conn, incoming
 			err = fmt.Errorf("解析 MCP App resource 请求: %w", decodeErr)
 		} else {
 			result, err = c.server.ReadAppResource(request.URI)
+		}
+	case operationArtifactRead:
+		var request struct {
+			ArtifactID string `json:"artifact_id"`
+			Offset     int64  `json:"offset"`
+			MaxBytes   int    `json:"max_bytes"`
+		}
+		if decodeErr := json.Unmarshal(incoming.Arguments, &request); decodeErr != nil {
+			err = fmt.Errorf("解析 Artifact 读取请求: %w", decodeErr)
+		} else {
+			result, err = c.server.ReadArtifactChunk(request.ArtifactID, request.Offset, request.MaxBytes)
 		}
 	default:
 		err = fmt.Errorf("不支持的 NexusDock 节点操作: %s", incoming.Operation)

--- a/internal/nexusbridge/client_test.go
+++ b/internal/nexusbridge/client_test.go
@@ -1,6 +1,7 @@
 package nexusbridge
 
 import (
+	"reflect"
 	"testing"
 
 	protocol "github.com/uvwt/agentdock-protocol"
@@ -23,5 +24,27 @@ func TestBridgeToolDescriptorsPreservePresentationBinding(t *testing.T) {
 	ui, ok := descriptors[0].Meta["ui"].(map[string]any)
 	if !ok || ui["resourceUri"] != protocol.FileChangeUIResourceURI {
 		t.Fatalf("presentation meta = %#v", descriptors[0].Meta)
+	}
+}
+
+func TestBridgeHelloSeparatesToolsFromBridgeCapabilities(t *testing.T) {
+	tools := []string{"read_file", "exec_command"}
+	hello := bridgeHello(
+		Identity{DeviceID: "device_abcdefgh"},
+		tools,
+		[]protocol.ToolDescriptor{{Name: "read_file"}, {Name: "exec_command"}},
+		[]protocol.UIResourceCapability{},
+		"sha256:test",
+	)
+	if !reflect.DeepEqual(hello.Capabilities, tools) {
+		t.Fatalf("capabilities = %#v, want tools %#v", hello.Capabilities, tools)
+	}
+	if len(hello.BridgeCapabilities) != 1 || hello.BridgeCapabilities[0] != protocol.ArtifactReadCapability {
+		t.Fatalf("bridge_capabilities = %#v", hello.BridgeCapabilities)
+	}
+	for _, capability := range hello.Capabilities {
+		if capability == protocol.ArtifactReadCapability {
+			t.Fatal("Bridge capability leaked into model-facing tool capabilities")
+		}
 	}
 }

--- a/internal/publicartifacts/store.go
+++ b/internal/publicartifacts/store.go
@@ -29,6 +29,9 @@ import (
 const (
 	DefaultRetention = 24 * time.Hour
 	MaxRetention     = 7 * 24 * time.Hour
+	// MaxBridgeChunkBytes keeps one base64-encoded Nexus Bridge response well below
+	// the WebSocket message limit while avoiding tiny repeated reads.
+	MaxBridgeChunkBytes = 512 << 10
 )
 
 type Store struct {
@@ -328,6 +331,66 @@ func (s Store) Read(artifactID string, maxBytes int64) (Metadata, []byte, error)
 		return Metadata{}, nil, errors.New("artifact payload checksum does not match metadata")
 	}
 	return meta, data, nil
+}
+
+// ReadChunk returns one verified slice of an Artifact for the outbound-only
+// Nexus Bridge. A zero maxBytes performs a metadata-only read for HTTP HEAD.
+func (s Store) ReadChunk(artifactID string, offset int64, maxBytes int) (Metadata, []byte, bool, error) {
+	if offset < 0 {
+		return Metadata{}, nil, false, errors.New("artifact offset must not be negative")
+	}
+	if maxBytes < 0 || maxBytes > MaxBridgeChunkBytes {
+		return Metadata{}, nil, false, fmt.Errorf("artifact chunk size must be between 0 and %d bytes", MaxBridgeChunkBytes)
+	}
+	meta, err := s.readMetadata(artifactID)
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("read artifact metadata: %w", err)
+	}
+	if time.Now().UTC().After(meta.ExpiresAt) {
+		return Metadata{}, nil, false, errors.New("artifact has expired")
+	}
+	if offset > meta.Size {
+		return Metadata{}, nil, false, fmt.Errorf("artifact offset %d exceeds payload size %d", offset, meta.Size)
+	}
+
+	payload := filepath.Join(s.Root, artifactID, "payload")
+	file, err := os.Open(payload)
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("open artifact payload: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() != meta.Size {
+		return Metadata{}, nil, false, errors.New("artifact payload size does not match metadata")
+	}
+	if maxBytes == 0 {
+		return meta, nil, offset == meta.Size, nil
+	}
+	// The first chunk verifies the immutable snapshot before any bytes leave the
+	// node. Nexus additionally verifies the complete stream against this digest.
+	if offset == 0 {
+		payloadSHA, hashErr := streamSHA256(file)
+		if hashErr != nil || payloadSHA != meta.SHA256 {
+			return Metadata{}, nil, false, errors.New("artifact payload checksum does not match metadata")
+		}
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("seek artifact payload: %w", err)
+	}
+	remaining := meta.Size - offset
+	readBytes := int64(maxBytes)
+	if remaining < readBytes {
+		readBytes = remaining
+	}
+	data, err := io.ReadAll(io.LimitReader(file, readBytes))
+	if err != nil {
+		return Metadata{}, nil, false, fmt.Errorf("read artifact chunk: %w", err)
+	}
+	if int64(len(data)) != readBytes {
+		return Metadata{}, nil, false, errors.New("artifact payload changed while it was being read")
+	}
+	nextOffset := offset + int64(len(data))
+	return meta, data, nextOffset == meta.Size, nil
 }
 
 func (s Store) Cleanup(now time.Time) error {

--- a/internal/publicartifacts/store.go
+++ b/internal/publicartifacts/store.go
@@ -24,14 +24,13 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	protocol "github.com/uvwt/agentdock-protocol"
 )
 
 const (
 	DefaultRetention = 24 * time.Hour
 	MaxRetention     = 7 * 24 * time.Hour
-	// MaxBridgeChunkBytes keeps one base64-encoded Nexus Bridge response well below
-	// the WebSocket message limit while avoiding tiny repeated reads.
-	MaxBridgeChunkBytes = 512 << 10
 )
 
 type Store struct {
@@ -257,7 +256,7 @@ func (s Store) ServeHTTP(w http.ResponseWriter, r *http.Request, prefix string) 
 		http.Error(w, http.StatusText(http.StatusGone), http.StatusGone)
 		return
 	}
-	meta, err := s.readMetadata(id)
+	meta, payload, err := s.resolveArtifact(id)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -276,8 +275,7 @@ func (s Store) ServeHTTP(w http.ResponseWriter, r *http.Request, prefix string) 
 		http.NotFound(w, r)
 		return
 	}
-	payload := filepath.Join(s.Root, id, "payload")
-	file, err := os.Open(payload)
+	file, err := os.OpenInRoot(s.Root, payload)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -308,7 +306,7 @@ func (s Store) ServeHTTP(w http.ResponseWriter, r *http.Request, prefix string) 
 }
 
 func (s Store) Read(artifactID string, maxBytes int64) (Metadata, []byte, error) {
-	meta, err := s.readMetadata(artifactID)
+	meta, payload, err := s.resolveArtifact(artifactID)
 	if err != nil {
 		return Metadata{}, nil, fmt.Errorf("read artifact metadata: %w", err)
 	}
@@ -318,8 +316,12 @@ func (s Store) Read(artifactID string, maxBytes int64) (Metadata, []byte, error)
 	if maxBytes > 0 && meta.Size > maxBytes {
 		return Metadata{}, nil, fmt.Errorf("artifact size %d exceeds limit %d", meta.Size, maxBytes)
 	}
-	payload := filepath.Join(s.Root, artifactID, "payload")
-	data, err := os.ReadFile(payload)
+	file, err := os.OpenInRoot(s.Root, payload)
+	if err != nil {
+		return Metadata{}, nil, fmt.Errorf("read artifact payload: %w", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return Metadata{}, nil, fmt.Errorf("read artifact payload: %w", err)
 	}
@@ -339,10 +341,13 @@ func (s Store) ReadChunk(artifactID string, offset int64, maxBytes int) (Metadat
 	if offset < 0 {
 		return Metadata{}, nil, false, errors.New("artifact offset must not be negative")
 	}
-	if maxBytes < 0 || maxBytes > MaxBridgeChunkBytes {
-		return Metadata{}, nil, false, fmt.Errorf("artifact chunk size must be between 0 and %d bytes", MaxBridgeChunkBytes)
+	if maxBytes < 0 {
+		return Metadata{}, nil, false, errors.New("artifact chunk size must not be negative")
 	}
-	meta, err := s.readMetadata(artifactID)
+	if maxBytes > protocol.MaxArtifactChunkBytes {
+		maxBytes = protocol.MaxArtifactChunkBytes
+	}
+	meta, payload, err := s.resolveArtifact(artifactID)
 	if err != nil {
 		return Metadata{}, nil, false, fmt.Errorf("read artifact metadata: %w", err)
 	}
@@ -353,8 +358,7 @@ func (s Store) ReadChunk(artifactID string, offset int64, maxBytes int) (Metadat
 		return Metadata{}, nil, false, fmt.Errorf("artifact offset %d exceeds payload size %d", offset, meta.Size)
 	}
 
-	payload := filepath.Join(s.Root, artifactID, "payload")
-	file, err := os.Open(payload)
+	file, err := os.OpenInRoot(s.Root, payload)
 	if err != nil {
 		return Metadata{}, nil, false, fmt.Errorf("open artifact payload: %w", err)
 	}
@@ -433,11 +437,43 @@ func (s Store) Cleanup(now time.Time) error {
 	return errors.Join(cleanupErrs...)
 }
 
-func (s Store) readMetadata(id string) (Metadata, error) {
-	if id == "" || id != filepath.Base(id) {
-		return Metadata{}, errors.New("invalid artifact id")
+func (s Store) resolveArtifact(id string) (Metadata, string, error) {
+	// Artifact IDs are generated as 16 random bytes encoded as lowercase hex.
+	// IsLocal plus the hex whitelist rejects absolute and traversing identifiers;
+	// os.Root below additionally prevents symlink traversal from escaping Root.
+	if !filepath.IsLocal(id) || !validArtifactID(id) {
+		return Metadata{}, "", errors.New("invalid artifact id")
 	}
-	return readMetadataPath(filepath.Join(s.Root, id, "metadata.json"))
+	root, err := os.OpenRoot(s.Root)
+	if err != nil {
+		return Metadata{}, "", err
+	}
+	defer root.Close()
+	metadataPath := filepath.Join(id, "metadata.json")
+	data, err := root.ReadFile(metadataPath)
+	if err != nil {
+		return Metadata{}, "", err
+	}
+	meta, err := decodeMetadata(data)
+	if err != nil {
+		return Metadata{}, "", err
+	}
+	if meta.ArtifactID != id {
+		return Metadata{}, "", errors.New("artifact metadata id does not match path")
+	}
+	return meta, filepath.Join(id, "payload"), nil
+}
+
+func validArtifactID(id string) bool {
+	if len(id) != 32 {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		if (id[i] < '0' || id[i] > '9') && (id[i] < 'a' || id[i] > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func readMetadataPath(path string) (Metadata, error) {
@@ -445,6 +481,10 @@ func readMetadataPath(path string) (Metadata, error) {
 	if err != nil {
 		return Metadata{}, err
 	}
+	return decodeMetadata(data)
+}
+
+func decodeMetadata(data []byte) (Metadata, error) {
 	var meta Metadata
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return Metadata{}, err

--- a/internal/publicartifacts/store_test.go
+++ b/internal/publicartifacts/store_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	protocol "github.com/uvwt/agentdock-protocol"
 )
 
 func TestPublishFileCreatesImmutableSignedSnapshot(t *testing.T) {
@@ -101,11 +103,11 @@ func TestReadChunkStreamsVerifiedArtifact(t *testing.T) {
 
 	var restored []byte
 	for offset := int64(0); ; {
-		meta, chunk, chunkEOF, readErr := store.ReadChunk(result.ArtifactID, offset, MaxBridgeChunkBytes)
+		meta, chunk, chunkEOF, readErr := store.ReadChunk(result.ArtifactID, offset, protocol.MaxArtifactChunkBytes)
 		if readErr != nil {
 			t.Fatal(readErr)
 		}
-		if meta.SHA256 != result.SHA256 || len(chunk) > MaxBridgeChunkBytes {
+		if meta.SHA256 != result.SHA256 || len(chunk) > protocol.MaxArtifactChunkBytes {
 			t.Fatalf("unexpected chunk metadata or size: %#v bytes=%d", meta, len(chunk))
 		}
 		restored = append(restored, chunk...)
@@ -119,16 +121,132 @@ func TestReadChunkStreamsVerifiedArtifact(t *testing.T) {
 	}
 }
 
-func TestReadChunkRejectsTamperedArtifactBeforeFirstChunk(t *testing.T) {
+func TestReadChunkClampsOversizedBridgeRequest(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	data := bytes.Repeat([]byte("x"), protocol.MaxArtifactChunkBytes+1024)
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "large.bin", Data: data})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, chunk, eof, err := store.ReadChunk(result.ArtifactID, 0, protocol.MaxArtifactChunkBytes+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunk) != protocol.MaxArtifactChunkBytes || eof {
+		t.Fatalf("clamped chunk bytes=%d eof=%t", len(chunk), eof)
+	}
+}
+
+func TestArtifactReadsRejectInvalidIDs(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	validHexID := strings.Repeat("a", 32)
+	invalidIDs := []string{
+		"",
+		"../" + validHexID,
+		"..\\" + validHexID,
+		"/" + validHexID,
+		validHexID + "/..",
+		strings.Repeat("A", 32),
+		strings.Repeat("g", 32),
+		strings.Repeat("a", 31),
+	}
+
+	for _, artifactID := range invalidIDs {
+		if _, _, err := store.Read(artifactID, 1024); err == nil || !strings.Contains(err.Error(), "invalid artifact id") {
+			t.Fatalf("Read(%q) error = %v", artifactID, err)
+		}
+		if _, _, _, err := store.ReadChunk(artifactID, 0, protocol.MaxArtifactChunkBytes); err == nil || !strings.Contains(err.Error(), "invalid artifact id") {
+			t.Fatalf("ReadChunk(%q) error = %v", artifactID, err)
+		}
+	}
+}
+
+func TestArtifactReadsRejectPayloadSymlinkEscape(t *testing.T) {
+	home := t.TempDir()
+	store := New(home, "https://agent.example", 8765)
+	original := []byte("same-bytes-outside-root")
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.bin", Data: original})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	artifactDir := filepath.Join(store.Root, result.ArtifactID)
+	outsidePayload := filepath.Join(home, "outside-payload.bin")
+	if err := os.WriteFile(outsidePayload, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payloadPath := filepath.Join(artifactDir, "payload")
+	if err := os.Remove(payloadPath); err != nil {
+		t.Fatal(err)
+	}
+	target, err := filepath.Rel(artifactDir, outsidePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, payloadPath); err != nil {
+		t.Skipf("symlink creation unavailable on this platform: %v", err)
+	}
+
+	if _, _, err := store.Read(result.ArtifactID, int64(len(original))); err == nil {
+		t.Fatal("Read followed an Artifact payload symlink outside the Artifact root")
+	}
+	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, protocol.MaxArtifactChunkBytes); err == nil {
+		t.Fatal("ReadChunk followed an Artifact payload symlink outside the Artifact root")
+	}
+	if _, status := download(t, store, result.URL); status != http.StatusNotFound {
+		t.Fatalf("ServeHTTP symlink escape status = %d, want %d", status, http.StatusNotFound)
+	}
+}
+
+func TestArtifactReadRejectsMetadataIDMismatch(t *testing.T) {
 	store := New(t.TempDir(), "", 0)
 	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.txt", Data: []byte("original")})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(store.Root, result.ArtifactID, "payload"), []byte("tampered"), 0o600); err != nil {
+
+	metadataPath := filepath.Join(store.Root, result.ArtifactID, "metadata.json")
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, MaxBridgeChunkBytes); err == nil || !strings.Contains(err.Error(), "checksum") {
+	var metadata Metadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	metadata.ArtifactID = strings.Repeat("b", 32)
+	data, err = json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metadataPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := store.Read(result.ArtifactID, 1024); err == nil || !strings.Contains(err.Error(), "metadata id does not match path") {
+		t.Fatalf("mismatched metadata Read error = %v", err)
+	}
+	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, protocol.MaxArtifactChunkBytes); err == nil || !strings.Contains(err.Error(), "metadata id does not match path") {
+		t.Fatalf("mismatched metadata ReadChunk error = %v", err)
+	}
+}
+
+func TestReadChunkRejectsTamperedArtifactBeforeFirstChunk(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	original := []byte("original")
+	tampered := []byte("tampered")
+	if len(original) != len(tampered) {
+		t.Fatal("test fixture must keep payload size unchanged so checksum validation is exercised")
+	}
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.txt", Data: original})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Root, result.ArtifactID, "payload"), tampered, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, protocol.MaxArtifactChunkBytes); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("tampered Artifact error = %v", err)
 	}
 }

--- a/internal/publicartifacts/store_test.go
+++ b/internal/publicartifacts/store_test.go
@@ -83,6 +83,56 @@ func TestPublishWithoutBaseURLReturnsArtifactReferenceAndCanRead(t *testing.T) {
 	}
 }
 
+func TestReadChunkStreamsVerifiedArtifact(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	data := bytes.Repeat([]byte("chunked-artifact-"), 70000)
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.bin", Data: data})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metadata, empty, eof, err := store.ReadChunk(result.ArtifactID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Size != int64(len(data)) || len(empty) != 0 || eof {
+		t.Fatalf("metadata read = size:%d bytes:%d eof:%t", metadata.Size, len(empty), eof)
+	}
+
+	var restored []byte
+	for offset := int64(0); ; {
+		meta, chunk, chunkEOF, readErr := store.ReadChunk(result.ArtifactID, offset, MaxBridgeChunkBytes)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if meta.SHA256 != result.SHA256 || len(chunk) > MaxBridgeChunkBytes {
+			t.Fatalf("unexpected chunk metadata or size: %#v bytes=%d", meta, len(chunk))
+		}
+		restored = append(restored, chunk...)
+		offset += int64(len(chunk))
+		if chunkEOF {
+			break
+		}
+	}
+	if !bytes.Equal(restored, data) {
+		t.Fatal("chunked Artifact content changed")
+	}
+}
+
+func TestReadChunkRejectsTamperedArtifactBeforeFirstChunk(t *testing.T) {
+	store := New(t.TempDir(), "", 0)
+	result, err := store.PublishBytes(PublishBytesRequest{Filename: "report.txt", Data: []byte("original")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Root, result.ArtifactID, "payload"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.ReadChunk(result.ArtifactID, 0, MaxBridgeChunkBytes); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("tampered Artifact error = %v", err)
+	}
+}
+
 func TestPublishDirectoryCreatesTarGzSnapshot(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "bundle")


### PR DESCRIPTION
基于贡献者 PR #35 的 Artifact Bridge 实现追加 maintainer hardening。保留原 feature commit 的 pmwl author，不 squash 贡献者提交。\n\n主要收敛：切换正式 agentdock-protocol v0.4.0、统一 Artifact operation/capability/chunk 契约、请求上限 clamp、BridgeCapabilities 与 MCP capability 分离，以及回归测试。\n\n本地已通过 GOWORK=off make check、macOS installer/DMG tests 与全仓 race。