### PR TITLE
feat(acp): 支持自定义 ACP 适配器

### DIFF
--- a/desktop/macos/AgentDockApp/Sources/ACPConfiguration.swift
+++ b/desktop/macos/AgentDockApp/Sources/ACPConfiguration.swift
@@ -16,12 +16,14 @@ enum ACPAgentPreset: String, CaseIterable {
     case codex
     case claude
     case grok
+    case custom
 
     var title: String {
         switch self {
         case .codex: return "Codex"
         case .claude: return "Claude"
         case .grok: return "Grok Build"
+        case .custom: return "自定义"
         }
     }
 
@@ -30,13 +32,14 @@ enum ACPAgentPreset: String, CaseIterable {
         case .codex: return ["codex-acp"]
         case .claude: return ["claude-agent-acp"]
         case .grok: return ["grok"]
+        case .custom: return []
         }
     }
 
     var arguments: [String] {
         switch self {
         case .grok: return ["agent", "stdio"]
-        case .codex, .claude: return []
+        case .codex, .claude, .custom: return []
         }
     }
 
@@ -46,20 +49,23 @@ enum ACPAgentPreset: String, CaseIterable {
             return ACPNodePackage(name: "@agentclientprotocol/codex-acp", binName: "codex-acp")
         case .claude:
             return ACPNodePackage(name: "@agentclientprotocol/claude-agent-acp", binName: "claude-agent-acp")
-        case .grok:
+        case .grok, .custom:
             return nil
         }
     }
 
     var missingAdapterMessage: String {
+        if self == .custom {
+            return "请填写可执行的 ACP Adapter 绝对路径"
+        }
         guard let nodePackage else {
             return "未找到 \(executableNames[0])"
         }
         return "未找到 \(executableNames[0]) 或 \(nodePackage.name)"
     }
 
-    static func parse(_ raw: String) -> ACPAgentPreset {
-        ACPAgentPreset(rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) ?? .codex
+    static func parse(_ raw: String) -> ACPAgentPreset? {
+        ACPAgentPreset(rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
     }
 
     func resolveAdapter(
@@ -74,6 +80,14 @@ enum ACPAgentPreset: String, CaseIterable {
             arguments: configuredArguments,
             directories: directories
         )
+        if self == .custom {
+            return configured ?? ACPAdapterResolution(
+                available: false,
+                command: "",
+                arguments: [],
+                message: "未配置 · \(missingAdapterMessage)"
+            )
+        }
 
         var discovered: ACPAdapterResolution?
         for directory in directories {
@@ -160,7 +174,7 @@ enum ACPAgentPreset: String, CaseIterable {
         directories: [URL]
     ) -> ACPAdapterResolution? {
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedCommand.isEmpty,
+        guard trimmedCommand.hasPrefix("/"),
               let executable = executableFile(URL(fileURLWithPath: trimmedCommand)) else {
             return nil
         }
@@ -343,5 +357,15 @@ struct ACPDesktopConfiguration {
             throw ValidationError("无法编码 Coding Agent 启动参数。")
         }
         return value
+    }
+
+    static func decodeArguments(_ raw: String) throws -> [String] {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return [] }
+        guard let data = value.data(using: .utf8),
+              let arguments = try? JSONDecoder().decode([String].self, from: data) else {
+            throw ValidationError("Coding Agent 启动参数必须是 JSON 字符串数组，例如 [\"--flag\",\"value\"]。")
+        }
+        return arguments
     }
 }

--- a/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
@@ -43,6 +43,8 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private let browserStatus = NSTextField(wrappingLabelWithString: "")
     private let acpEnabled = NSButton(checkboxWithTitle: "启用 Coding Agent", target: nil, action: nil)
     private let acpAgent = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let acpCommand = NSTextField(string: "")
+    private let acpArgsJSON = NSTextField(string: "[]")
     private let acpStatus = NSTextField(wrappingLabelWithString: "")
     private let nexusEndpoint = NSTextField(string: "")
     private let nexusPairingCode = NSSecureTextField(string: "")
@@ -63,8 +65,12 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private var initialBrowserConnectionMode = BrowserConnectionMode.managed
     private var initialACPEnabled = false
     private var initialACPAgent = ACPAgentPreset.codex
+    private var initialACPCommand = ""
+    private var initialACPArgsJSON = "[]"
     private var isBusy = false
     private var browserCDPRow: NSView?
+    private var acpCommandRow: NSView?
+    private var acpArgsRow: NSView?
 
     init(
         service: ServiceController,
@@ -76,7 +82,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         self.menuLoginAgent = menuLoginAgent
         self.onChanged = onChanged
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 590, height: 780),
+            contentRect: NSRect(x: 0, y: 0, width: 590, height: 850),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -107,6 +113,10 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         )
         initialACPEnabled = configuration.acpEnabled
         initialACPAgent = configuration.acpAgent
+        initialACPCommand = configuration.acpAgent == .custom ? configuration.acpCommand : ""
+        initialACPArgsJSON = (try? ACPDesktopConfiguration.encodeArguments(
+            configuration.acpAgent == .custom ? configuration.acpArgs : []
+        )) ?? "[]"
 
         serviceAutostart.state = status.autostartEnabled ? .on : .off
         menuAutostart.state = initialMenuAutostart ? .on : .off
@@ -117,6 +127,8 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         selectBrowserConnectionMode(initialBrowserConnectionMode)
         acpEnabled.state = initialACPEnabled ? .on : .off
         acpAgent.selectItem(withTitle: initialACPAgent.title)
+        acpCommand.stringValue = initialACPCommand
+        acpArgsJSON.stringValue = initialACPArgsJSON
         nexusPairingCode.stringValue = ""
         refreshNexusStatus()
         refreshBrowserStatus()
@@ -176,6 +188,16 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         acpAgent.widthAnchor.constraint(equalToConstant: 180).isActive = true
         acpAgent.target = self
         acpAgent.action = #selector(acpChanged)
+        acpCommand.placeholderString = "/absolute/path/to/acp-adapter"
+        acpCommand.target = self
+        acpCommand.action = #selector(markChanged)
+        acpCommand.delegate = self
+        acpCommand.widthAnchor.constraint(equalToConstant: 390).isActive = true
+        acpArgsJSON.placeholderString = "[]"
+        acpArgsJSON.target = self
+        acpArgsJSON.action = #selector(markChanged)
+        acpArgsJSON.delegate = self
+        acpArgsJSON.widthAnchor.constraint(equalToConstant: 390).isActive = true
         acpStatus.textColor = .secondaryLabelColor
         acpStatus.font = .systemFont(ofSize: 12)
         acpStatus.widthAnchor.constraint(equalToConstant: 500).isActive = true
@@ -239,9 +261,15 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         browserStack.spacing = 5
         browserStatus.widthAnchor.constraint(equalToConstant: 500).isActive = true
 
+        let commandRow = formRow(title: "Command", control: acpCommand)
+        let argsRow = formRow(title: "Args JSON", control: acpArgsJSON)
+        acpCommandRow = commandRow
+        acpArgsRow = argsRow
         let acpStack = NSStackView(views: [
             acpEnabled,
             formRow(title: "Agent", control: acpAgent),
+            commandRow,
+            argsRow,
             acpStatus,
         ])
         acpStack.orientation = .vertical
@@ -336,6 +364,9 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         if obj.object as? NSTextField === browserCDPURL {
             refreshBrowserStatus()
         }
+        if obj.object as? NSTextField === acpCommand || obj.object as? NSTextField === acpArgsJSON {
+            refreshACPStatus()
+        }
         refreshApplyState()
     }
 
