### PR TITLE
refactor(file): 完善 Gitignore 匹配语义

### DIFF
--- a/internal/tool/file/ignore.go
+++ b/internal/tool/file/ignore.go
@@ -8,79 +8,219 @@ import (
 )
 
 type ignoreMatcher struct {
-	rules []ignoreRule
+	root    string
+	exclude []gitignoreRule
+	files   map[string][]gitignoreRule
 }
 
-type ignoreRule struct {
-	pattern string
-	negate  bool
-	dirOnly bool
-	rooted  bool
+type gitignoreRule struct {
+	domain   []string
+	pattern  string
+	negate   bool
+	dirOnly  bool
+	rooted   bool
+	hasSlash bool
 }
 
-func loadIgnoreMatcher(root string) ignoreMatcher {
-	file, err := os.Open(filepath.Join(root, ".gitignore"))
-	if err != nil {
-		return ignoreMatcher{}
+func loadIgnoreMatcher(root string) *ignoreMatcher {
+	matcher := &ignoreMatcher{
+		root:  root,
+		files: make(map[string][]gitignoreRule),
 	}
-	defer file.Close()
-	matcher := ignoreMatcher{}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		rule := ignoreRule{}
-		if strings.HasPrefix(line, "!") {
-			rule.negate = true
-			line = strings.TrimPrefix(line, "!")
-		}
-		if strings.HasPrefix(line, "/") {
-			rule.rooted = true
-			line = strings.TrimPrefix(line, "/")
-		}
-		if strings.HasSuffix(line, "/") {
-			rule.dirOnly = true
-			line = strings.TrimSuffix(line, "/")
-		}
-		if line == "" {
-			continue
-		}
-		rule.pattern = filepath.ToSlash(line)
-		matcher.rules = append(matcher.rules, rule)
-	}
+	matcher.exclude = loadIgnoreRules(resolveGitInfoExclude(root), nil)
 	return matcher
 }
 
-func (m ignoreMatcher) Ignored(rel string, isDir bool) bool {
-	rel = filepath.ToSlash(rel)
-	ignored := false
-	for _, rule := range m.rules {
-		if rule.dirOnly && !isDir {
-			continue
+func (m *ignoreMatcher) Ignored(rel string, isDir bool) bool {
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." || rel == "" {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+
+	// Git 不允许通过子路径的否定规则重新包含一个已被忽略目录里的文件。
+	// 逐级检查父目录，也保证只有真正能进入的目录才会读取其中的 .gitignore。
+	for depth := 1; depth < len(parts); depth++ {
+		if m.pathIgnored(parts[:depth], true) {
+			return true
 		}
-		if matchIgnoreRule(rule, rel) {
+	}
+	return m.pathIgnored(parts, isDir)
+}
+
+func (m *ignoreMatcher) pathIgnored(parts []string, isDir bool) bool {
+	ignored := false
+	for _, rule := range m.exclude {
+		if rule.matches(parts, isDir) {
 			ignored = !rule.negate
+		}
+	}
+	for depth := 0; depth < len(parts); depth++ {
+		for _, rule := range m.ignoreFile(parts[:depth]) {
+			if rule.matches(parts, isDir) {
+				ignored = !rule.negate
+			}
 		}
 	}
 	return ignored
 }
 
-func matchIgnoreRule(rule ignoreRule, rel string) bool {
-	pattern := rule.pattern
+func (m *ignoreMatcher) ignoreFile(domain []string) []gitignoreRule {
+	key := strings.Join(domain, "/")
+	if rules, ok := m.files[key]; ok {
+		return rules
+	}
+
+	parts := make([]string, 0, len(domain)+2)
+	parts = append(parts, m.root)
+	parts = append(parts, domain...)
+	parts = append(parts, ".gitignore")
+	rules := loadIgnoreRules(filepath.Join(parts...), domain)
+	m.files[key] = rules
+	return rules
+}
+
+func loadIgnoreRules(path string, domain []string) []gitignoreRule {
+	if path == "" {
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	rules := make([]gitignoreRule, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if rule, ok := parseGitignoreRule(scanner.Text(), domain); ok {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
+}
+
+func parseGitignoreRule(line string, domain []string) (gitignoreRule, bool) {
+	line = strings.TrimSuffix(line, "\r")
+	line = trimGitignoreTrailingSpaces(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return gitignoreRule{}, false
+	}
+
+	rule := gitignoreRule{domain: append([]string(nil), domain...)}
+	if strings.HasPrefix(line, `\#`) {
+		line = line[1:]
+	}
+	if strings.HasPrefix(line, "!") {
+		rule.negate = true
+		line = line[1:]
+	} else if strings.HasPrefix(line, `\!`) {
+		line = line[1:]
+	}
+	if line == "" {
+		return gitignoreRule{}, false
+	}
+
+	rule.dirOnly = strings.HasSuffix(line, "/")
+	if rule.dirOnly {
+		line = strings.TrimSuffix(line, "/")
+	}
+	rule.rooted = strings.HasPrefix(line, "/")
 	if rule.rooted {
-		return globMatch(pattern, rel)
+		line = strings.TrimPrefix(line, "/")
 	}
-	if globMatch(pattern, rel) || globMatch(pattern, filepath.Base(rel)) {
-		return true
+	if line == "" {
+		return gitignoreRule{}, false
 	}
-	parts := strings.Split(rel, "/")
-	for i := range parts {
-		suffix := strings.Join(parts[i:], "/")
-		if globMatch(pattern, suffix) {
+	rule.pattern = line
+	rule.hasSlash = strings.Contains(line, "/")
+	return rule, true
+}
+
+func trimGitignoreTrailingSpaces(line string) string {
+	for strings.HasSuffix(line, " ") {
+		backslashes := 0
+		for i := len(line) - 2; i >= 0 && line[i] == '\\'; i-- {
+			backslashes++
+		}
+		if backslashes%2 == 1 {
+			break
+		}
+		line = strings.TrimSuffix(line, " ")
+	}
+	return line
+}
+
+func (r gitignoreRule) matches(parts []string, isDir bool) bool {
+	if len(parts) <= len(r.domain) {
+		return false
+	}
+	for i, component := range r.domain {
+		if parts[i] != component {
+			return false
+		}
+	}
+	relParts := parts[len(r.domain):]
+	if r.rooted || r.hasSlash {
+		if r.dirOnly && !isDir {
+			return false
+		}
+		return matchGitignorePattern(r.pattern, strings.Join(relParts, "/"))
+	}
+
+	for i, component := range relParts {
+		componentIsDir := i < len(relParts)-1 || isDir
+		if r.dirOnly && !componentIsDir {
+			continue
+		}
+		if matchGitignorePattern(r.pattern, component) {
 			return true
 		}
 	}
 	return false
+}
+
+func matchGitignorePattern(pattern, candidate string) bool {
+	// Git 中 trailing /** 匹配目录内部内容，不匹配该目录本身；doublestar
+	// 会把二者都视为匹配，因此这里补齐 Git 的这一处语义差异。
+	if strings.HasSuffix(pattern, "/**") && candidate == strings.TrimSuffix(pattern, "/**") {
+		return false
+	}
+	return globMatch(pattern, candidate)
+}
+
+func resolveGitInfoExclude(root string) string {
+	gitPath := filepath.Join(root, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+	if info.IsDir() {
+		return filepath.Join(gitPath, "info", "exclude")
+	}
+
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	gitDir, ok := strings.CutPrefix(line, "gitdir:")
+	if !ok {
+		return ""
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(root, gitDir)
+	}
+	gitDir = filepath.Clean(gitDir)
+
+	commonDir := gitDir
+	if data, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+		commonDir = strings.TrimSpace(string(data))
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+		commonDir = filepath.Clean(commonDir)
+	}
+	return filepath.Join(commonDir, "info", "exclude")
 }

--- a/internal/tool/file/ignore_test.go
+++ b/internal/tool/file/ignore_test.go
@@ -1,0 +1,249 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestIgnoreMatcherHonorsGitHierarchyAndExclude(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreTestFile(t, root, ".gitignore", "*.tmp\n/root-only.txt\nignored/\n!ignored/keep.txt\na/**/b.txt\n\\#literal\n\\!literal\nspace\\ \n")
+	writeIgnoreTestFile(t, root, "src/.gitignore", "!important.tmp\n/generated/\n")
+	writeIgnoreTestFile(t, root, ".git/info/exclude", "vendor/\n")
+
+	matcher := loadIgnoreMatcher(root)
+	tests := []struct {
+		path  string
+		isDir bool
+		want  bool
+	}{
+		{path: "root-only.txt", want: true},
+		{path: "nested/root-only.txt", want: false},
+		{path: "drop.tmp", want: true},
+		{path: "src/drop.tmp", want: true},
+		{path: "src/important.tmp", want: false},
+		{path: "src/generated", isDir: true, want: true},
+		{path: "src/generated/file.txt", want: true},
+		{path: "generated", isDir: true, want: false},
+		{path: "ignored/keep.txt", want: true},
+		{path: "vendor", isDir: true, want: true},
+		{path: "vendor/file.txt", want: true},
+		{path: "a/b.txt", want: true},
+		{path: "a/x/y/b.txt", want: true},
+		{path: "#literal", want: true},
+		{path: "!literal", want: true},
+		{path: "space ", want: true},
+		{path: "keep.txt", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			if got := matcher.Ignored(test.path, test.isDir); got != test.want {
+				t.Fatalf("Ignored(%q, %t) = %t, want %t", test.path, test.isDir, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIgnoreMatcherMatchesGit(t *testing.T) {
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is required for gitignore differential test")
+	}
+	root := t.TempDir()
+	if output, err := exec.Command(git, "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+	writeIgnoreTestFile(t, root, ".gitignore", "*.tmp\n/root-only.txt\nignored/\n!ignored/keep.txt\na/**/b.txt\n\\#literal\n\\!literal\nspace\\ \nabc/**\ndocs/*.md\nfile?.txt\n[ab].cfg\n")
+	writeIgnoreTestFile(t, root, "src/.gitignore", "!important.tmp\n/generated/\n")
+	writeIgnoreTestFile(t, root, ".git/info/exclude", "vendor/\n")
+
+	files := []string{
+		"root-only.txt",
+		"nested/root-only.txt",
+		"drop.tmp",
+		"src/drop.tmp",
+		"src/important.tmp",
+		"src/generated/file.txt",
+		"ignored/keep.txt",
+		"vendor/file.txt",
+		"a/b.txt",
+		"a/x/y/b.txt",
+		"#literal",
+		"!literal",
+		"space ",
+		"abc/file.txt",
+		"docs/a.md",
+		"docs/sub/a.md",
+		"file1.txt",
+		"file10.txt",
+		"a.cfg",
+		"c.cfg",
+		"keep.txt",
+	}
+	for _, rel := range files {
+		writeIgnoreTestFile(t, root, rel, "fixture")
+	}
+	for _, rel := range []string{"src/generated", "generated", "ignored", "vendor", "abc"} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(rel)), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matcher := loadIgnoreMatcher(root)
+	tests := []struct {
+		path  string
+		isDir bool
+	}{
+		{path: "root-only.txt"},
+		{path: "nested/root-only.txt"},
+		{path: "drop.tmp"},
+		{path: "src/drop.tmp"},
+		{path: "src/important.tmp"},
+		{path: "src/generated", isDir: true},
+		{path: "src/generated/file.txt"},
+		{path: "generated", isDir: true},
+		{path: "ignored/keep.txt"},
+		{path: "vendor", isDir: true},
+		{path: "vendor/file.txt"},
+		{path: "a/b.txt"},
+		{path: "a/x/y/b.txt"},
+		{path: "#literal"},
+		{path: "!literal"},
+		{path: "space "},
+		{path: "abc", isDir: true},
+		{path: "abc/file.txt"},
+		{path: "docs/a.md"},
+		{path: "docs/sub/a.md"},
+		{path: "file1.txt"},
+		{path: "file10.txt"},
+		{path: "a.cfg"},
+		{path: "c.cfg"},
+		{path: "keep.txt"},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			want := gitCheckIgnored(t, git, root, test.path)
+			if got := matcher.Ignored(test.path, test.isDir); got != want {
+				t.Fatalf("Ignored(%q, %t) = %t, git check-ignore = %t", test.path, test.isDir, got, want)
+			}
+		})
+	}
+}
+
+func TestResolveGitInfoExcludeForWorktree(t *testing.T) {
+	root := t.TempDir()
+	gitDir := filepath.Join(root, "git", "worktrees", "sample")
+	commonDir := filepath.Join(root, "git")
+	if err := os.MkdirAll(gitDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIgnoreTestFile(t, root, ".git", "gitdir: git/worktrees/sample\n")
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(commonDir, "info", "exclude")
+	if got := resolveGitInfoExclude(root); got != want {
+		t.Fatalf("resolveGitInfoExclude() = %q, want %q", got, want)
+	}
+}
+
+func gitCheckIgnored(t *testing.T, git, root, rel string) bool {
+	t.Helper()
+	cmd := exec.Command(git, "-C", root, "check-ignore", "--no-index", "-q", "--", filepath.ToSlash(rel))
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git check-ignore %q: %v", rel, err)
+	return false
+}
+
+func TestSearchTextGoHonorsNestedGitignoreAndExclude(t *testing.T) {
+	runtime, root := newCodeToolsRuntime(t)
+	for path, content := range map[string]string{
+		"src/keep.txt":           "needle keep\n",
+		"src/drop.tmp":           "needle root-ignore\n",
+		"src/important.tmp":      "needle nested-include\n",
+		"src/vendor/drop.txt":    "needle info-exclude\n",
+		"src/generated/drop.txt": "needle nested-ignore\n",
+	} {
+		writeIgnoreTestFile(t, root, path, content)
+	}
+	writeIgnoreTestFile(t, root, ".gitignore", "*.tmp\n")
+	writeIgnoreTestFile(t, root, "src/.gitignore", "!important.tmp\n/generated/\n")
+	writeIgnoreTestFile(t, root, ".git/info/exclude", "src/vendor/\n")
+
+	path, err := runtime.ws.ResolveExisting("src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.searchTextGo(context.Background(), path, SearchOptions{
+		Query: "needle", CaseSensitive: true, MaxResults: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	for _, match := range result["matches"].([]map[string]any) {
+		got[match["path"].(string)] = true
+	}
+	if len(got) != 2 || !got["src/keep.txt"] || !got["src/important.tmp"] {
+		t.Fatalf("search fallback ignored paths = %#v, want keep.txt and important.tmp only", got)
+	}
+}
+
+func TestListDirHonorsNestedGitignoreAndExclude(t *testing.T) {
+	runtime, root := newFileTestService(t)
+	for path, content := range map[string]string{
+		"src/keep.txt":           "keep",
+		"src/drop.tmp":           "root ignore",
+		"src/important.tmp":      "nested include",
+		"src/vendor/drop.txt":    "info exclude",
+		"src/generated/drop.txt": "nested ignore",
+	} {
+		writeIgnoreTestFile(t, root, path, content)
+	}
+	writeIgnoreTestFile(t, root, ".gitignore", "*.tmp\n")
+	writeIgnoreTestFile(t, root, "src/.gitignore", "!important.tmp\n/generated/\n")
+	writeIgnoreTestFile(t, root, ".git/info/exclude", "src/vendor/\n")
+
+	result, err := runtime.listDirTest(context.Background(), map[string]any{
+		"path": "src", "max_depth": 2, "include_hidden": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, entry := range result["entries"].([]map[string]any) {
+		got[entry["path"].(string)] = true
+	}
+	if !got["keep.txt"] || !got["important.tmp"] {
+		t.Fatalf("list_dir missing expected entries: %#v", got)
+	}
+	for _, ignored := range []string{"drop.tmp", "generated", "generated/drop.txt", "vendor", "vendor/drop.txt"} {
+		if got[ignored] {
+			t.Fatalf("list_dir returned ignored path %q: %#v", ignored, got)
+		}
+	}
+}
+
+func writeIgnoreTestFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## 改动
- 完善原生文件工具的 Gitignore 规则解析与层级作用域
- 支持 nested `.gitignore`、`.git/info/exclude`、worktree `commondir`
- 复用现有 `doublestar`，不新增 Go 依赖
- 使用真实 `git check-ignore` 做差分回归测试

## 验证
- `go test ./internal/tool/file`
- `go test ./...`
- `go vet ./...`
- Windows amd64 交叉编译
- `git diff --check`

以上均已在最新 `main` 基线上通过。