### PR TITLE
feat(mcp): 添加 MCP Apps UI 开关

### DIFF
--- a/cmd/agentdock/server.go
+++ b/cmd/agentdock/server.go
@@ -51,6 +51,7 @@ func runServer(ctx context.Context, args []string, stderr io.Writer) error {
 	flags.StringVar(&cfg.Host, "host", cfg.Host, "HTTP bind host")
 	flags.IntVar(&cfg.Port, "port", cfg.Port, "HTTP bind port")
 	flags.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "log level: debug, info, warn, error")
+	flags.BoolVar(&cfg.MCPAppsEnabled, "mcp-apps-enabled", cfg.MCPAppsEnabled, "expose optional MCP Apps UI resources and metadata")
 	flags.BoolVar(&cfg.BrowserEnabled, "browser-enabled", cfg.BrowserEnabled, "expose optional browser automation tools")
 	flags.StringVar(&cfg.BrowserExecutablePath, "browser-executable-path", cfg.BrowserExecutablePath, "optional absolute Chrome, Chromium, or Edge executable path")
 	flags.StringVar(&cfg.BrowserCDPURL, "browser-cdp-url", cfg.BrowserCDPURL, "optional existing Chromium CDP endpoint to attach")
@@ -86,7 +87,7 @@ func runServer(ctx context.Context, args []string, stderr io.Writer) error {
 		// 失败不应阻断 MCP 服务启动；保留明确日志并在下次启动继续重试。
 		slog.Warn("desktop runtime repair skipped", "error", err)
 	}