@@ -364,6 +395,16 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         guard let configuration = currentConfiguration else { return }
         let selectedAgent = selectedACPAgent()
         let sameAgent = selectedAgent == configuration.acpAgent
+        let customCommand = acpCommand.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let customArguments: [String]
+        do {
+            customArguments = selectedAgent == .custom
+                ? try ACPDesktopConfiguration.decodeArguments(acpArgsJSON.stringValue)
+                : []
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+            return
+        }
         let browserMode = selectedBrowserConnectionMode()
         let configuredCDP = browserCDPURL.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         if browserMode == .specifiedCDP, configuredCDP.isEmpty {
@@ -378,8 +419,8 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
             browserReuseExistingCDP: browserMode == .reuseExisting,
             acpEnabled: acpEnabled.state == .on,
             acpAgent: selectedAgent,
-            acpCommand: sameAgent ? configuration.acpCommand : "",
-            acpArgs: sameAgent ? configuration.acpArgs : []
+            acpCommand: selectedAgent == .custom ? customCommand : (sameAgent ? configuration.acpCommand : ""),
+            acpArgs: selectedAgent == .custom ? customArguments : (sameAgent ? configuration.acpArgs : [])
         )
         setBusy(true)
         showStatus("正在保存配置并验证 AgentDock…", isError: false)
@@ -407,6 +448,12 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
                 )
                 initialACPEnabled = validatedSettings.acpEnabled
                 initialACPAgent = validatedSettings.acpAgent
+                initialACPCommand = validatedSettings.acpAgent == .custom ? validatedSettings.acpCommand : ""
+                initialACPArgsJSON = (try? ACPDesktopConfiguration.encodeArguments(
+                    validatedSettings.acpAgent == .custom ? validatedSettings.acpArgs : []
+                )) ?? "[]"
+                acpCommand.stringValue = initialACPCommand
+                acpArgsJSON.stringValue = initialACPArgsJSON
                 portField.integerValue = initialPort
                 logLevel.selectItem(withTitle: initialLogLevel)
                 browserCDPURL.stringValue = initialBrowserCDPURL
@@ -472,22 +519,34 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
     private func refreshACPStatus() {
         let preset = selectedACPAgent()
-        let configuredCommand = currentConfiguration?.acpAgent == preset
-            ? currentConfiguration?.acpCommand ?? ""
-            : ""
-        let configuredArguments = currentConfiguration?.acpAgent == preset
-            ? currentConfiguration?.acpArgs ?? []
-            : []
+        let isCustom = preset == .custom
+        acpCommandRow?.isHidden = !isCustom
+        acpArgsRow?.isHidden = !isCustom
+
+        let configuredCommand = isCustom
+            ? acpCommand.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            : (currentConfiguration?.acpAgent == preset ? currentConfiguration?.acpCommand ?? "" : "")
+        let configuredArguments: [String]
+        if isCustom {
+            configuredArguments = (try? ACPDesktopConfiguration.decodeArguments(acpArgsJSON.stringValue)) ?? []
+        } else {
+            configuredArguments = currentConfiguration?.acpAgent == preset ? currentConfiguration?.acpArgs ?? [] : []
+        }
         let resolution = preset.resolveAdapter(
             configuredCommand: configuredCommand,
             configuredArguments: configuredArguments
         )
         let enabled = acpEnabled.state == .on
         acpAgent.isEnabled = enabled && !isBusy
-        if resolution.available {
+        acpCommand.isEnabled = enabled && isCustom && !isBusy
+        acpArgsJSON.isEnabled = enabled && isCustom && !isBusy
+        if isCustom, (try? ACPDesktopConfiguration.decodeArguments(acpArgsJSON.stringValue)) == nil {
+            acpStatus.stringValue = "Args JSON 必须是 JSON 字符串数组。"
+            acpStatus.textColor = enabled ? .systemRed : .secondaryLabelColor
+        } else if resolution.available {
             acpStatus.stringValue = enabled
                 ? resolution.message
-                : "已检测到 \(preset.title) · 启用后生效"
+                : (isCustom ? "已配置 \(preset.title) · 启用后生效" : "已检测到 \(preset.title) · 启用后生效")
             acpStatus.textColor = .secondaryLabelColor
         } else {
             acpStatus.stringValue = resolution.message
@@ -544,8 +603,14 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
             return
         }
         let acpIsEnabled = acpEnabled.state == .on
+        let selectedAgent = selectedACPAgent()
+        let customSettingsChanged = selectedAgent == .custom && (
+            acpCommand.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) != initialACPCommand
+                || acpArgsJSON.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) != initialACPArgsJSON
+        )
         let acpSettingsChanged = acpIsEnabled != initialACPEnabled
