### PR TITLE
fix(command): 支持显式透传宿主环境变量

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ AgentDock exposes tools over MCP Streamable HTTP. The exact client syntax varies
 - Output truncation and sensitive-value redaction
 - macOS, Linux, Windows, and WSL support
 
+#### Forward selected host environment variables
+
+`exec_command` intentionally starts from a small environment instead of inheriting the complete AgentDock process environment. When a host runtime needs additional variables, configure an explicit child-to-host mapping:
+
+```bash
+export AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON='{"NIX_LD":"NIX_LD","NIX_LD_LIBRARY_PATH":"NIX_LD_LIBRARY_PATH"}'
+```
+
+Only mapped variables are copied. A missing host variable is skipped. Skill environment values override the mapped host value, and an explicit `exec_command.env` value overrides both.
+
+For a systemd or OpenRC deployment, the source variables must also exist in the AgentDock service process environment. The mapping does not read a user's login shell. For example, a NixOS service using `nix-ld` should provide the current `NIX_LD` and `NIX_LD_LIBRARY_PATH` values through the service configuration together with the mapping above. Prefer declarative NixOS service configuration over snapshotting generation-specific `/nix/store` paths into a long-lived file.
+
 ### Git and GitHub
 
 - Read repository status, diffs, and history

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,6 +122,18 @@ AgentDock 通过 MCP Streamable HTTP 提供工具能力。下面是一个通用�
 - 输出截断和敏感信息脱敏
 - macOS、Linux、Windows 与 WSL 支持
 