-	slog.Info("server starting", "agentdock_home", cfg.AgentDockHome, "agentdock_default_dir", cfg.AgentDockDefaultDir, "path_model", config.PathModel, "host", cfg.Host, "port", cfg.Port, "stdio", cfg.Stdio, "log_level", cfg.LogLevel, "recall_enabled", cfg.NexusEndpoint != "", "nexus_enabled", cfg.NexusEndpoint != "", "browser_enabled", cfg.BrowserEnabled)
+	slog.Info("server starting", "agentdock_home", cfg.AgentDockHome, "agentdock_default_dir", cfg.AgentDockDefaultDir, "path_model", config.PathModel, "host", cfg.Host, "port", cfg.Port, "stdio", cfg.Stdio, "log_level", cfg.LogLevel, "recall_enabled", cfg.NexusEndpoint != "", "nexus_enabled", cfg.NexusEndpoint != "", "mcp_apps_enabled", cfg.MCPAppsEnabled, "browser_enabled", cfg.BrowserEnabled)
 	runtime, err := app.NewRuntime(cfg)
 	if err != nil {
 		return err

--- a/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
@@ -37,6 +37,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private let menuAutostart = NSButton(checkboxWithTitle: "登录后显示 AgentDock 菜单栏", target: nil, action: nil)
     private let portField = NSTextField(string: "8765")
     private let logLevel = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let mcpAppsEnabled = NSButton(checkboxWithTitle: "启用 MCP Apps UI", target: nil, action: nil)
     private let browserEnabled = NSButton(checkboxWithTitle: "启用浏览器 CDP 控制", target: nil, action: nil)
     private let browserConnectionMode = NSPopUpButton(frame: .zero, pullsDown: false)
     private let browserCDPURL = NSTextField(string: "")
@@ -60,6 +61,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private var initialMenuAutostart = true
     private var initialPort = 8765
     private var initialLogLevel = "info"
+    private var initialMCPAppsEnabled = true
     private var initialBrowserEnabled = false
     private var initialBrowserCDPURL = ""
     private var initialBrowserConnectionMode = BrowserConnectionMode.managed
@@ -105,6 +107,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         initialMenuAutostart = menuLoginAgent.isEnabled
         initialPort = configuration.port
         initialLogLevel = configuration.logLevel
+        initialMCPAppsEnabled = configuration.mcpAppsEnabled
         initialBrowserEnabled = configuration.browserEnabled
         initialBrowserCDPURL = configuration.browserCDPURL
         initialBrowserConnectionMode = BrowserConnectionMode.resolve(
@@ -122,6 +125,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         menuAutostart.state = initialMenuAutostart ? .on : .off
         portField.integerValue = initialPort
         logLevel.selectItem(withTitle: initialLogLevel)
+        mcpAppsEnabled.state = initialMCPAppsEnabled ? .on : .off
         browserEnabled.state = initialBrowserEnabled ? .on : .off
         browserCDPURL.stringValue = initialBrowserCDPURL
         selectBrowserConnectionMode(initialBrowserConnectionMode)
@@ -167,6 +171,9 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         logLevel.widthAnchor.constraint(equalToConstant: 120).isActive = true
         logLevel.target = self
         logLevel.action = #selector(markChanged)
+
+        mcpAppsEnabled.target = self
+        mcpAppsEnabled.action = #selector(markChanged)
 
         browserEnabled.target = self
         browserEnabled.action = #selector(browserToggled)
@@ -243,6 +250,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         let serviceForm = NSStackView(views: [
             formRow(title: "服务端口", control: portField),
             formRow(title: "日志级别", control: logLevel),
+            mcpAppsEnabled,
         ])
         serviceForm.orientation = .vertical
         serviceForm.alignment = .leading
@@ -414,6 +422,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         let settings = EditableServiceSettings(
             port: portField.integerValue,
             logLevel: logLevel.titleOfSelectedItem ?? "info",
+            mcpAppsEnabled: mcpAppsEnabled.state == .on,
             browserEnabled: browserEnabled.state == .on,
             browserCDPURL: browserMode == .specifiedCDP ? configuredCDP : "",
             browserReuseExistingCDP: browserMode == .reuseExisting,
@@ -440,6 +449,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
                 initialMenuAutostart = menuAutostartValue
                 initialPort = validatedSettings.port
                 initialLogLevel = validatedSettings.logLevel
+                initialMCPAppsEnabled = validatedSettings.mcpAppsEnabled
                 initialBrowserEnabled = validatedSettings.browserEnabled
                 initialBrowserCDPURL = validatedSettings.browserCDPURL
                 initialBrowserConnectionMode = BrowserConnectionMode.resolve(
@@ -456,6 +466,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
                 acpArgsJSON.stringValue = initialACPArgsJSON
                 portField.integerValue = initialPort
                 logLevel.selectItem(withTitle: initialLogLevel)
+                mcpAppsEnabled.state = initialMCPAppsEnabled ? .on : .off
                 browserCDPURL.stringValue = initialBrowserCDPURL
                 selectBrowserConnectionMode(initialBrowserConnectionMode)
                 if let updatedConfiguration = ServiceConfiguration.load(from: service.paths.environment) {
@@ -619,6 +630,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
             || (menuAutostart.state == .on) != initialMenuAutostart
             || portField.integerValue != initialPort
             || (logLevel.titleOfSelectedItem ?? "info") != initialLogLevel
+            || (mcpAppsEnabled.state == .on) != initialMCPAppsEnabled
             || (browserEnabled.state == .on) != initialBrowserEnabled
             || browserMode != initialBrowserConnectionMode
             || browserCDP != initialBrowserCDPURL
@@ -631,7 +643,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
     private func setBusy(_ busy: Bool) {
         isBusy = busy
-        for control in [serviceAutostart, menuAutostart, portField, logLevel, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, acpAgent, acpCommand, acpArgsJSON, nexusEndpoint, nexusPairingCode, nexusPairButton] {
+        for control in [serviceAutostart, menuAutostart, portField, logLevel, mcpAppsEnabled, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, acpAgent, acpCommand, acpArgsJSON, nexusEndpoint, nexusPairingCode, nexusPairButton] {
             control.isEnabled = !busy
         }
         refreshBrowserStatus()

--- a/desktop/macos/AgentDockApp/Sources/AppPaths.swift
+++ b/desktop/macos/AgentDockApp/Sources/AppPaths.swift
@@ -36,6 +36,7 @@ struct ServiceConfiguration: Equatable {
     static let editableKeys = [
         "AGENTDOCK_PORT",
         "AGENTDOCK_LOG_LEVEL",
+        "AGENTDOCK_MCP_APPS_ENABLED",
         "AGENTDOCK_BROWSER_ENABLED",
         "AGENTDOCK_BROWSER_CDP_URL",
         "AGENTDOCK_BROWSER_REUSE_EXISTING_CDP",
@@ -58,6 +59,7 @@ struct ServiceConfiguration: Equatable {
     let authToken: String
     let oauthPassword: String
     let logLevel: String
+    let mcpAppsEnabled: Bool
     let browserEnabled: Bool
     let browserCDPURL: String
     let browserReuseExistingCDP: Bool
@@ -107,6 +109,7 @@ struct ServiceConfiguration: Equatable {
             authToken: values["AGENTDOCK_AUTH_TOKEN"] ?? "",
             oauthPassword: values["AGENTDOCK_OAUTH_PASSWORD"] ?? "",
             logLevel: normalizedLogLevel(values["AGENTDOCK_LOG_LEVEL"] ?? "info"),
+            mcpAppsEnabled: parseBool(values["AGENTDOCK_MCP_APPS_ENABLED"], defaultValue: true),
             browserEnabled: parseBool(values["AGENTDOCK_BROWSER_ENABLED"]),
             browserCDPURL: values["AGENTDOCK_BROWSER_CDP_URL"] ?? "",
             browserReuseExistingCDP: parseBool(values["AGENTDOCK_BROWSER_REUSE_EXISTING_CDP"]),
@@ -130,10 +133,11 @@ struct ServiceConfiguration: Equatable {
         return values
     }
 
-    private static func parseBool(_ raw: String?) -> Bool {
+    private static func parseBool(_ raw: String?, defaultValue: Bool = false) -> Bool {
         switch raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "1", "true", "yes", "on": return true
-        default: return false
+        case "0", "false", "no", "off": return false
+        default: return defaultValue
         }
     }
 }

--- a/desktop/macos/AgentDockApp/Sources/ServiceConfigurationController.swift
+++ b/desktop/macos/AgentDockApp/Sources/ServiceConfigurationController.swift
@@ -4,6 +4,7 @@ import Foundation
 struct EditableServiceSettings {
     let port: Int
     let logLevel: String
+    let mcpAppsEnabled: Bool
     let browserEnabled: Bool
     let browserCDPURL: String
     let browserReuseExistingCDP: Bool
@@ -43,6 +44,7 @@ struct EditableServiceSettings {
         return EditableServiceSettings(
             port: port,
             logLevel: normalizedLogLevel,
+            mcpAppsEnabled: mcpAppsEnabled,
             browserEnabled: browserEnabled,
             browserCDPURL: browserCDPURL,
             browserReuseExistingCDP: browserReuseExistingCDP,
@@ -87,6 +89,7 @@ final class ServiceConfigurationController {
         var replacements = [
             "AGENTDOCK_PORT": String(settings.port),
             "AGENTDOCK_LOG_LEVEL": settings.logLevel,
+            "AGENTDOCK_MCP_APPS_ENABLED": settings.mcpAppsEnabled ? "true" : "false",
             "AGENTDOCK_BROWSER_ENABLED": settings.browserEnabled ? "true" : "false",
             "AGENTDOCK_BROWSER_CDP_URL": settings.browserCDPURL,
             "AGENTDOCK_BROWSER_REUSE_EXISTING_CDP": settings.browserReuseExistingCDP ? "true" : "false",

--- a/desktop/macos/AgentDockApp/Tests/InstallerConfigurationTests.swift
+++ b/desktop/macos/AgentDockApp/Tests/InstallerConfigurationTests.swift
@@ -57,6 +57,14 @@ struct InstallerConfigurationTests {
         precondition(updatedValues["AGENTDOCK_BROWSER_REUSE_EXISTING_CDP"] == "true")
         precondition(updatedText.components(separatedBy: "AGENTDOCK_PORT=").count == 2)
 
+        let serviceEnvironmentURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agentdock-service-config-\(UUID().uuidString).env")
+        defer { try? FileManager.default.removeItem(at: serviceEnvironmentURL) }
+        try Data("AGENTDOCK_PORT=8765\n".utf8).write(to: serviceEnvironmentURL)
+        precondition(ServiceConfiguration.load(from: serviceEnvironmentURL)?.mcpAppsEnabled == true)
+        try Data("AGENTDOCK_PORT=8765\nAGENTDOCK_MCP_APPS_ENABLED=false\n".utf8).write(to: serviceEnvironmentURL)
+        precondition(ServiceConfiguration.load(from: serviceEnvironmentURL)?.mcpAppsEnabled == false)
+
         let nexusIdentityURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("agentdock-nexus-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: nexusIdentityURL) }

--- a/desktop/windows/control-panel/MainWindow.xaml
+++ b/desktop/windows/control-panel/MainWindow.xaml
@@ -163,6 +163,7 @@
                 <Grid.RowDefinitions>
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="端口" VerticalAlignment="Center" Margin="0,0,0,10" />
                 <TextBox x:Name="PortTextBox" Grid.Column="1" Width="130" HorizontalAlignment="Left" Margin="0,0,0,10" />
@@ -173,6 +174,7 @@
                   <ComboBoxItem Content="warn" />
                   <ComboBoxItem Content="error" />
                 </ComboBox>
+                <CheckBox x:Name="McpAppsEnabledCheckBox" Grid.Row="2" Grid.ColumnSpan="2" Content="启用 MCP Apps UI" Margin="0,4,0,4" />
               </Grid>
             </GroupBox>
 

--- a/desktop/windows/control-panel/MainWindow.xaml.cs
+++ b/desktop/windows/control-panel/MainWindow.xaml.cs
@@ -125,6 +125,7 @@ public partial class MainWindow : Window
             {
                 PortTextBox.Text = snapshot.Settings.Port.ToString();
                 SelectLogLevel(snapshot.Settings.LogLevel);
+                McpAppsEnabledCheckBox.IsChecked = snapshot.Settings.McpAppsEnabled;
                 BrowserEnabledCheckBox.IsChecked = snapshot.Settings.BrowserEnabled;
                 BrowserCdpUrlTextBox.Text = snapshot.Settings.BrowserCdpUrl;
                 SelectBrowserConnectionMode(snapshot.Settings);
@@ -457,6 +458,7 @@ public partial class MainWindow : Window
             Port = port,
             LogLevel = SelectedLogLevel(),
             OAuthAccessTokenTtl = _snapshot?.Settings.OAuthAccessTokenTtl ?? "",
+            McpAppsEnabled = McpAppsEnabledCheckBox.IsChecked == true,
             BrowserEnabled = BrowserEnabledCheckBox.IsChecked == true,
             BrowserCdpUrl = browserConnectionMode == BrowserConnectionSpecified ? browserCdpUrl : "",
             BrowserReuseExistingCdp = browserConnectionMode == BrowserConnectionReuse,

--- a/desktop/windows/control-panel/Models/RuntimeModels.cs
+++ b/desktop/windows/control-panel/Models/RuntimeModels.cs
@@ -64,6 +64,9 @@ public sealed class ControlPanelSettings
     [JsonPropertyName("oauth_access_token_ttl")]
     public string OAuthAccessTokenTtl { get; set; } = "";
 
+    [JsonPropertyName("mcp_apps_enabled")]
+    public bool McpAppsEnabled { get; set; } = true;
+
     [JsonPropertyName("browser_enabled")]
     public bool BrowserEnabled { get; set; }
 

--- a/desktop/windows/control-panel/Services/RuntimeService.cs
+++ b/desktop/windows/control-panel/Services/RuntimeService.cs
@@ -229,6 +229,7 @@ public sealed class RuntimeService : IDisposable
             "--port", settings.Port.ToString(),
             "--log-level", settings.LogLevel,
             "--oauth-access-token-ttl", settings.OAuthAccessTokenTtl ?? "",
+            $"--mcp-apps-enabled={settings.McpAppsEnabled.ToString().ToLowerInvariant()}",
             $"--browser-enabled={settings.BrowserEnabled.ToString().ToLowerInvariant()}",
             "--browser-cdp-url", settings.BrowserCdpUrl ?? "",
             $"--browser-reuse-existing-cdp={settings.BrowserReuseExistingCdp.ToString().ToLowerInvariant()}",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	LogLevel                     string
 	NexusEndpoint                string
 	NexusDeviceToken             string
+	MCPAppsEnabled               bool
 	BrowserEnabled               bool
 	BrowserExecutablePath        string
 	BrowserCDPURL                string
@@ -82,6 +83,10 @@ func FromEnv() (Config, error) {
 		return Config{}, err
 	}
 	stdio, err := getenvBool("AGENTDOCK_STDIO", false)
+	if err != nil {
+		return Config{}, err
+	}
+	mcpAppsEnabled, err := getenvBool("AGENTDOCK_MCP_APPS_ENABLED", true)
 	if err != nil {
 		return Config{}, err
 	}
@@ -131,6 +136,7 @@ func FromEnv() (Config, error) {
 		OAuthAccessTokenTTLSeconds:   oauthAccessTokenTTLSeconds,
 		OAuthAccessTokenNeverExpires: oauthAccessTokenNeverExpires,
 		LogLevel:                     getenv("AGENTDOCK_LOG_LEVEL", "info"),
+		MCPAppsEnabled:               mcpAppsEnabled,
 		BrowserEnabled:               browserEnabled,
 		BrowserExecutablePath:        os.Getenv("AGENTDOCK_BROWSER_EXECUTABLE_PATH"),
 		BrowserCDPURL:                strings.TrimSpace(os.Getenv("AGENTDOCK_BROWSER_CDP_URL")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,6 +47,25 @@ func TestFromEnvParsesCommandEnvironmentMapping(t *testing.T) {
 	}
 }
 
+func TestFromEnvMCPAppsEnabledDefaultsAndOverride(t *testing.T) {
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if !cfg.MCPAppsEnabled {
+		t.Fatal("MCPAppsEnabled = false, want true by default")
+	}
+
+	t.Setenv("AGENTDOCK_MCP_APPS_ENABLED", "false")
+	cfg, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() with override error = %v", err)
+	}
+	if cfg.MCPAppsEnabled {
+		t.Fatal("MCPAppsEnabled = true, want false from environment override")
+	}
+}
+
 func TestCommandEnvironmentMappingRejectsInvalidNames(t *testing.T) {
 	t.Setenv("AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON", `{"BAD-NAME":"HOST_TOKEN"}`)
 	if _, err := FromEnv(); err == nil || !strings.Contains(err.Error(), "AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON") {

--- a/internal/desktopruntime/config_command.go
+++ b/internal/desktopruntime/config_command.go
@@ -19,6 +19,7 @@ type ConfigUpdateRequest struct {
 	Port                    int
 	LogLevel                string
 	OAuthAccessTokenTTL     string
+	MCPAppsEnabled          bool
 	BrowserEnabled          bool
 	BrowserCDPURL           string
 	BrowserReuseExistingCDP bool
@@ -40,6 +41,7 @@ func RunConfigCommand(ctx context.Context, args []string, stdout, stderr io.Writ
 		port := flags.Int("port", 0, "本地监听端口")
 		logLevel := flags.String("log-level", "info", "日志级别")
 		oauthAccessTokenTTL := flags.String("oauth-access-token-ttl", "", "OAuth Access Token 有效期；留空表示继承环境变量或使用默认值")
+		mcpAppsEnabled := flags.Bool("mcp-apps-enabled", true, "启用 MCP Apps UI")
 		browserEnabled := flags.Bool("browser-enabled", false, "启用浏览器")
 		browserCDPURL := flags.String("browser-cdp-url", "", "已有 Chromium CDP 地址")
 		browserReuseExistingCDP := flags.Bool("browser-reuse-existing-cdp", false, "自动发现并复用唯一已有 CDP")
@@ -62,6 +64,7 @@ func RunConfigCommand(ctx context.Context, args []string, stdout, stderr io.Writ
 			Port:                    *port,
 			LogLevel:                strings.ToLower(strings.TrimSpace(*logLevel)),
 			OAuthAccessTokenTTL:     strings.TrimSpace(*oauthAccessTokenTTL),
+			MCPAppsEnabled:          *mcpAppsEnabled,
 			BrowserEnabled:          *browserEnabled,
 			BrowserCDPURL:           strings.TrimSpace(*browserCDPURL),
 			BrowserReuseExistingCDP: *browserReuseExistingCDP,

--- a/internal/desktopruntime/config_windows.go
+++ b/internal/desktopruntime/config_windows.go
@@ -128,6 +128,7 @@ func platformUpdateConfig(ctx context.Context, request ConfigUpdateRequest) erro
 		Port:                    request.Port,
 		LogLevel:                request.LogLevel,
 		OAuthAccessTokenTTL:     request.OAuthAccessTokenTTL,
+		MCPAppsEnabled:          request.MCPAppsEnabled,
 		BrowserEnabled:          request.BrowserEnabled,
 		BrowserCDPURL:           request.BrowserCDPURL,
 		BrowserReuseExistingCDP: request.BrowserReuseExistingCDP,

--- a/internal/desktopruntime/service_environment_windows.go
+++ b/internal/desktopruntime/service_environment_windows.go
@@ -22,6 +22,7 @@ var managedCoreEnvironment = []string{
 	"AGENTDOCK_HOST",
 	"AGENTDOCK_PORT",
 	"AGENTDOCK_LOG_LEVEL",
+	"AGENTDOCK_MCP_APPS_ENABLED",
 	// 仅用于清除旧服务环境，核心不再读取这两个配置。
 	"AGENTDOCK_NEXUS_ENDPOINT",
 	"AGENTDOCK_NEXUS_TOKEN",
@@ -47,6 +48,7 @@ type controlPanelSettings struct {
 	Port                    int      `json:"port"`
 	LogLevel                string   `json:"log_level"`
 	OAuthAccessTokenTTL     string   `json:"oauth_access_token_ttl,omitempty"`
+	MCPAppsEnabled          bool     `json:"mcp_apps_enabled"`
 	BrowserEnabled          bool     `json:"browser_enabled"`
 	BrowserCDPURL           string   `json:"browser_cdp_url"`
 	BrowserReuseExistingCDP bool     `json:"browser_reuse_existing_cdp"`
@@ -91,6 +93,7 @@ func platformPrepareCoreEnvironment(runtimeRoot string) error {
 		"AGENTDOCK_HOST":                       "127.0.0.1",
 		"AGENTDOCK_PORT":                       strconv.Itoa(settings.Port),
 		"AGENTDOCK_LOG_LEVEL":                  settings.LogLevel,
+		"AGENTDOCK_MCP_APPS_ENABLED":           strconv.FormatBool(settings.MCPAppsEnabled),
 		"AGENTDOCK_BROWSER_ENABLED":            strconv.FormatBool(settings.BrowserEnabled),
 		"AGENTDOCK_BROWSER_REUSE_EXISTING_CDP": strconv.FormatBool(settings.BrowserReuseExistingCDP),
 		"AGENTDOCK_ACP_ENABLED":                strconv.FormatBool(settings.ACPEnabled),
@@ -154,7 +157,7 @@ func platformPrepareCoreEnvironment(runtimeRoot string) error {
 }
 
 func loadControlPanelSettings(runtimeRoot string, fallbackPort int) (controlPanelSettings, error) {
-	settings := controlPanelSettings{Port: fallbackPort, LogLevel: "info", ACPAgent: "codex"}
+	settings := controlPanelSettings{Port: fallbackPort, LogLevel: "info", MCPAppsEnabled: true, ACPAgent: "codex"}
 	data, err := os.ReadFile(filepath.Join(runtimeRoot, "control-panel-settings.json"))
 	if errors.Is(err, os.ErrNotExist) {
 		return settings, nil

--- a/internal/desktopruntime/service_environment_windows_test.go
+++ b/internal/desktopruntime/service_environment_windows_test.go
@@ -41,6 +41,9 @@ func TestLoadControlPanelSettingsValidatesOAuthAccessTokenTTL(t *testing.T) {
 	if settings.OAuthAccessTokenTTL != "never" {
 		t.Fatalf("OAuthAccessTokenTTL = %q, want never", settings.OAuthAccessTokenTTL)
 	}
+	if !settings.MCPAppsEnabled {
+		t.Fatal("legacy settings without mcp_apps_enabled should default MCP Apps UI to enabled")
+	}
 
 	if err := os.WriteFile(settingsPath, []byte(`{"port":8765,"log_level":"info","oauth_access_token_ttl":"59s"}`), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/mcp/apps.go
+++ b/internal/mcp/apps.go
@@ -20,6 +20,9 @@ type appResourceDefinition struct {
 }
 
 func (s *Server) appResourceDefinitions() []appResourceDefinition {
+	if s == nil || !s.cfg.MCPAppsEnabled {
+		return nil
+	}
 	definitions := []appResourceDefinition{
 		{
 			URI:         protocol.ContextUIResourceURI,

--- a/internal/mcp/apps_test.go
+++ b/internal/mcp/apps_test.go
@@ -64,7 +64,12 @@ func assertResourceUIMeta(t *testing.T, meta mcpsdk.Meta, domain string) {
 }
 
 func newMCPAppTestHarness(t *testing.T, cfg config.Config) *mcpAppTestHarness {
+	return newMCPAppTestHarnessWithApps(t, cfg, true)
+}
+
+func newMCPAppTestHarnessWithApps(t *testing.T, cfg config.Config, enabled bool) *mcpAppTestHarness {
 	t.Helper()
+	cfg.MCPAppsEnabled = enabled
 	if err := cfg.Normalize(); err != nil {
 		t.Fatalf("Normalize() error = %v", err)
 	}
@@ -104,7 +109,7 @@ func newMCPAppTestHarness(t *testing.T, cfg config.Config) *mcpAppTestHarness {
 }
 
 func TestUIResourcesMatchServedResourceRegistry(t *testing.T) {
-	server := &Server{cfg: config.Config{NexusEndpoint: "https://nexus.example.test", ACPEnabled: true}}
+	server := &Server{cfg: config.Config{NexusEndpoint: "https://nexus.example.test", ACPEnabled: true, MCPAppsEnabled: true}}
 	definitions := server.appResourceDefinitions()
 	resources := server.UIResources()
 	if len(definitions) != 8 || len(resources) != len(definitions) {
@@ -129,6 +134,50 @@ func TestUIResourcesMatchServedResourceRegistry(t *testing.T) {
 		if resource.Contract != contract || resource.MIMEType != protocol.MCPAppMIMEType {
 			t.Fatalf("resource capability %s = %#v", definition.URI, resource)
 		}
+	}
+}
+
+func TestMCPAppsCanBeDisabledWithoutRemovingTools(t *testing.T) {
+	root := t.TempDir()
+	harness := newMCPAppTestHarnessWithApps(t, config.Config{
+		AgentDockDefaultDir: root,
+		AgentDockHome:       filepath.Join(root, ".agentdock"),
+	}, false)
+
+	tools := map[string]*mcpsdk.Tool{}
+	for tool, err := range harness.session.Tools(t.Context(), nil) {
+		if err != nil {
+			t.Fatalf("Tools() error = %v", err)
+		}
+		tools[tool.Name] = tool
+	}
+	if tools["agentdock_context"] == nil || tools["file_edit"] == nil || tools["task_manage"] == nil {
+		t.Fatalf("core tools disappeared when MCP Apps UI was disabled: %#v", tools)
+	}
+	for _, name := range []string{"agentdock_context", "file_edit", "task_manage", "mcp_tool_call", "file_publish"} {
+		if ui := tools[name].Meta["ui"]; ui != nil {
+			t.Fatalf("%s still exposes Apps UI metadata while disabled: %#v", name, ui)
+		}
+	}
+	if tools["file_publish"].Meta["file_arg_rewrite_paths"] == nil {
+		t.Fatalf("file_publish lost non-UI metadata while MCP Apps UI was disabled: %#v", tools["file_publish"].Meta)
+	}
+
+	resources := 0
+	for _, err := range harness.session.Resources(t.Context(), nil) {
+		if err != nil {
+			t.Fatalf("Resources() error = %v", err)
+		}
+		resources++
+	}
+	if resources != 0 {
+		t.Fatalf("resources/list count = %d, want 0 while MCP Apps UI is disabled", resources)
+	}
+	if got := harness.server.UIResources(); len(got) != 0 {
+		t.Fatalf("UIResources() = %#v, want empty while disabled", got)
+	}
+	if _, err := harness.server.ReadAppResource(protocol.ContextUIResourceURI); err == nil {
+		t.Fatal("ReadAppResource() served an MCP App while disabled")
 	}
 }
 
@@ -466,12 +515,12 @@ func TestMCPAppsExposeNexusViewsWhenNexusEnabled(t *testing.T) {
 	if !ok {
 		t.Fatal("workflow_template_manage definition missing")
 	}
-	matchMeta := toolResultMetadata(workflowDef, map[string]any{"action": "match"})
+	matchMeta := toolResultMetadata(workflowDef, map[string]any{"action": "match"}, true)
 	matchUI, ok := matchMeta["ui"].(map[string]any)
 	if !ok || matchUI["resourceUri"] != protocol.WorkflowUIResourceURI {
 		t.Fatalf("workflow match result UI metadata = %#v", matchMeta)
 	}
-	if meta := toolResultMetadata(workflowDef, map[string]any{"action": "list"}); len(meta) != 0 {
+	if meta := toolResultMetadata(workflowDef, map[string]any{"action": "list"}, true); len(meta) != 0 {
 		t.Fatalf("workflow list should not bind result UI: %#v", meta)
 	}
 	if tool := tools["recall_bootstrap"]; tool != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -89,7 +89,7 @@ func (s *Server) ToolDescriptors() []map[string]any {
 	if s == nil || s.runtime == nil {
 		return nil
 	}
-	return toolDescriptors(s.runtime.ToolDefinitions())
+	return toolDescriptors(s.runtime.ToolDefinitions(), s.cfg.MCPAppsEnabled)
 }
 
 func (s *Server) Invoke(ctx context.Context, name string, arguments map[string]any) (map[string]any, error) {
@@ -115,7 +115,7 @@ func (s *Server) ServeStdio(in io.Reader, out io.Writer) error {
 }
 
 func (s *Server) registerTool(def ToolDefinition) {
-	meta := toolMetadata(def)
+	meta := toolMetadata(def, s.cfg.MCPAppsEnabled)
 	tool := &mcpsdk.Tool{
 		Name:         def.Name,
 		Title:        def.Title,
@@ -168,16 +168,16 @@ func (s *Server) callTool(ctx context.Context, name string, request *mcpsdk.Call
 		return nil, fmt.Errorf("decode MCP tool result: %w", decodeErr)
 	}
 	if def, ok := s.runtime.ToolDefinition(name); ok {
-		if meta := toolResultMetadata(def, arguments); len(meta) > 0 {
+		if meta := toolResultMetadata(def, arguments, s.cfg.MCPAppsEnabled); len(meta) > 0 {
 			response.Meta = meta
 		}
 	}
 	return &response, nil
 }
 
-func toolMetadata(def ToolDefinition) map[string]any {
+func toolMetadata(def ToolDefinition, mcpAppsEnabled bool) map[string]any {
 	meta := map[string]any{}
-	if def.UIBinding != nil && def.UIBinding.Action == "" {
+	if mcpAppsEnabled && def.UIBinding != nil && def.UIBinding.Action == "" {
 		meta["ui"] = map[string]any{"resourceUri": def.UIBinding.ResourceURI}
 	}
 	if len(def.FileArgRewritePaths) > 0 {
@@ -196,8 +196,8 @@ func toolMetadata(def ToolDefinition) map[string]any {
 
 // Action-scoped Apps UI lives on the call result rather than the tool descriptor,
 // so unrelated actions on the same action-based tool do not render a widget.
-func toolResultMetadata(def ToolDefinition, arguments map[string]any) mcpsdk.Meta {
-	if def.UIBinding == nil || def.UIBinding.Action == "" {
+func toolResultMetadata(def ToolDefinition, arguments map[string]any, mcpAppsEnabled bool) mcpsdk.Meta {
+	if !mcpAppsEnabled || def.UIBinding == nil || def.UIBinding.Action == "" {
 		return nil
 	}
 	action, _ := arguments["action"].(string)
@@ -223,7 +223,7 @@ type writeCloser struct{ io.Writer }
 
 func (writeCloser) Close() error { return nil }
 
-func toolDescriptors(definitions []ToolDefinition) []map[string]any {
+func toolDescriptors(definitions []ToolDefinition, mcpAppsEnabled bool) []map[string]any {
 	descriptors := make([]map[string]any, 0, len(definitions))
 	for _, def := range definitions {
 		descriptor := map[string]any{
@@ -240,7 +240,7 @@ func toolDescriptors(definitions []ToolDefinition) []map[string]any {
 				"openWorldHint": def.Annotations.OpenWorldHint,
 			}
 		}
-		meta := toolMetadata(def)
+		meta := toolMetadata(def, mcpAppsEnabled)
 		if paths, ok := meta["file_arg_rewrite_paths"].([]string); ok {
 			descriptor["file_arg_rewrite_paths"] = paths
 		}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -72,7 +72,7 @@ func TestFilePublishDescriptorExposesFileRewritePath(t *testing.T) {
 
 func TestOpenAIFileMetadataMatchesDeclaredSchemas(t *testing.T) {
 	for _, def := range app.ToolDefinitions() {
-		meta := toolMetadata(def)
+		meta := toolMetadata(def, true)
 		inputProps, _ := def.InputSchema["properties"].(map[string]any)
 		for _, path := range def.FileArgRewritePaths {
 			property, ok := inputProps[path].(map[string]any)
@@ -312,5 +312,5 @@ func toolDescriptorsForConfig(t *testing.T, names []string, cfg config.Config) [
 		}
 		definitions = append(definitions, definition)
 	}
-	return toolDescriptors(definitions)
+	return toolDescriptors(definitions, true)
 }


### PR DESCRIPTION
## 变更
- 新增“启用 MCP Apps UI”开关，默认启用
- AgentDock 关闭后仅移除 Apps UI 资源与 ui metadata，不影响工具执行
- 补齐 macOS / Windows 设置入口与配置持久化

## 验证
- make check 通过
- macOS App 构建与签名校验通过
- Windows Go 测试、dotnet publish 与 Inno Setup 实机打包通过