### PR TITLE
release: 发布 v0.8.1

### DIFF
--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const Version = "0.8.0"
+const Version = "0.8.1"
 
 var (
 	Commit    string


### PR DESCRIPTION
准备 AgentDock v0.8.1 正式发布。

- 内置版本：0.8.1
- 基线：当前已通过 main CI / CodeQL / Windows Installer E2E 的 Artifact Bridge 合入版本
- 本地已通过：`GOWORK=off make check`、`git diff --check`

合并后从 main 对应提交创建 annotated tag `v0.8.1`，由 Release workflow 构建并发布 Linux / macOS / Windows 资产、GHCR / Docker Hub 镜像并执行发布后安装验证。