+#### 显式透传宿主环境变量
+
+`exec_command` 默认只使用精简环境，不会完整继承 AgentDock 进程环境。宿主运行环境确实依赖额外变量时，可以配置“子进程变量名 -> AgentDock 宿主进程变量名”的显式映射：
+
+```bash
+export AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON='{"NIX_LD":"NIX_LD","NIX_LD_LIBRARY_PATH":"NIX_LD_LIBRARY_PATH"}'
+```
+
+只有显式声明的变量会被复制；宿主变量不存在时会跳过。Skill 环境变量可以覆盖宿主映射值，单次 `exec_command.env` 又可以继续覆盖 Skill 环境。
+
+使用 systemd 或 OpenRC 部署时，映射来源是 **AgentDock 服务进程自身的环境**，不会读取某个用户的登录 Shell。以启用 `nix-ld` 的 NixOS 为例，需要同时通过服务配置向 AgentDock 注入当前的 `NIX_LD`、`NIX_LD_LIBRARY_PATH`，再配置上述映射。NixOS 建议通过声明式服务配置提供这些值，不要把某一代 `/nix/store` 的绝对路径长期快照到手写配置里。
+
 ### Git 与 GitHub
 
 - 仓库状态、差异和提交记录读取

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ const (
 type Config struct {
 	AgentDockHome                string
 	AgentDockDefaultDir          string
+	CommandEnvFromEnv            map[string]string
 	Host                         string
 	Port                         int
 	AuthToken                    string
@@ -84,6 +85,10 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	commandEnvFromEnv, err := getenvStringMapJSON("AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON")
+	if err != nil {
+		return Config{}, err
+	}
 	acpEnabled, err := getenvBool("AGENTDOCK_ACP_ENABLED", false)
 	if err != nil {
 		return Config{}, err
@@ -117,6 +122,7 @@ func FromEnv() (Config, error) {
 	return Config{
 		AgentDockHome:                strings.TrimSpace(os.Getenv("AGENTDOCK_HOME")),
 		AgentDockDefaultDir:          strings.TrimSpace(os.Getenv("AGENTDOCK_DEFAULT_DIR")),
+		CommandEnvFromEnv:            commandEnvFromEnv,
 		Host:                         getenv("AGENTDOCK_HOST", "127.0.0.1"),
 		Port:                         port,
 		AuthToken:                    os.Getenv("AGENTDOCK_AUTH_TOKEN"),
@@ -242,6 +248,9 @@ func (c *Config) Normalize() error {
 		if c.Instructions == "" {
 			return fmt.Errorf("InstructionsFile must contain non-empty instructions: %s", c.InstructionsFile)
 		}
+	}
+	if err := validateEnvironmentMapping(c.CommandEnvFromEnv); err != nil {
+		return fmt.Errorf("AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON: %w", err)
 	}
 	if err := c.normalizeACP(); err != nil {
 		return err
@@ -413,7 +422,7 @@ func (c *Config) normalizeACP() error {
 	if err := validateACPArguments(c.ACPArgs); err != nil {
 		return fmt.Errorf("AGENTDOCK_ACP_ARGS_JSON: %w", err)
 	}
-	if err := validateACPEnvironmentMapping(c.ACPEnvFromEnv); err != nil {
+	if err := validateEnvironmentMapping(c.ACPEnvFromEnv); err != nil {
 		return fmt.Errorf("AGENTDOCK_ACP_ENV_FROM_ENV_JSON: %w", err)
 	}
 	c.ACPCommand = filepath.Clean(strings.TrimSpace(c.ACPCommand))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,31 @@ func TestNormalizeDefaultsToUserDirectories(t *testing.T) {
 	}
 }
 
+func TestFromEnvParsesCommandEnvironmentMapping(t *testing.T) {
+	t.Setenv("AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON", `{"NIX_LD":"NIX_LD","CHILD_TOKEN":"HOST_TOKEN"}`)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if cfg.CommandEnvFromEnv["NIX_LD"] != "NIX_LD" || cfg.CommandEnvFromEnv["CHILD_TOKEN"] != "HOST_TOKEN" {
+		t.Fatalf("CommandEnvFromEnv = %#v", cfg.CommandEnvFromEnv)
+	}
+}
+
+func TestCommandEnvironmentMappingRejectsInvalidNames(t *testing.T) {
+	t.Setenv("AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON", `{"BAD-NAME":"HOST_TOKEN"}`)
+	if _, err := FromEnv(); err == nil || !strings.Contains(err.Error(), "AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON") {
+		t.Fatalf("FromEnv() error = %v, want command env mapping validation error", err)
+	}
+
+	setTestUserHome(t, t.TempDir())
+	cfg := Config{CommandEnvFromEnv: map[string]string{"CHILD_TOKEN": "BAD-HOST"}}
+	if err := cfg.Normalize(); err == nil || !strings.Contains(err.Error(), "AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON") {
+		t.Fatalf("Normalize() error = %v, want command env mapping validation error", err)
+	}
+}
+
 func TestFromEnvIgnoresOldDirectoryConfig(t *testing.T) {
 	home := t.TempDir()
 	setTestUserHome(t, home)

--- a/internal/config/environment_mapping.go
+++ b/internal/config/environment_mapping.go
@@ -16,13 +16,13 @@ func getenvStringMapJSON(key string) (map[string]string, error) {
 	if err := json.Unmarshal([]byte(value), &raw); err != nil {
 		return nil, fmt.Errorf("parse %s as JSON string map: %w", key, err)
 	}
-	if err := validateACPEnvironmentMapping(raw); err != nil {
+	if err := validateEnvironmentMapping(raw); err != nil {
 		return nil, fmt.Errorf("%s: %w", key, err)
 	}
 	return raw, nil
 }
 
-func validateACPEnvironmentMapping(values map[string]string) error {
+func validateEnvironmentMapping(values map[string]string) error {
 	if len(values) > 64 {
 		return fmt.Errorf("contains %d mappings; maximum is 64", len(values))
 	}

--- a/internal/config/environment_mapping_test.go
+++ b/internal/config/environment_mapping_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestValidateEnvironmentMapping(t *testing.T) {
+	if err := validateEnvironmentMapping(map[string]string{
+		"NIX_LD":      "NIX_LD",
+		"CHILD_TOKEN": "HOST_TOKEN_2",
+	}); err != nil {
+		t.Fatalf("valid environment mapping rejected: %v", err)
+	}
+
+	tooMany := make(map[string]string, 65)
+	for i := 0; i < 65; i++ {
+		key := fmt.Sprintf("KEY_%d", i)
+		tooMany[key] = key
+	}
+	if err := validateEnvironmentMapping(tooMany); err == nil || !strings.Contains(err.Error(), "maximum is 64") {
+		t.Fatalf("too many mappings error = %v", err)
+	}
+}

--- a/internal/tool/command/command.go
+++ b/internal/tool/command/command.go
@@ -493,7 +493,17 @@ func (svc *Service) baseCommandEnv() (map[string]string, error) {
 	if err := os.MkdirAll(commandTempDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create command temp directory: %w", err)
 	}
+	svc.applyHostEnvMapping(env)
 	return env, nil
+}
+
+// applyHostEnvMapping 只复制部署者显式声明的宿主变量；未配置的宿主环境继续保持隔离。
+func (svc *Service) applyHostEnvMapping(env map[string]string) {
+	for childKey, hostKey := range svc.config().CommandEnvFromEnv {
+		if value, ok := os.LookupEnv(hostKey); ok {
+			setPlatformCommandEnv(env, childKey, value)
+		}
+	}
 }
 
 func formatCommandEnv(env map[string]string) []string {

--- a/internal/tool/command/command_behavior_test.go
+++ b/internal/tool/command/command_behavior_test.go
@@ -29,6 +29,31 @@ func TestExecCommandDoesNotFilterCommandContent(t *testing.T) {
 	}
 }
 
+func TestExecCommandForwardsConfiguredHostEnv(t *testing.T) {
+	rt, cfg := newCommandTestService(t)
+	t.Setenv("AGENTDOCK_TEST_HOST_PASSTHROUGH", "host-forwarded")
+	cfg.CommandEnvFromEnv = map[string]string{
+		"AGENTDOCK_TEST_CHILD_PASSTHROUGH": "AGENTDOCK_TEST_HOST_PASSTHROUGH",
+	}
+
+	command := `printf '%s' "$AGENTDOCK_TEST_CHILD_PASSTHROUGH"`
+	if runtime.GOOS == "windows" {
+		command = `[Console]::Out.Write($env:AGENTDOCK_TEST_CHILD_PASSTHROUGH)`
+	}
+	result, err := rt.execArgs(context.Background(), map[string]any{
+		"cmd":            command,
+		"yield_time_ms":  15000,
+		"timeout_ms":     15000,
+		"execution_mode": "sync",
+	})
+	if err != nil {
+		t.Fatalf("exec_command should forward configured host env: %v", err)
+	}
+	if result["status"] != "exited" || result["stdout"].(string) != "host-forwarded" {
+		t.Fatalf("configured host env was not forwarded: %#v", result)
+	}
+}
+
 func TestExecCommandForwardsExplicitEnv(t *testing.T) {
 	rt, _ := newCommandTestService(t)
 	command := `printf '%s' "$AGENTDOCK_TEST_EXEC_ENV"`

--- a/internal/tool/command/command_env_test.go
+++ b/internal/tool/command/command_env_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -36,4 +37,126 @@ func TestCommandEnvExplicitPathOverridesPlatformDefault(t *testing.T) {
 		}
 	}
 	t.Fatal("command environment missing PATH")
+}
+
+func TestCommandEnvMappingOverridesBaseEnvironment(t *testing.T) {
+	svc, cfg := newCommandTestService(t)
+	t.Setenv("AGENTDOCK_TEST_MAPPED_PATH", "/mapped/bin")
+	cfg.CommandEnvFromEnv = map[string]string{"PATH": "AGENTDOCK_TEST_MAPPED_PATH"}
+
+	got, err := svc.CommandEnv("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value := commandEnvValues(got)["PATH"]; value != "/mapped/bin" {
+		t.Fatalf("mapped PATH = %q, want /mapped/bin", value)
+	}
+}
+
+func TestCommandEnvUsesConfiguredHostMapping(t *testing.T) {
+	svc, cfg := newCommandTestService(t)
+	t.Setenv("AGENTDOCK_TEST_HOST_FROM_ENV", "host-value")
+	unsetEnvForTest(t, "AGENTDOCK_TEST_MISSING_HOST_FROM_ENV")
+	cfg.CommandEnvFromEnv = map[string]string{
+		"AGENTDOCK_TEST_CHILD_FROM_ENV":   "AGENTDOCK_TEST_HOST_FROM_ENV",
+		"AGENTDOCK_TEST_MISSING_FROM_ENV": "AGENTDOCK_TEST_MISSING_HOST_FROM_ENV",
+	}
+
+	commandEnv, err := svc.CommandEnv("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := commandEnvValues(commandEnv)
+	if values["AGENTDOCK_TEST_CHILD_FROM_ENV"] != "host-value" {
+		t.Fatalf("configured host environment = %#v", values)
+	}
+	if _, ok := values["AGENTDOCK_TEST_MISSING_FROM_ENV"]; ok {
+		t.Fatalf("missing host environment should not create a child variable: %#v", values)
+	}
+
+	internalEnv, err := svc.InternalCommandEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := commandEnvValues(internalEnv)["AGENTDOCK_TEST_CHILD_FROM_ENV"]; got != "host-value" {
+		t.Fatalf("internal command host environment = %q, want host-value", got)
+	}
+}
+
+func TestCommandEnvPriorityKeepsSkillAndExplicitOverrides(t *testing.T) {
+	svc, cfg := newCommandTestService(t)
+	const childKey = "AGENTDOCK_TEST_ENV_PRIORITY"
+	t.Setenv("AGENTDOCK_TEST_ENV_PRIORITY_HOST", "host-value")
+	cfg.CommandEnvFromEnv = map[string]string{childKey: "AGENTDOCK_TEST_ENV_PRIORITY_HOST"}
+	if err := svc.envs.Set(envstore.Scope{Kind: envstore.ScopeSkill, Name: "demo-skill"}, childKey, "skill-value"); err != nil {
+		t.Fatal(err)
+	}
+
+	skillEnv, err := svc.CommandEnv("demo-skill", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := commandEnvValues(skillEnv)[childKey]; got != "skill-value" {
+		t.Fatalf("Skill env priority = %q, want skill-value", got)
+	}
+
+	explicitEnv, err := svc.CommandEnv("demo-skill", map[string]string{childKey: "explicit-value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := commandEnvValues(explicitEnv)[childKey]; got != "explicit-value" {
+		t.Fatalf("explicit env priority = %q, want explicit-value", got)
+	}
+
+	internalEnv, err := svc.InternalCommandEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := commandEnvValues(internalEnv)[childKey]; got != "host-value" {
+		t.Fatalf("internal command env = %q, want host-value without Skill env", got)
+	}
+}
+
+func TestCommandEnvStillBlocksUnconfiguredHostInjectionVariables(t *testing.T) {
+	svc, _ := newCommandTestService(t)
+	for _, key := range []string{"NODE_OPTIONS", "PYTHONPATH", "JAVA_TOOL_OPTIONS"} {
+		t.Setenv(key, "must-not-inherit")
+	}
+
+	got, err := svc.CommandEnv("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := commandEnvValues(got)
+	for _, key := range []string{"NODE_OPTIONS", "PYTHONPATH", "JAVA_TOOL_OPTIONS"} {
+		if _, ok := values[key]; ok {
+			t.Fatalf("unconfigured host variable %s leaked into command environment", key)
+		}
+	}
+}
+
+func commandEnvValues(entries []string) map[string]string {
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	return values
+}
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	old, existed := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, old)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
 }

--- a/internal/tool/command/command_env_windows_test.go
+++ b/internal/tool/command/command_env_windows_test.go
@@ -75,6 +75,19 @@ func TestWindowsCommandEnvPlatformKeyContract(t *testing.T) {
 	}
 }
 
+func TestCommandEnvMappingUsesWindowsCaseInsensitiveKeys(t *testing.T) {
+	svc, cfg := newCommandTestService(t)
+	t.Setenv("AGENTDOCK_TEST_WINDOWS_HOST_MAPPING", "mapped-value")
+	cfg.CommandEnvFromEnv = map[string]string{
+		"custom_mapped_key": "AGENTDOCK_TEST_WINDOWS_HOST_MAPPING",
+	}
+
+	values := windowsCommandEnvValues(t, svc)
+	if got := values["CUSTOM_MAPPED_KEY"]; got != "mapped-value" {
+		t.Fatalf("mapped Windows environment = %q, want mapped-value", got)
+	}
+}
+
 func TestCommandEnvPreservesWindowsPlatformBaseline(t *testing.T) {
 	svc := newWindowsCommandEnvTestService(t)
 	for _, key := range platformCommandEnvKeys() {

--- a/internal/tool/command/command_invocation_test.go
+++ b/internal/tool/command/command_invocation_test.go
@@ -48,6 +48,17 @@ func TestBuildWSLProcessEnvForwardsValuesWithoutPuttingThemInArgs(t *testing.T) 
 	}
 }
 
+func TestBuildWSLProcessEnvDoesNotForwardBaseOnlyVariables(t *testing.T) {
+	env := buildWSLProcessEnv(
+		[]string{"HOST_ONLY=host-value"},
+		nil,
+	)
+	want := []string{"HOST_ONLY=host-value"}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("buildWSLProcessEnv() = %#v, want %#v", env, want)
+	}
+}
+
 func TestBuildWSLProcessEnvHonorsExplicitWSLEnv(t *testing.T) {
 	env := buildWSLProcessEnv(
 		[]string{"CUSTOM=base", "WSLENV=OLD"},


### PR DESCRIPTION
## 背景

修复 Linux/NixOS 下 `exec_command` 默认精简环境导致 `NIX_LD`、`NIX_LD_LIBRARY_PATH` 等宿主运行时变量无法传入子进程的问题。

Closes #43

## 改动

- 新增 `AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON`，按“子进程变量名 -> AgentDock 宿主进程变量名”显式映射环境变量。
- 保持默认精简环境，不改为全量继承 `os.Environ()`，避免 `NODE_OPTIONS`、`PYTHONPATH` 等代码加载相关变量被隐式带入。
- 缺失的宿主变量静默跳过。
- 覆盖优先级保持：基础环境 < Host Mapping < Skill Env < `exec_command.env`。
- `InternalCommandEnv` 可获得显式 Host Mapping，但仍不加载 Skill Env。
- 保持 Windows 环境变量大小写语义，并确保 Host Mapping 不会自动通过 `WSLENV` 跨入 WSL。
- 将 ACP 现有环境映射校验泛化为通用环境映射校验。
- README 中英文补充通用配置与 NixOS / nix-ld 使用说明。

## 设计取舍

没有直接把 `NIX_LD*` 加入 Linux 默认白名单，也没有改成全量继承宿主环境。`NIX_LD_LIBRARY_PATH` 会影响动态库加载路径，默认继承会破坏现有环境隔离模型。

也没有在通用 Linux installer 中快照 NixOS 当前 `/nix/store` 路径：systemd 服务不会继承登录 Shell，仅写映射无法形成闭环；持久化 generation-specific store path 又可能在 NixOS rebuild / GC 后失效。NixOS 部署应通过服务环境或声明式配置提供源变量。

## 验证

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Linux amd64 / Windows amd64 相关测试包交叉编译
- agy 独立 Review：无阻塞问题