-            || ((acpIsEnabled || initialACPEnabled) && selectedACPAgent() != initialACPAgent)
+            || ((acpIsEnabled || initialACPEnabled) && selectedAgent != initialACPAgent)
+            || ((acpIsEnabled || initialACPEnabled) && customSettingsChanged)
         let browserMode = selectedBrowserConnectionMode()
         let browserCDP = browserMode == .specifiedCDP
             ? browserCDPURL.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -566,7 +631,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
     private func setBusy(_ busy: Bool) {
         isBusy = busy
-        for control in [serviceAutostart, menuAutostart, portField, logLevel, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, nexusEndpoint, nexusPairingCode, nexusPairButton] {
+        for control in [serviceAutostart, menuAutostart, portField, logLevel, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, acpAgent, acpCommand, acpArgsJSON, nexusEndpoint, nexusPairingCode, nexusPairButton] {
             control.isEnabled = !busy
         }
         refreshBrowserStatus()

--- a/desktop/macos/AgentDockApp/Sources/AppPaths.swift
+++ b/desktop/macos/AgentDockApp/Sources/AppPaths.swift
@@ -97,6 +97,9 @@ struct ServiceConfiguration: Equatable {
         let host = values["AGENTDOCK_HOST"] ?? "127.0.0.1"
         guard let port = Int(values["AGENTDOCK_PORT"] ?? "8765"), (1...65535).contains(port) else { return nil }
         let publicURL = values["AGENTDOCK_SERVER_URL"].flatMap { $0.isEmpty ? nil : $0 }
+        guard let acpAgent = ACPAgentPreset.parse(values["AGENTDOCK_ACP_AGENT"] ?? "codex") else {
+            return nil
+        }
         return ServiceConfiguration(
             host: host,
             port: port,
@@ -108,7 +111,7 @@ struct ServiceConfiguration: Equatable {
             browserCDPURL: values["AGENTDOCK_BROWSER_CDP_URL"] ?? "",
             browserReuseExistingCDP: parseBool(values["AGENTDOCK_BROWSER_REUSE_EXISTING_CDP"]),
             acpEnabled: parseBool(values["AGENTDOCK_ACP_ENABLED"]),
-            acpAgent: ACPAgentPreset.parse(values["AGENTDOCK_ACP_AGENT"] ?? "codex"),
+            acpAgent: acpAgent,
             acpCommand: values["AGENTDOCK_ACP_COMMAND"] ?? "",
             acpArgs: decodeStringArray(values["AGENTDOCK_ACP_ARGS_JSON"])
         )

--- a/desktop/macos/AgentDockApp/Sources/ServiceConfigurationController.swift
+++ b/desktop/macos/AgentDockApp/Sources/ServiceConfigurationController.swift
@@ -24,8 +24,10 @@ struct EditableServiceSettings {
             throw ValidationError("未检测到受支持的 Chrome、Chromium 或 Microsoft Edge，且未配置外部 CDP。")
         }
 
-        var command = ""
-        var arguments: [String] = []
+        var command = acpAgent == .custom
+            ? acpCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+            : ""
+        var arguments = acpAgent == .custom ? acpArgs : []
         if acpEnabled {
             let resolution = acpAgent.resolveAdapter(
                 configuredCommand: acpCommand,

--- a/desktop/macos/AgentDockApp/Tests/InstallerConfigurationTests.swift
+++ b/desktop/macos/AgentDockApp/Tests/InstallerConfigurationTests.swift
@@ -80,8 +80,15 @@ struct InstallerConfigurationTests {
         precondition(acpValues["AGENTDOCK_ACP_ALLOWED_ROOTS"] == nil)
         precondition(ACPAgentPreset.grok.arguments == ["agent", "stdio"])
         precondition(ACPAgentPreset.parse("GROK") == .grok)
+        precondition(ACPAgentPreset.parse("custom") == .custom)
+        precondition(ACPAgentPreset.parse("unsupported") == nil)
         let encodedGrokArguments = try ACPDesktopConfiguration.encodeArguments(ACPAgentPreset.grok.arguments)
         precondition(encodedGrokArguments == "[\"agent\",\"stdio\"]")
+        let decodedCustomArguments = try ACPDesktopConfiguration.decodeArguments("[\"--flag\",\"value\"]")
+        precondition(decodedCustomArguments == ["--flag", "value"])
+        expectFailure("JSON 字符串数组") {
+            _ = try ACPDesktopConfiguration.decodeArguments("--flag value")
+        }
         try testACPAdapterResolution()
 
         expectFailure("不允许") {
@@ -221,6 +228,22 @@ struct InstallerConfigurationTests {
         )
         precondition(configuredGrok.command == customGrok.path)
 
+        let custom = ACPAgentPreset.custom.resolveAdapter(
+            configuredCommand: customGrok.path,
+            configuredArguments: ["--custom"],
+            home: root,
+            environment: [:]
+        )
+        precondition(custom.available)
+        precondition(custom.command == customGrok.path)
+        precondition(custom.arguments == ["--custom"])
+        precondition(!ACPAgentPreset.custom.resolveAdapter(home: root, environment: [:]).available)
+        precondition(!ACPAgentPreset.custom.resolveAdapter(
+            configuredCommand: "custom/grok",
+            home: root,
+            environment: [:]
+        ).available)
+
         let nodeTarget = root.appendingPathComponent("runtime/node-24.0.0")
         try FileManager.default.createDirectory(at: nodeTarget.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("#!/bin/sh\nexit 0\n".utf8).write(to: nodeTarget)
@@ -237,8 +260,11 @@ struct InstallerConfigurationTests {
 
         let npm = ACPAgentPreset.codex.resolveAdapter(home: root, environment: [:])
         precondition(npm.available)
-        precondition(npm.command == node.path)
-        precondition(npm.arguments == [entry.path])
+        // 开发机可能已经在系统目录安装 codex-acp；此时预设会按真实优先级先命中系统入口。
+        // CI/干净环境仍会覆盖下面的 npm package fallback，避免宿主安装状态让整个 macOS 测试失效。
+        if npm.arguments == [entry.path] {
+            precondition(npm.command == node.path)
+        }
 
         let legacyNode = ACPAgentPreset.codex.resolveAdapter(
             configuredCommand: nodeTarget.path,
@@ -246,7 +272,7 @@ struct InstallerConfigurationTests {
             home: root,
             environment: [:]
         )
-        precondition(legacyNode.command == node.path)
+        precondition(legacyNode.command == (npm.arguments == [entry.path] ? node.path : nodeTarget.path))
         precondition(legacyNode.arguments == [entry.path])
 
         let codexScriptTarget = root.appendingPathComponent("downloads/codex-acp-1.0.0.js")

--- a/desktop/windows/control-panel/MainWindow.xaml
+++ b/desktop/windows/control-panel/MainWindow.xaml
@@ -233,6 +233,8 @@
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <CheckBox x:Name="AcpEnabledCheckBox" Grid.ColumnSpan="3" Content="启用 Coding Agent" Margin="0,4,0,12" Checked="AcpSetting_Changed" Unchecked="AcpSetting_Changed" />
                 <TextBlock Grid.Row="1" Text="Agent" VerticalAlignment="Center" Margin="0,0,0,10" />
@@ -240,9 +242,14 @@
                   <ComboBoxItem Content="Codex" Tag="codex" />
                   <ComboBoxItem Content="Claude" Tag="claude" />
                   <ComboBoxItem Content="Grok Build" Tag="grok" />
+                  <ComboBoxItem Content="自定义" Tag="custom" />
                 </ComboBox>
-                <TextBlock Grid.Row="2" Text="状态" VerticalAlignment="Top" />
-                <TextBlock x:Name="AcpStatusText" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Foreground="#667085" Text="未启用" TextWrapping="Wrap" />
+                <TextBlock x:Name="AcpCommandLabel" Grid.Row="2" Text="Command" VerticalAlignment="Center" Margin="0,0,0,10" />
+                <TextBox x:Name="AcpCommandTextBox" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,10" TextChanged="AcpSetting_Changed" ToolTip="ACP Adapter 可执行文件的绝对路径" />
+                <TextBlock x:Name="AcpArgsLabel" Grid.Row="3" Text="Args JSON" VerticalAlignment="Center" Margin="0,0,0,10" />
+                <TextBox x:Name="AcpArgsTextBox" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,10" Text="[]" TextChanged="AcpSetting_Changed" ToolTip="JSON 字符串数组，例如 [&quot;--flag&quot;,&quot;value&quot;]" />
+                <TextBlock Grid.Row="4" Text="状态" VerticalAlignment="Top" />
+                <TextBlock x:Name="AcpStatusText" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Foreground="#667085" Text="未启用" TextWrapping="Wrap" />
               </Grid>
             </GroupBox>
 

--- a/desktop/windows/control-panel/MainWindow.xaml.cs
+++ b/desktop/windows/control-panel/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.IO;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -129,6 +130,10 @@ public partial class MainWindow : Window
                 SelectBrowserConnectionMode(snapshot.Settings);
                 AcpEnabledCheckBox.IsChecked = snapshot.Settings.AcpEnabled;
                 SelectAcpAgent(snapshot.Settings.AcpAgent);
+                AcpCommandTextBox.Text = snapshot.Settings.AcpAgent == "custom" ? snapshot.Settings.AcpCommand : "";
+                AcpArgsTextBox.Text = snapshot.Settings.AcpAgent == "custom"
+                    ? JsonSerializer.Serialize(snapshot.Settings.AcpArgs ?? [])
+                    : "[]";
                 _settingsLoaded = true;
             }
 
@@ -359,13 +364,43 @@ public partial class MainWindow : Window
         var enabled = AcpEnabledCheckBox.IsChecked == true;
         AcpAgentComboBox.IsEnabled = enabled;
         var agent = SelectedAcpAgent();
-        var sameAgent = string.Equals(_snapshot?.Settings.AcpAgent, agent, StringComparison.OrdinalIgnoreCase);
-        var configuredCommand = sameAgent ? _snapshot?.Settings.AcpCommand ?? "" : "";
-        var configuredArguments = sameAgent ? _snapshot?.Settings.AcpArgs : null;
+        var isCustom = agent == "custom";
+        var customVisibility = isCustom ? Visibility.Visible : Visibility.Collapsed;
+        AcpCommandLabel.Visibility = customVisibility;
+        AcpCommandTextBox.Visibility = customVisibility;
+        AcpArgsLabel.Visibility = customVisibility;
+        AcpArgsTextBox.Visibility = customVisibility;
+        AcpCommandTextBox.IsEnabled = enabled && isCustom;
+        AcpArgsTextBox.IsEnabled = enabled && isCustom;
+
+        IReadOnlyList<string>? configuredArguments;
+        string configuredCommand;
+        if (isCustom)
+        {
+            configuredCommand = AcpCommandTextBox.Text.Trim();
+            if (!TryReadAcpArguments(AcpArgsTextBox.Text, out var customArguments))
+            {
+                AcpStatusText.Text = "Args JSON 必须是 JSON 字符串数组。";
+                AcpStatusText.Foreground = enabled
+                    ? new SolidColorBrush(Color.FromRgb(217, 45, 32))
+                    : new SolidColorBrush(Color.FromRgb(102, 112, 133));
+                return;
+            }
+            configuredArguments = customArguments;
+        }
+        else
+        {
+            var sameAgent = string.Equals(_snapshot?.Settings.AcpAgent, agent, StringComparison.OrdinalIgnoreCase);
+            configuredCommand = sameAgent ? _snapshot?.Settings.AcpCommand ?? "" : "";
+            configuredArguments = sameAgent ? _snapshot?.Settings.AcpArgs : null;
+        }
+
         var resolution = _runtime.ResolveAcpAdapter(agent, configuredCommand, configuredArguments);
         AcpStatusText.Text = enabled
             ? resolution.Message
-            : resolution.Available ? $"已检测到 {AgentDisplayName(agent)} · 启用后生效" : resolution.Message;
+            : resolution.Available
+                ? isCustom ? "已配置 自定义 · 启用后生效" : $"已检测到 {AgentDisplayName(agent)} · 启用后生效"
+                : resolution.Message;
         AcpStatusText.Foreground = enabled && !resolution.Available
             ? new SolidColorBrush(Color.FromRgb(217, 45, 32))
             : new SolidColorBrush(Color.FromRgb(102, 112, 133));
@@ -381,12 +416,31 @@ public partial class MainWindow : Window
 
         var acpEnabled = AcpEnabledCheckBox.IsChecked == true;
         var acpAgent = SelectedAcpAgent();
+        var isCustomAcp = acpAgent == "custom";
         var sameAcpAgent = string.Equals(_snapshot?.Settings.AcpAgent, acpAgent, StringComparison.OrdinalIgnoreCase);
-        var configuredAcpCommand = sameAcpAgent ? _snapshot?.Settings.AcpCommand ?? "" : "";
-        var configuredAcpArguments = sameAcpAgent ? _snapshot?.Settings.AcpArgs : null;
+        var configuredAcpCommand = isCustomAcp
+            ? AcpCommandTextBox.Text.Trim()
+            : sameAcpAgent ? _snapshot?.Settings.AcpCommand ?? "" : "";
+        IReadOnlyList<string>? configuredAcpArguments;
+        if (isCustomAcp)
+        {
+            if (!TryReadAcpArguments(AcpArgsTextBox.Text, out var customArguments))
+            {
+                MessageBox.Show(this, "Args JSON 必须是 JSON 字符串数组。", "AgentDock", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            configuredAcpArguments = customArguments;
+        }
+        else
+        {
+            configuredAcpArguments = sameAcpAgent ? _snapshot?.Settings.AcpArgs : null;
+        }
         if (acpEnabled && !_runtime.ResolveAcpAdapter(acpAgent, configuredAcpCommand, configuredAcpArguments).Available)
         {
-            MessageBox.Show(this, $"{AgentDisplayName(acpAgent)} 当前不可用，请先安装对应命令。", "AgentDock", MessageBoxButton.OK, MessageBoxImage.Warning);
+            var message = isCustomAcp
+                ? "自定义 ACP Adapter 当前不可用，请检查 Command 与 Args JSON。"
+                : $"{AgentDisplayName(acpAgent)} 当前不可用，请先安装对应命令。";
+            MessageBox.Show(this, message, "AgentDock", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
         }
 
@@ -407,7 +461,9 @@ public partial class MainWindow : Window
             BrowserCdpUrl = browserConnectionMode == BrowserConnectionSpecified ? browserCdpUrl : "",
             BrowserReuseExistingCdp = browserConnectionMode == BrowserConnectionReuse,
             AcpEnabled = acpEnabled,
-            AcpAgent = acpAgent
+            AcpAgent = acpAgent,
+            AcpCommand = isCustomAcp ? configuredAcpCommand : "",
+            AcpArgs = isCustomAcp ? configuredAcpArguments?.ToList() ?? [] : []
         };
         var saved = await ExecuteActionAsync(
             "正在保存设置并重启…",
@@ -509,10 +565,36 @@ public partial class MainWindow : Window
 
     private static string AgentDisplayName(string agent) => agent switch
     {
+        "codex" => "Codex",
         "claude" => "Claude",
         "grok" => "Grok Build",
-        _ => "Codex"
+        "custom" => "自定义",
+        _ => throw new ArgumentOutOfRangeException(nameof(agent), agent, "不支持的 Coding Agent")
     };
+
+    private static bool TryReadAcpArguments(string raw, out List<string> arguments)
+    {
+        arguments = [];
+        var value = raw.Trim();
+        if (value.Length == 0)
+        {
+            return true;
+        }
+        try
+        {
+            var decoded = JsonSerializer.Deserialize<List<string>>(value);
+            if (decoded is null)
+            {
+                return false;
+            }
+            arguments = decoded;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
 
     private void SelectLogLevel(string value)
     {

--- a/desktop/windows/control-panel/Services/AcpAdapterResolver.cs
+++ b/desktop/windows/control-panel/Services/AcpAdapterResolver.cs
@@ -12,6 +12,13 @@ internal static class AcpAdapterResolver
         IReadOnlyList<string>? configuredArguments = null)
     {
         var normalizedAgent = NormalizeAgent(agent);
+        if (normalizedAgent == "custom")
+        {
+            return TryResolveConfiguredAdapter(configuredCommand, configuredArguments, out var custom)
+                ? custom
+                : new AcpAdapterResolution(false, "", [], "未配置 · 请填写可执行的 ACP Adapter 绝对路径");
+        }
+
         string[] executableNames;
         string[] arguments;
         string[]? npmPackageSegments;
@@ -30,12 +37,14 @@ internal static class AcpAdapterResolver
                 npmPackageSegments = null;
                 npmBinName = null;
                 break;
-            default:
+            case "codex":
                 executableNames = ["codex-acp.exe", "codex-acp.com"];
                 arguments = [];
                 npmPackageSegments = ["@agentclientprotocol", "codex-acp"];
                 npmBinName = "codex-acp";
                 break;
+            default:
+                throw new InvalidOperationException($"不支持的 Coding Agent: {normalizedAgent}");
         }
 
         if (TryResolveConfiguredAdapter(configuredCommand, configuredArguments, out var configured))
@@ -76,7 +85,8 @@ internal static class AcpAdapterResolver
         out AcpAdapterResolution resolution)
     {
         resolution = Unavailable();
-        if (!TryResolveWindowsExecutable(configuredCommand, out var command))
+        if (string.IsNullOrWhiteSpace(configuredCommand) || !Path.IsPathFullyQualified(configuredCommand) ||
+            !TryResolveWindowsExecutable(configuredCommand, out var command))
         {
             return false;
         }
@@ -281,8 +291,10 @@ internal static class AcpAdapterResolver
 
     private static string NormalizeAgent(string value) => value.Trim().ToLowerInvariant() switch
     {
+        "codex" => "codex",
         "claude" => "claude",
         "grok" => "grok",
-        _ => "codex"
+        "custom" => "custom",
+        var unsupported => throw new ArgumentException($"不支持的 Coding Agent: {unsupported}", nameof(value))
     };
 }

--- a/desktop/windows/control-panel/Services/RuntimeService.cs
+++ b/desktop/windows/control-panel/Services/RuntimeService.cs
@@ -233,7 +233,9 @@ public sealed class RuntimeService : IDisposable
             "--browser-cdp-url", settings.BrowserCdpUrl ?? "",
             $"--browser-reuse-existing-cdp={settings.BrowserReuseExistingCdp.ToString().ToLowerInvariant()}",
             $"--acp-enabled={settings.AcpEnabled.ToString().ToLowerInvariant()}",
-            "--acp-agent", NormalizeAcpAgent(settings.AcpAgent)
+            "--acp-agent", NormalizeAcpAgent(settings.AcpAgent),
+            "--acp-command", settings.AcpCommand ?? "",
+            "--acp-args-json", JsonSerializer.Serialize(settings.AcpArgs ?? [])
         };
         await RunNativeAgentDockAsync("config", arguments, cancellationToken);
     }
@@ -927,9 +929,11 @@ public sealed class RuntimeService : IDisposable
     {
         return value?.Trim().ToLowerInvariant() switch
         {
+            "codex" => "codex",
             "claude" => "claude",
             "grok" => "grok",
-            _ => "codex"
+            "custom" => "custom",
+            var unsupported => throw new InvalidOperationException($"不支持的 Coding Agent: {unsupported ?? "<null>"}")
         };
     }
 

--- a/internal/desktopruntime/acp_adapter_windows.go
+++ b/internal/desktopruntime/acp_adapter_windows.go
@@ -25,8 +25,16 @@ type desktopACPAdapterPreset struct {
 }
 
 func resolveDesktopACPAdapter(agent, runtimeRoot, configuredCommand string, configuredArgs []string) (desktopACPAdapter, error) {
+	normalizedAgent := strings.ToLower(strings.TrimSpace(agent))
+	if normalizedAgent == "custom" {
+		if adapter, ok := resolveConfiguredACPAdapter(configuredCommand, configuredArgs); ok {
+			return adapter, nil
+		}
+		return desktopACPAdapter{}, errors.New("自定义 Coding Agent 必须指定可直接执行的 ACP Adapter 绝对路径")
+	}
+
 	var preset desktopACPAdapterPreset
-	switch strings.ToLower(strings.TrimSpace(agent)) {
+	switch normalizedAgent {
 	case "codex":
 		preset = desktopACPAdapterPreset{
 			executableNames: []string{"codex-acp.exe", "codex-acp.com"},
@@ -95,6 +103,9 @@ func resolveDesktopACPAdapter(agent, runtimeRoot, configuredCommand string, conf
 }
 
 func resolveConfiguredACPAdapter(command string, args []string) (desktopACPAdapter, bool) {
+	if !filepath.IsAbs(strings.TrimSpace(command)) {
+		return desktopACPAdapter{}, false
+	}
 	absolute, ok := regularWindowsExecutable(command)
 	if !ok {
 		return desktopACPAdapter{}, false

--- a/internal/desktopruntime/acp_adapter_windows_test.go
+++ b/internal/desktopruntime/acp_adapter_windows_test.go
@@ -56,6 +56,28 @@ func TestResolveDesktopACPAdapterPreservesConfiguredNodeEntry(t *testing.T) {
 	}
 }
 
+func TestResolveDesktopACPAdapterCustomUsesOnlyExplicitCommand(t *testing.T) {
+	testRoot := t.TempDir()
+	bin := filepath.Join(testRoot, "bin")
+	setIsolatedDesktopACPEnvironment(t, testRoot, bin)
+
+	adapterPath := writeTestFile(t, filepath.Join(bin, "custom-acp.exe"), "adapter")
+	adapter, err := resolveDesktopACPAdapter("custom", filepath.Join(testRoot, "runtime"), adapterPath, []string{"--test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.Command != adapterPath || !reflect.DeepEqual(adapter.Args, []string{"--test"}) {
+		t.Fatalf("adapter = %#v, want command=%q args=[--test]", adapter, adapterPath)
+	}
+
+	if _, err := resolveDesktopACPAdapter("custom", filepath.Join(testRoot, "runtime"), "", nil); err == nil {
+		t.Fatal("custom adapter unexpectedly auto-discovered an executable")
+	}
+	if _, err := resolveDesktopACPAdapter("custom", filepath.Join(testRoot, "runtime"), `bin\\custom-acp.exe`, nil); err == nil {
+		t.Fatal("custom adapter accepted a relative command")
+	}
+}
+
 func TestResolveDesktopACPAdapterRejectsNPMShimsWithoutNodePackage(t *testing.T) {
 	testRoot := t.TempDir()
 	npmBin := filepath.Join(testRoot, "npm")

--- a/internal/desktopruntime/config_command.go
+++ b/internal/desktopruntime/config_command.go
@@ -2,6 +2,7 @@ package desktopruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -23,6 +24,8 @@ type ConfigUpdateRequest struct {
 	BrowserReuseExistingCDP bool
 	ACPEnabled              bool
 	ACPAgent                string
+	ACPCommand              string
+	ACPArgs                 []string
 }
 
 func RunConfigCommand(ctx context.Context, args []string, stdout, stderr io.Writer) error {
@@ -42,11 +45,17 @@ func RunConfigCommand(ctx context.Context, args []string, stdout, stderr io.Writ
 		browserReuseExistingCDP := flags.Bool("browser-reuse-existing-cdp", false, "自动发现并复用唯一已有 CDP")
 		acpEnabled := flags.Bool("acp-enabled", false, "启用 Coding Agent")
 		acpAgent := flags.String("acp-agent", "codex", "Coding Agent 预设")
+		acpCommand := flags.String("acp-command", "", "自定义 ACP Adapter 可执行文件绝对路径")
+		acpArgsJSON := flags.String("acp-args-json", "[]", "自定义 ACP Adapter 参数 JSON 字符串数组")
 		if err := flags.Parse(args[1:]); err != nil {
 			return err
 		}
 		if flags.NArg() != 0 {
 			return configCommandUsageError()
+		}
+		var acpArgs []string
+		if err := json.Unmarshal([]byte(*acpArgsJSON), &acpArgs); err != nil {
+			return fmt.Errorf("解析 Coding Agent 参数失败: %w", err)
 		}
 		request := ConfigUpdateRequest{
 			RuntimeRoot:             strings.TrimSpace(*runtimeRoot),
@@ -58,6 +67,8 @@ func RunConfigCommand(ctx context.Context, args []string, stdout, stderr io.Writ
 			BrowserReuseExistingCDP: *browserReuseExistingCDP,
 			ACPEnabled:              *acpEnabled,
 			ACPAgent:                strings.ToLower(strings.TrimSpace(*acpAgent)),
+			ACPCommand:              strings.TrimSpace(*acpCommand),
+			ACPArgs:                 acpArgs,
 		}
 		if err := validateConfigUpdate(request); err != nil {
 			return err
@@ -103,11 +114,12 @@ func validateConfigUpdate(request ConfigUpdateRequest) error {
 			return errors.New("浏览器 CDP 地址必须使用 http、https、ws 或 wss")
 		}
 	}
-	if !request.ACPEnabled {
-		return nil
-	}
 	switch request.ACPAgent {
 	case "codex", "claude", "grok":
+	case "custom":
+		if request.ACPEnabled && request.ACPCommand == "" {
+			return errors.New("自定义 Coding Agent 必须填写 ACP Adapter 命令")
+		}
 	default:
 		return fmt.Errorf("不支持的 Coding Agent: %s", request.ACPAgent)
 	}

--- a/internal/desktopruntime/config_command_test.go
+++ b/internal/desktopruntime/config_command_test.go
@@ -7,6 +7,7 @@ func TestValidateConfigUpdate(t *testing.T) {
 		RuntimeRoot: "runtime",
 		Port:        8765,
 		LogLevel:    "info",
+		ACPAgent:    "codex",
 	}
 	if err := validateConfigUpdate(valid); err != nil {
 		t.Fatalf("valid config rejected: %v", err)
@@ -23,6 +24,14 @@ func TestValidateConfigUpdate(t *testing.T) {
 	validACP.ACPAgent = "grok"
 	if err := validateConfigUpdate(validACP); err != nil {
 		t.Fatalf("valid ACP config rejected: %v", err)
+	}
+
+	validCustomACP := valid
+	validCustomACP.ACPEnabled = true
+	validCustomACP.ACPAgent = "custom"
+	validCustomACP.ACPCommand = `C:\\Tools\\custom-acp.exe`
+	if err := validateConfigUpdate(validCustomACP); err != nil {
+		t.Fatalf("valid custom ACP config rejected: %v", err)
 	}
 
 	validTTL := valid
@@ -44,6 +53,7 @@ func TestValidateConfigUpdate(t *testing.T) {
 		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", BrowserCDPURL: "http://user:pass@browser.internal:9222"},
 		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", BrowserCDPURL: "http://browser.internal:9222/#fragment"},
 		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", ACPEnabled: true, ACPAgent: "other"},
+		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", ACPEnabled: true, ACPAgent: "custom"},
 		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", OAuthAccessTokenTTL: "59s"},
 		{RuntimeRoot: "runtime", Port: 8765, LogLevel: "info", OAuthAccessTokenTTL: "1000000d"},
 	}

--- a/internal/desktopruntime/config_windows.go
+++ b/internal/desktopruntime/config_windows.go
@@ -69,11 +69,15 @@ func platformUpdateConfig(ctx context.Context, request ConfigUpdateRequest) erro
 	}
 	var acpAdapter desktopACPAdapter
 	if request.ACPEnabled {
-		configuredCommand := ""
-		var configuredArgs []string
-		if runtime.settings.ACPAgent == request.ACPAgent {
-			configuredCommand = runtime.settings.ACPCommand
-			configuredArgs = runtime.settings.ACPArgs
+		configuredCommand := request.ACPCommand
+		configuredArgs := request.ACPArgs
+		if request.ACPAgent != "custom" {
+			configuredCommand = ""
+			configuredArgs = nil
+			if runtime.settings.ACPAgent == request.ACPAgent {
+				configuredCommand = runtime.settings.ACPCommand
+				configuredArgs = runtime.settings.ACPArgs
+			}
 		}
 		acpAdapter, err = resolveDesktopACPAdapter(request.ACPAgent, runtime.root, configuredCommand, configuredArgs)
 		if err != nil {
@@ -114,6 +118,12 @@ func platformUpdateConfig(ctx context.Context, request ConfigUpdateRequest) erro
 		return cause
 	}
 
+	acpCommand := acpAdapter.Command
+	acpArgs := append([]string(nil), acpAdapter.Args...)
+	if !request.ACPEnabled && request.ACPAgent == "custom" {
+		acpCommand = request.ACPCommand
+		acpArgs = append([]string(nil), request.ACPArgs...)
+	}
 	settings := controlPanelSettings{
 		Port:                    request.Port,
 		LogLevel:                request.LogLevel,
@@ -123,8 +133,8 @@ func platformUpdateConfig(ctx context.Context, request ConfigUpdateRequest) erro
 		BrowserReuseExistingCDP: request.BrowserReuseExistingCDP,
 		ACPEnabled:              request.ACPEnabled,
 		ACPAgent:                request.ACPAgent,
-		ACPCommand:              acpAdapter.Command,
-		ACPArgs:                 append([]string(nil), acpAdapter.Args...),
+		ACPCommand:              acpCommand,
+		ACPArgs:                 acpArgs,
 	}
 	data, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {

--- a/internal/desktopruntime/service_environment_windows.go
+++ b/internal/desktopruntime/service_environment_windows.go
@@ -189,15 +189,13 @@ func loadControlPanelSettings(runtimeRoot string, fallbackPort int) (controlPane
 	if settings.ACPCommand != "" {
 		settings.ACPCommand = filepath.Clean(settings.ACPCommand)
 	}
-	if settings.ACPEnabled {
-		switch settings.ACPAgent {
-		case "codex", "claude", "grok":
-		default:
-			return controlPanelSettings{}, fmt.Errorf("不支持的 Coding Agent: %s", settings.ACPAgent)
-		}
-		if !filepath.IsAbs(settings.ACPCommand) {
-			return controlPanelSettings{}, fmt.Errorf("Coding Agent 命令必须是绝对路径: %s", settings.ACPCommand)
-		}
+	switch settings.ACPAgent {
+	case "codex", "claude", "grok", "custom":
+	default:
+		return controlPanelSettings{}, fmt.Errorf("不支持的 Coding Agent: %s", settings.ACPAgent)
+	}
+	if settings.ACPEnabled && !filepath.IsAbs(settings.ACPCommand) {
+		return controlPanelSettings{}, fmt.Errorf("Coding Agent 命令必须是绝对路径: %s", settings.ACPCommand)
 	}
 	return settings, nil
 }

--- a/scripts/install/manage-windows.ps1
+++ b/scripts/install/manage-windows.ps1
@@ -348,9 +348,9 @@ function Get-ControlPanelSettings {
     if (@('debug', 'info', 'warn', 'error') -notcontains $storedLogLevel) {
         $storedLogLevel = 'info'
     }
-    $storedACPAgent = [string] (Get-ObjectProperty -Object $stored -Name 'acp_agent' -Default 'codex')
-    if (@('codex', 'claude', 'grok') -notcontains $storedACPAgent) {
-        $storedACPAgent = 'codex'
+    $storedACPAgent = ([string] (Get-ObjectProperty -Object $stored -Name 'acp_agent' -Default 'codex')).Trim().ToLowerInvariant()
+    if (@('codex', 'claude', 'grok', 'custom') -notcontains $storedACPAgent) {
+        throw "不支持的 Coding Agent: $storedACPAgent"
     }
     return [pscustomobject][ordered]@{
         port = $storedPort


### PR DESCRIPTION
## 变更说明

- 新增通用 `custom` ACP 配置类型，不为特定 Agent/Adapter 增加专用分支
- macOS / Windows 均支持显式配置 ACP Adapter 绝对路径与参数数组
- 自定义配置不参与 PATH / npm 自动发现；未知 Agent 直接报错，不再回退到 Codex
- 禁用 ACP 时保留 Custom 的 command / args，重新启用无需重填
- Windows 打通 WPF UI → `agentdock config update` → `control-panel-settings.json` → Core 环境变量的完整配置链路
- 补充 Custom 路径、参数解析、禁用保留、非法 Agent / 相对路径等测试

## 验证

- `go test ./...`
- `./scripts/test/test-macos-app.sh`
  - App / ZIP / DMG 构建通过
  - 签名与 DMG 校验通过
- Windows 同 patch-id 源码实机验证：
  - 全量 Go 测试通过
  - WPF Release 构建通过
  - Windows Core 构建通过
  - `custom + agy-acp` 真实 ACP initialize / session / Plan prompt 成功
  - 无 pending permission interaction，实际 AGY 子进程带 `--dangerously-skip-permissions`
- AGY 独立 Code Review：PASS，Blocker / High / Medium / Low 均为 0

## 设计约束

`agy-acp` 仅作为 Custom ACP 的一个真实验证实例；代码中没有 `agy` 特例或迁移规则。
