### PR TITLE
fix(oauth): 支持元数据端点 HEAD 请求

### DIFF
--- a/internal/httpx/oauth.go
+++ b/internal/httpx/oauth.go
@@ -48,20 +48,10 @@ func registerOAuthRoutes(mux *http.ServeMux, cfg config.Config, store *auth.OAut
 		return
 	}
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", http.MethodGet)
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		writeJSON(w, oauthMetadata(cfg, r))
+		writeOAuthMetadata(w, r, oauthMetadata(cfg, r))
 	})
 	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", http.MethodGet)
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		writeJSON(w, protectedResourceMetadata(cfg, r))
+		writeOAuthMetadata(w, r, protectedResourceMetadata(cfg, r))
 	})
 	registrationLimiter := newFixedWindowLimiter(30, time.Minute)
 	passwordLimiter := newFixedWindowLimiter(10, 5*time.Minute)
@@ -85,6 +75,21 @@ func registerOAuthRoutes(mux *http.ServeMux, cfg config.Config, store *auth.OAut
 		handleToken(w, r, cfg, store)
 	})
 }
+
+func writeOAuthMetadata(w http.ResponseWriter, r *http.Request, metadata map[string]any) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Method == http.MethodHead {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	writeJSON(w, metadata)
+}
+
 func handleRegister(w http.ResponseWriter, r *http.Request, cfg config.Config, store *auth.OAuthStore) {
 	if !cfg.OAuthEnabled {
 		http.NotFound(w, r)

--- a/internal/httpx/server_test.go
+++ b/internal/httpx/server_test.go
@@ -527,7 +527,7 @@ func TestRegisterOAuthRoutesExposesOnlyCanonicalEndpoints(t *testing.T) {
 	}
 }
 
-func TestOAuthMetadataEndpointsOnlyAllowGet(t *testing.T) {
+func TestOAuthMetadataEndpointsAllowGetAndHead(t *testing.T) {
 	cfg := oauthTestConfig(t)
 	mux := http.NewServeMux()
 	registerOAuthRoutes(mux, cfg, auth.NewOAuthStore())
@@ -535,11 +535,22 @@ func TestOAuthMetadataEndpointsOnlyAllowGet(t *testing.T) {
 		"/.well-known/oauth-authorization-server",
 		"/.well-known/oauth-protected-resource/mcp",
 	} {
-		request := httptest.NewRequest(http.MethodPost, path, nil)
-		response := httptest.NewRecorder()
-		mux.ServeHTTP(response, request)
-		if response.Code != http.StatusMethodNotAllowed || response.Header().Get("Allow") != http.MethodGet {
-			t.Fatalf("POST %s status=%d Allow=%q", path, response.Code, response.Header().Get("Allow"))
+		getResponse := httptest.NewRecorder()
+		mux.ServeHTTP(getResponse, httptest.NewRequest(http.MethodGet, path, nil))
+		if getResponse.Code != http.StatusOK || getResponse.Header().Get("Content-Type") != "application/json" || getResponse.Body.Len() == 0 {
+			t.Fatalf("GET %s status=%d Content-Type=%q bodyLen=%d", path, getResponse.Code, getResponse.Header().Get("Content-Type"), getResponse.Body.Len())
+		}
+
+		headResponse := httptest.NewRecorder()
+		mux.ServeHTTP(headResponse, httptest.NewRequest(http.MethodHead, path, nil))
+		if headResponse.Code != http.StatusOK || headResponse.Header().Get("Content-Type") != "application/json" || headResponse.Body.Len() != 0 {
+			t.Fatalf("HEAD %s status=%d Content-Type=%q bodyLen=%d", path, headResponse.Code, headResponse.Header().Get("Content-Type"), headResponse.Body.Len())
+		}
+
+		postResponse := httptest.NewRecorder()
+		mux.ServeHTTP(postResponse, httptest.NewRequest(http.MethodPost, path, nil))
+		if postResponse.Code != http.StatusMethodNotAllowed || postResponse.Header().Get("Allow") != "GET, HEAD" {
+			t.Fatalf("POST %s status=%d Allow=%q", path, postResponse.Code, postResponse.Header().Get("Allow"))
 		}
 	}
 }


### PR DESCRIPTION
修复 Issue #51 描述的 OAuth metadata HEAD 兼容问题。

变更：
- `/.well-known/oauth-authorization-server` 支持 GET/HEAD
- `/.well-known/oauth-protected-resource/mcp` 支持 GET/HEAD
- HEAD 返回 200 + application/json 且无响应体
- 非 GET/HEAD 返回 405，并设置 `Allow: GET, HEAD`
- 增加 GET/HEAD/POST 回归测试

本地验证：
- `go test ./internal/httpx`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- 临时实例实测两个 metadata 端点 GET=200、HEAD=200、POST=405

Fixes #51