### PR TITLE
fix(macos): 修复临时隧道 OAuth 启动时序

### DIFF
--- a/desktop/macos/AgentDockApp/Sources/InstallerRunner.swift
+++ b/desktop/macos/AgentDockApp/Sources/InstallerRunner.swift
@@ -27,6 +27,13 @@ struct InstallResult: Decodable {
     }
 }
 
+enum QuickTunnelBootstrap {
+    static func prepareInitialCoreEnvironment(_ values: inout [String: String]) {
+        values.removeValue(forKey: "AGENTDOCK_SERVER_URL")
+        values["AGENTDOCK_OAUTH_ENABLED"] = "false"
+    }
+}
+
 final class InstallerRunner {
     private let service: ServiceController
     private let paths: AppPaths
@@ -76,8 +83,14 @@ final class InstallerRunner {
             try await service.start()
             if request.mode != .local {
                 try service.setTunnelEnabled(true)
-                if request.mode == .named, !(await service.waitForTunnelProcess()) {
-                    throw ValidationError("AgentDock Tunnel 已注册，但 cloudflared 没有稳定运行。")
+                if !(await service.waitForTunnelProcess()) {
+                    // App Bundle 被原子替换后，SMAppService 可能仍显示已注册，
+                    // 但实际的 Tunnel job 没有随之启动。对 Quick Tunnel 也
+                    // 需要与 Named Tunnel 相同的自愈，否则会一直等到 URL 超时。
+                    try service.restartTunnel()
+                    guard await service.waitForTunnelProcess() else {
+                        throw ValidationError("AgentDock Tunnel 已重新注册，但 cloudflared 没有稳定运行。")
+                    }
                 }
             }
 
@@ -183,8 +196,7 @@ final class InstallerRunner {
             values.removeValue(forKey: "AGENTDOCK_SERVER_URL")
             values["AGENTDOCK_OAUTH_ENABLED"] = "false"
         case .quick:
-            values.removeValue(forKey: "AGENTDOCK_SERVER_URL")
-            values["AGENTDOCK_OAUTH_ENABLED"] = "true"
+            QuickTunnelBootstrap.prepareInitialCoreEnvironment(&values)
             tunnelValues["AGENTDOCK_TUNNEL_TARGET"] = "http://127.0.0.1:\(port)"
         case .named:
             guard let serverURL else {

--- a/desktop/macos/AgentDockApp/Tests/ServiceControllerValidationTests.swift
+++ b/desktop/macos/AgentDockApp/Tests/ServiceControllerValidationTests.swift
@@ -53,6 +53,7 @@ struct ServiceControllerValidationTests {
         }
 
         try testConfiguredTunnelMode(root: root, appBundle: appBundle)
+        testQuickTunnelBootstrap()
         testServiceRegistrationStatusClassification()
         try testNexusConnectionStateResolution(root: root)
         try testDesktopUpdateCheckDecoding()
@@ -79,6 +80,24 @@ struct ServiceControllerValidationTests {
             let configuredMode = try service.configuredTunnelMode()
             precondition(configuredMode == expected, rawMode)
         }
+    }
+
+    private static func testQuickTunnelBootstrap() {
+        var values = [
+            "AGENTDOCK_AUTH_TOKEN": "token",
+            "AGENTDOCK_OAUTH_PASSWORD": "password",
+            "AGENTDOCK_OAUTH_TOKEN_SECRET": "secret",
+            "AGENTDOCK_SERVER_URL": "https://stale.trycloudflare.com",
+            "AGENTDOCK_OAUTH_ENABLED": "true",
+        ]
+
+        QuickTunnelBootstrap.prepareInitialCoreEnvironment(&values)
+
+        precondition(values["AGENTDOCK_SERVER_URL"] == nil)
+        precondition(values["AGENTDOCK_OAUTH_ENABLED"] == "false")
+        precondition(values["AGENTDOCK_AUTH_TOKEN"] == "token")
+        precondition(values["AGENTDOCK_OAUTH_PASSWORD"] == "password")
+        precondition(values["AGENTDOCK_OAUTH_TOKEN_SECRET"] == "secret")
     }
 
     private static func testServiceRegistrationStatusClassification() {


### PR DESCRIPTION
## 问题背景

macOS 图形安装器在“临时公网地址（Quick Tunnel）”模式下，会在 cloudflared 生成公网 Origin 前启用 OAuth。

当 `AGENTDOCK_OAUTH_ENABLED=true` 而 `AGENTDOCK_SERVER_URL` 尚未写入时，Core 的 OAuth 配置校验会失败，导致服务健康检查失败。

另外，App Bundle 被替换后，SMAppService 可能仍显示 Tunnel 已注册，但 `cloudflared` 实际没有运行；此前 Quick Tunnel 不会进行自愈重启，最终只会等待地址生成超时。

## 修改内容

- Quick Tunnel 初始启动时清除旧的 `AGENTDOCK_SERVER_URL`，并暂时关闭 OAuth，使 Core 能先以本地配置恢复健康。
- 保留现有 Bearer Token、OAuth 密码和 OAuth token secret；Tunnel 运行流程在获取真实公网 Origin 后再写回地址并启用 OAuth。
- 对 Quick 与 Named Tunnel 统一检查 `cloudflared` 进程；若 SMAppService 已注册但进程不存在，则重新注册并启动 Tunnel。
- 在现有 macOS 服务控制器验证中补充 Quick Tunnel 引导配置回归测试。

## 验证

- `scripts/test/test-macos-app.sh` 通过。
- 手动端到端验证：本地与公网健康检查通过，OAuth 元数据可用，ChatGPT 完成 OAuth 连接并通过 AgentDock 执行只读 `pwd` 命令。