### PR TITLE
fix(windows): 避免运行时继承 RedirectionGuard

### DIFF
--- a/packaging/windows/AgentDock.iss
+++ b/packaging/windows/AgentDock.iss
@@ -67,6 +67,7 @@ Name: "chinesesimplified"; MessagesFile: "compiler:Default.isl, languages\Chines
 
 [Files]
 Source: "..\..\scripts\install\install.ps1"; Flags: dontcopy
+Source: "..\..\scripts\install\launch-windows-process.ps1"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\agentdock_windows_{#PayloadArchitecture}.zip"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\agentdock_windows_{#PayloadArchitecture}.zip.sha256"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\cloudflared.exe"; Flags: dontcopy

--- a/packaging/windows/includes/code.iss
+++ b/packaging/windows/includes/code.iss
@@ -182,6 +182,32 @@ begin
   Result := '"' + Value + '"';
 end;
 
+function LaunchRuntimeProcess(const Filename: String; const Arguments: String): Boolean;
+var
+  ExitCode: Integer;
+  Parameters: String;
+begin
+  Parameters :=
+    '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ' +
+    QuoteArgument(ExpandConstant('{tmp}\launch-windows-process.ps1')) +
+    ' -FilePath ' + QuoteArgument(Filename);
+  if Arguments <> '' then
+    Parameters := Parameters + ' -Arguments ' + QuoteArgument(Arguments);
+
+  Result := Exec(
+    ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
+    Parameters,
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ExitCode);
+  if Result and (ExitCode <> 0) then
+  begin
+    Log('AgentDock runtime launch broker exited with code ' + IntToStr(ExitCode) + '.');
+    Result := False;
+  end;
+end;
+
 function SelectedTunnelMode(): String;
 begin
   case ConnectionPage.SelectedValueIndex of
@@ -332,20 +358,13 @@ end;
 function NextButtonClick(CurPageID: Integer): Boolean;
 var
   URL: String;
-  ExitCode: Integer;
 begin
   Result := True;
   if CurPageID = wpFinished then
   begin
     if not ApplyDesktopControlPanelShortcut(DesktopShortcutCheckBox.Checked) then
       Log('AgentDock desktop shortcut state could not be applied.');
-    if not Exec(
-      ExpandConstant('{app}\bin\agentdock-tray.exe'),
-      '',
-      '',
-      SW_SHOWNORMAL,
-      ewNoWait,
-      ExitCode) then
+    if not LaunchRuntimeProcess(ExpandConstant('{app}\bin\agentdock-tray.exe'), '') then
       Log('AgentDock control panel could not be opened from the Finish button.');
     Exit;
   end;
@@ -403,6 +422,7 @@ begin
     InstallProgressPage.SetText(GetLocalizedMessage('OfflineProgressPreparing'), '');
     InstallProgressPage.SetProgress(1, 4);
     ExtractTemporaryFile('install.ps1');
+    ExtractTemporaryFile('launch-windows-process.ps1');
     ExtractTemporaryFile('agentdock_windows_{#PayloadArchitecture}.zip');
     ExtractTemporaryFile('agentdock_windows_{#PayloadArchitecture}.zip.sha256');
     ExtractTemporaryFile('cloudflared.exe');

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -32,6 +32,30 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 Add-Type -AssemblyName System.Security
+$setupRuntimeLauncherPath = Join-Path $PSScriptRoot 'launch-windows-process.ps1'
+
+function Invoke-SetupRuntimeProcess {
+    param(
+        [string] $FilePath,
+        [string] $Arguments = '',
+        [switch] $WaitForExit
+    )
+
+    if ($InstallChannel -ne 'setup') {
+        throw 'The Setup runtime launcher is only valid for InstallChannel=setup.'
+    }
+    if (-not (Test-Path -LiteralPath $setupRuntimeLauncherPath -PathType Leaf)) {
+        throw "Setup runtime launcher was not found: $setupRuntimeLauncherPath"
+    }
+
+    # Inno Setup 6.7+ enables ProcessRedirectionTrustPolicy on its process tree.
+    # Task Scheduler creates the long-lived runtime from a clean user process context
+    # while Setup keeps RedirectionGuard enabled for install-time filesystem work.
+    & $setupRuntimeLauncherPath `
+        -FilePath $FilePath `
+        -Arguments $Arguments `
+        -WaitForExit:$WaitForExit
+}
 
 function Get-AgentDockArchitecture {
     $architecture = $env:PROCESSOR_ARCHITECTURE
@@ -683,6 +707,10 @@ function Start-HiddenPowerShellScript {
         throw "Launcher was not found: $ScriptPath"
     }
     $arguments = "-NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$ScriptPath`""
+    if ($InstallChannel -eq 'setup') {
+        Invoke-SetupRuntimeProcess -FilePath (Join-Path $PSHOME 'powershell.exe') -Arguments $arguments
+        return
+    }
     Start-Process -FilePath 'powershell.exe' -ArgumentList $arguments -WindowStyle Hidden | Out-Null
 }
 
@@ -701,6 +729,10 @@ function Start-AgentDockTray {
 
     if (-not (Test-Path -LiteralPath $BinaryPath -PathType Leaf)) {
         throw "AgentDock tray was not found: $BinaryPath"
+    }
+    if ($InstallChannel -eq 'setup') {
+        Invoke-SetupRuntimeProcess -FilePath $BinaryPath -Arguments '--background'
+        return
     }
     Start-Process -FilePath $BinaryPath -ArgumentList '--background' -WindowStyle Hidden | Out-Null
 }
@@ -1316,9 +1348,16 @@ exit `$LASTEXITCODE
         } else {
             $startupCommand = "`"$destinationTrayBinary`" --start-core --runtime-root `"$runtimeDir`""
             Set-RunValue -RegistryPath $runKey -Name $runValueName -Value $startupCommand
-            & $destinationBinary service start --runtime-root $runtimeDir
-            if ($LASTEXITCODE -ne 0) {
-                throw "AgentDock native service start failed with exit code $LASTEXITCODE."
+            if ($InstallChannel -eq 'setup') {
+                Invoke-SetupRuntimeProcess `
+                    -FilePath $destinationBinary `
+                    -Arguments "service start --runtime-root `"$runtimeDir`"" `
+                    -WaitForExit
+            } else {
+                & $destinationBinary service start --runtime-root $runtimeDir
+                if ($LASTEXITCODE -ne 0) {
+                    throw "AgentDock native service start failed with exit code $LASTEXITCODE."
+                }
             }
         }
         $startupRegistrationChanged = $true
@@ -1525,9 +1564,16 @@ exit `$process.ExitCode
             $cloudflaredStartupCommand = "`"$destinationTrayBinary`" --start-tunnel --runtime-root `"$runtimeDir`""
             Set-RunValue -RegistryPath $runKey -Name $cloudflaredRunValueName -Value $cloudflaredStartupCommand
             $tunnelStartupRegistrationChanged = $true
-            & $destinationBinary tunnel start --runtime-root $runtimeDir
-            if ($LASTEXITCODE -ne 0) {
-                throw "AgentDock native Tunnel start failed with exit code $LASTEXITCODE."
+            if ($InstallChannel -eq 'setup') {
+                Invoke-SetupRuntimeProcess `
+                    -FilePath $destinationBinary `
+                    -Arguments "tunnel start --runtime-root `"$runtimeDir`"" `
+                    -WaitForExit
+            } else {
+                & $destinationBinary tunnel start --runtime-root $runtimeDir
+                if ($LASTEXITCODE -ne 0) {
+                    throw "AgentDock native Tunnel start failed with exit code $LASTEXITCODE."
+                }
             }
 
             if ($resolvedTunnelMode -eq 'quick') {
@@ -1556,9 +1602,16 @@ exit `$process.ExitCode
 
     $mustRestartExistingProcess = (-not $RegisterStartup) -and $processWasRunning
     if ($mustRestartExistingProcess) {
-        & $destinationBinary service start --runtime-root $runtimeDir
-        if ($LASTEXITCODE -ne 0) {
-            throw "AgentDock native service restart failed with exit code $LASTEXITCODE."
+        if ($InstallChannel -eq 'setup') {
+            Invoke-SetupRuntimeProcess `
+                -FilePath $destinationBinary `
+                -Arguments "service start --runtime-root `"$runtimeDir`"" `
+                -WaitForExit
+        } else {
+            & $destinationBinary service start --runtime-root $runtimeDir
+            if ($LASTEXITCODE -ne 0) {
+                throw "AgentDock native service restart failed with exit code $LASTEXITCODE."
+            }
         }
     }
 

--- a/scripts/install/launch-windows-process.ps1
+++ b/scripts/install/launch-windows-process.ps1
@@ -1,0 +1,105 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $FilePath,
+    [string] $Arguments = '',
+    [switch] $WaitForExit,
+    [ValidateRange(1, 120)]
+    [int] $TimeoutSeconds = 30
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
+    throw "Runtime executable was not found: $FilePath"
+}
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+if ($null -eq $identity -or [string]::IsNullOrWhiteSpace($identity.Name)) {
+    throw 'Unable to resolve the current Windows identity for runtime launch.'
+}
+
+$taskName = 'AgentDock Setup Runtime ' + [Guid]::NewGuid().ToString('N')
+$wrapperLines = @("`$ErrorActionPreference = 'Stop'")
+foreach ($name in @('AGENTDOCK_HOME', 'AGENTDOCK_DEFAULT_DIR')) {
+    $value = [Environment]::GetEnvironmentVariable($name, 'Process')
+    if ($null -ne $value) {
+        $encodedValue = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($value))
+        $wrapperLines += "`$env:$name = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$encodedValue'))"
+    }
+}
+$encodedFilePath = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($FilePath))
+$wrapperLines += "`$filePath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$encodedFilePath'))"
+if ([string]::IsNullOrWhiteSpace($Arguments)) {
+    $wrapperLines += '$process = Start-Process -FilePath $filePath -PassThru'
+} else {
+    $encodedArguments = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Arguments))
+    $wrapperLines += "`$arguments = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$encodedArguments'))"
+    $wrapperLines += '$process = Start-Process -FilePath $filePath -ArgumentList $arguments -PassThru'
+}
+if ($WaitForExit) {
+    $wrapperLines += '$process.WaitForExit()'
+    $wrapperLines += 'exit $process.ExitCode'
+} else {
+    $wrapperLines += 'exit 0'
+}
+$encodedCommand = [Convert]::ToBase64String(
+    [Text.Encoding]::Unicode.GetBytes(($wrapperLines -join "`r`n"))
+)
+$powerShellPath = Join-Path $PSHOME 'powershell.exe'
+$action = New-ScheduledTaskAction `
+    -Execute $powerShellPath `
+    -Argument "-NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -EncodedCommand $encodedCommand"
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $identity.Name `
+    -LogonType Interactive `
+    -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries
+
+$registered = $false
+$startedAt = Get-Date
+try {
+    Register-ScheduledTask `
+        -TaskName $taskName `
+        -Action $action `
+        -Principal $principal `
+        -Settings $settings `
+        -Force | Out-Null
+    $registered = $true
+    Start-ScheduledTask -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $task = Get-ScheduledTask -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+        $info = Get-ScheduledTaskInfo -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+        $hasRun = $info.LastRunTime -ge $startedAt.AddSeconds(-1)
+        if ($hasRun) {
+            if (-not $WaitForExit) {
+                if ($task.State -eq 'Ready' -and $info.LastTaskResult -ne 0) {
+                    throw "Runtime process failed to launch, Task Scheduler result: $($info.LastTaskResult)."
+                }
+                return
+            }
+            if ($task.State -notin @('Running', 'Queued')) {
+                if ($info.LastTaskResult -ne 0) {
+                    throw "Runtime process exited with Task Scheduler result: $($info.LastTaskResult)."
+                }
+                return
+            }
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    if ($WaitForExit) {
+        throw "Runtime process did not finish within $TimeoutSeconds seconds."
+    }
+    throw "Runtime process did not start within $TimeoutSeconds seconds."
+} finally {
+    if ($registered) {
+        Unregister-ScheduledTask -TaskName $taskName -TaskPath '\' -Confirm:$false -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/test/install_test.go
+++ b/scripts/test/install_test.go
@@ -1107,6 +1107,83 @@ func TestWindowsControlPanelUsesStableAppUserModelID(t *testing.T) {
 	}
 }
 
+func TestWindowsSetupLaunchesRuntimeOutsideRedirectionGuardTree(t *testing.T) {
+	installData, err := os.ReadFile(filepath.Join("..", "..", "scripts", "install", "install.ps1"))
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	brokerData, err := os.ReadFile(filepath.Join("..", "..", "scripts", "install", "launch-windows-process.ps1"))
+	if err != nil {
+		t.Fatalf("read launch-windows-process.ps1: %v", err)
+	}
+	setupData, err := os.ReadFile(filepath.Join("..", "..", "packaging", "windows", "includes", "code.iss"))
+	if err != nil {
+		t.Fatalf("read code.iss: %v", err)
+	}
+	definitionData, err := os.ReadFile(filepath.Join("..", "..", "packaging", "windows", "AgentDock.iss"))
+	if err != nil {
+		t.Fatalf("read AgentDock.iss: %v", err)
+	}
+
+	installScript := strings.ReplaceAll(string(installData), "\r\n", "\n")
+	brokerScript := strings.ReplaceAll(string(brokerData), "\r\n", "\n")
+	setupScript := strings.ReplaceAll(string(setupData), "\r\n", "\n")
+	definition := strings.ReplaceAll(string(definitionData), "\r\n", "\n")
+
+	for _, want := range []string{
+		"$setupRuntimeLauncherPath = Join-Path $PSScriptRoot 'launch-windows-process.ps1'",
+		"function Invoke-SetupRuntimeProcess",
+		"if ($InstallChannel -eq 'setup') {\n                Invoke-SetupRuntimeProcess `\n                    -FilePath $destinationBinary `\n                    -Arguments \"service start --runtime-root",
+		"if ($InstallChannel -eq 'setup') {\n                Invoke-SetupRuntimeProcess `\n                    -FilePath $destinationBinary `\n                    -Arguments \"tunnel start --runtime-root",
+		"Invoke-SetupRuntimeProcess -FilePath $BinaryPath -Arguments '--background'",
+		"Invoke-SetupRuntimeProcess -FilePath (Join-Path $PSHOME 'powershell.exe') -Arguments $arguments",
+	} {
+		if !strings.Contains(installScript, want) {
+			t.Fatalf("install.ps1 must route Setup-owned long-lived launches through the runtime broker; missing %q", want)
+		}
+	}
+
+	for _, want := range []string{
+		"New-ScheduledTaskAction",
+		"New-ScheduledTaskPrincipal",
+		"-LogonType Interactive",
+		"-RunLevel Limited",
+		"Register-ScheduledTask",
+		"Start-ScheduledTask",
+		"if ($WaitForExit) {",
+		"$process.WaitForExit()",
+		"$wrapperLines += 'exit 0'",
+		"Unregister-ScheduledTask",
+		"AGENTDOCK_HOME",
+		"AGENTDOCK_DEFAULT_DIR",
+	} {
+		if !strings.Contains(brokerScript, want) {
+			t.Fatalf("runtime launch broker missing %q", want)
+		}
+	}
+	if !strings.Contains(brokerScript, "finally {") || !strings.Contains(brokerScript, "Unregister-ScheduledTask") {
+		t.Fatal("runtime launch broker must remove its temporary task even when launch fails")
+	}
+
+	for _, want := range []string{
+		"Source: \"..\\..\\scripts\\install\\launch-windows-process.ps1\"; Flags: dontcopy",
+		"ExtractTemporaryFile('launch-windows-process.ps1')",
+		"function LaunchRuntimeProcess(",
+		"LaunchRuntimeProcess(ExpandConstant('{app}\\bin\\agentdock-tray.exe'), '')",
+	} {
+		if !strings.Contains(definition+"\n"+setupScript, want) {
+			t.Fatalf("Windows Setup must package and use the runtime launch broker; missing %q", want)
+		}
+	}
+	if strings.Contains(strings.ToLower(definition), "redirectionguard=no") || strings.Contains(strings.ToLower(definition), "/noredirectionguard") {
+		t.Fatal("Windows Setup must keep Inno RedirectionGuard enabled instead of disabling the mitigation globally")
+	}
+	legacyFinishLaunch := "if not Exec(\n      ExpandConstant('{app}\\bin\\agentdock-tray.exe')"
+	if strings.Contains(setupScript, legacyFinishLaunch) {
+		t.Fatal("Setup finish page must not launch the long-lived tray directly from the RedirectionGuard process tree")
+	}
+}
+
 func TestWindowsControlPanelOmitsCopyButtons(t *testing.T) {
 	xamlData, err := os.ReadFile(filepath.Join("..", "..", "desktop", "windows", "control-panel", "MainWindow.xaml"))
 	if err != nil {


### PR DESCRIPTION
修复 Windows 官方 Setup 安装完成后，长期 AgentDock Runtime 继承 Inno Setup `EnforceRedirectionTrust` 的问题。

修复策略：
- 保留 Inno Setup `RedirectionGuard`；
- Setup 渠道启动长期 Core / Tunnel / Tray 时，通过一次性当前用户 Limited Task Scheduler broker 切断 mitigation 继承；
- broker 启动后删除临时任务，不留持久任务；
- 保留 `AGENTDOCK_HOME` / `AGENTDOCK_DEFAULT_DIR`；
- rollback 和 Finish 页启动路径同样走 broker。

Windows 实机验证：
- A（Setup 安装后立即启动）：最终 Core / Tray `EnforceRedirectionTrust=False`
- B（Setup 退出后 service start）：`False`
- C（正常 Tray 启动）：`False`
- 通过最终测试 Core 的 MCP `exec_command` 成功访问 NTFS Junction
- `go test ./...` 通过
- Inno Setup 6.7.3 实际编译通过

Fixes #42