### PR TITLE
feat(skill): 内置 AgentDock 用户指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For a systemd or OpenRC deployment, the source variables must also exist in the 
 
 ### Skills and dynamic MCP
 
-Official and community Skill sources live in [uvwt/agentdock-skills](https://github.com/uvwt/agentdock-skills). This repository only keeps the three bootstrap Skills that must ship with the AgentDock runtime.
+Official and community Skill sources live in [uvwt/agentdock-skills](https://github.com/uvwt/agentdock-skills). This repository only keeps core Skills that must ship with the AgentDock runtime, including bootstrap/security Skills and the built-in `agentdock-user-guide` official user guide.
 
 - Validate, install, activate, and roll back Skill packages
 - Stable, development, canary, and pinned release channels

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,7 +143,7 @@ export AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON='{"NIX_LD":"NIX_LD","NIX_LD_LIBRARY_P
 
 ### Skill 与动态 MCP
 
-官方与社区 Skill 源码统一维护在 [uvwt/agentdock-skills](https://github.com/uvwt/agentdock-skills)。本仓库只保留必须随 AgentDock 运行时发布的三个自举核心 Skill。
+官方与社区 Skill 源码统一维护在 [uvwt/agentdock-skills](https://github.com/uvwt/agentdock-skills)。本仓库只保留必须随 AgentDock 运行时发布的核心 Skill，包括自举/安全相关 Skill，以及内置的 `agentdock-user-guide` 官方用户指南。
 
 - Skill 包校验、安装、激活和回滚
 - 稳定版、开发版、Canary 和固定版本通道

--- a/core-skills/agentdock-user-guide/SKILL.md
+++ b/core-skills/agentdock-user-guide/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: agentdock-user-guide
+description: 当用户询问 AgentDock 是什么、如何使用、配置在哪里、不同平台或安装方式怎样修改配置并生效、如何重启或验证配置，以及常见运行问题时使用；覆盖 macOS Desktop、Windows Desktop、Linux 服务、Docker 和直接运行二进制，不用于源码开发与贡献流程。
+version: 1.0.4
+---
+
+# AgentDock User Guide
+
+这是随 AgentDock 发布的官方用户指南 Skill。目标是让模型基于用户当前真实安装方式，正确解释和操作 AgentDock，而不是依赖固定路径、旧版本经验或猜测。
+
+回答使用用户当前语言；命令、路径和配置键保持原样。
+
+## AgentDock 是什么
+
+AgentDock 是面向 AI Agent 的独立工具运行层。它把文件、命令、Git、Skill、动态 MCP、浏览器、任务等能力通过 MCP 提供给 ChatGPT、Claude、Codex 等客户端；它本身不是聊天界面，也不负责模型推理。
+
+一个 AgentDock 实例对应一个实际运行环境。客户端可以连接本机 AgentDock，也可以连接远程服务器、容器或其他设备上的 AgentDock。多设备场景下，先确认当前工具实际连到哪一个实例，再解释或修改该实例的配置。
+
+通常通过 AgentDock 暴露的 MCP 地址连接，默认 HTTP 端口是 8765，MCP 路径是 `/mcp`；实际地址、认证方式和端口始终以当前安装/部署配置为准。公网访问必须保留认证并使用 HTTPS，不要把 Token、OAuth 密码或其他凭据发到公开聊天、截图或 Issue。
+
+如果当前 AgentDock 暴露 `agentdock_context`，把它作为识别版本、平台、运行目录、可用 Skill 与能力的首选入口；具体文件、进程、服务和容器状态仍应通过真实工具继续验证。
+
+## AgentDock 生态项目
+
+### NexusDock
+
+[NexusDock](https://github.com/uvwt/nexusdock) 是 AgentDock 的自托管中心服务。它把多台 AgentDock、长期记忆和 Workflow 集中到一个入口；单台 AgentDock 仍可独立使用，NexusDock 不是运行 AgentDock 的必需组件。
+
+以下场景尤其适合使用 NexusDock：
+
+- **ChatGPT 只接入一个 MCP**：把多台 AgentDock 与 NexusDock 配对后，ChatGPT 只需要配置 NexusDock 的统一 `/mcp` 地址。NexusDock 会向客户端提供统一工具入口；需要执行某台设备上的文件、命令、浏览器、Skill、动态 MCP 等能力时，先通过 `agentdock_context` 确认节点，再用对应 `node_id` 把工具调用路由到那台 AgentDock。这样不需要在 ChatGPT 中分别维护多台设备的 MCP 连接。
+- **需要长期记忆能力**：NexusDock 提供集中式 Recall 工作区和 `recall_*` 工具，用于搜索、读取、维护长期项目记忆、运行手册和经验记录。多台 AgentDock 可以使用同一份中心记忆，而不是各自在本机保存彼此不可见的长期上下文。
+- **需要 Workflow 能力**：NexusDock 集中保存和匹配可复用 Workflow 模板，并通过 `workflow_template_manage` 提供给模型；多步骤任务仍可结合 `task_manage` 持久化执行进度。基础 Workflow 不依赖 Embedding，配置向量服务后还可以使用语义匹配。
+- **需要多设备统一管理**：Web 控制台可以查看设备在线状态、版本和运行时能力，并集中查看 Recall、Workflow、任务、Skill 和动态 MCP 状态。
+
+NexusDock 不替代设备端 AgentDock：实际文件、命令、浏览器、Skill、动态 MCP 等设备能力仍由目标 AgentDock 节点执行；NexusDock 负责中心管理、共享 Recall/Workflow、统一 MCP 接入和跨设备路由。只有一台 AgentDock、也不需要中心记忆或 Workflow 时，可以直接连接 AgentDock，不必额外部署 NexusDock。
+
+统一 MCP 地址形式为：`https://<你的 NexusDock 域名>/mcp`。支持 OAuth 的客户端可以直接授权；其他客户端也可以使用 NexusDock 的 MCP Access Token。具体认证方式以 NexusDock 当前部署为准。
+
+官方仓库：<https://github.com/uvwt/nexusdock>
+
+### AgentDock Documentation
+
+AgentDock 的用户文档独立维护在 [uvwt/agentdock-docs](https://github.com/uvwt/agentdock-docs)。安装、平台配置、部署、升级、工具和用户可见行为等说明应优先参考这里，而不是只依赖主仓库 README。
+
+在线文档：<https://uvwt.github.io/agentdock-docs/zh-CN/>
+
+文档源码仓库：<https://github.com/uvwt/agentdock-docs>
+
+### AgentDock Skills
+
+[AgentDock Skills](https://github.com/uvwt/agentdock-skills) 是 AgentDock 官方与社区 Skill 的源码、测试和发布仓库。普通业务集成、个人效率工具和社区 Skill 在这里独立维护和版本化，避免与 AgentDock Core 版本强耦合。
+
+AgentDock 主仓库的 `core-skills/` 只保留必须随 AgentDock 运行时一起安装和升级的内置核心 Skill；需要查找、阅读、贡献或发布其他 Skill 时，应优先查看 AgentDock Skills 仓库。安装第三方或社区 Skill 前仍应进行来源和安全审查。
+
+官方仓库：<https://github.com/uvwt/agentdock-skills>
+
+### ChatGPT 的工具 Schema 缓存
+
+使用 ChatGPT 平台连接 AgentDock 时，工具定义还存在一层平台侧缓存。AgentDock 已经完成工具变更，不代表当前 ChatGPT 会话会立即拿到新的 Schema。
+
+以下变化都应按“工具 Schema 已变更”处理：
+
+- 新增或删除工具；
+- 修改工具名称、描述、输入参数或输出 Schema；
+- AgentDock 升级后导致当前暴露的 MCP 工具集合发生变化。
+
+让变更在 ChatGPT 中生效时：
+
+1. 先确认 AgentDock Core 已经升级/重启并暴露新的工具定义；
+2. 进入 GPT 的 AgentDock 插件页面，点击**刷新**按钮，让 ChatGPT 重新获取 AgentDock 的工具 Schema；
+3. **新开一个会话**再进行验证。旧会话可能继续使用创建会话时缓存的旧 Schema。
+
+因此，如果出现“AgentDock 代码和 Core 都已经更新，但 ChatGPT 仍看不到新工具/新参数”的情况，不要继续反复重启 Core；先检查 ChatGPT 侧是否已经刷新插件并新建会话。这个缓存属于 ChatGPT 平台侧，不是 AgentDock 本地配置未生效。
+
+## 适用场景
+
+使用本 Skill 处理：
+
+- AgentDock 的定位、能力和基本使用方式；
+- “配置文件在哪里”“这个配置怎么改”“改完为什么没生效”；
+- macOS、Windows、Linux、Docker、直接运行二进制之间的配置差异；
+- Core 的启动、停止、重启、健康检查和配置生效验证；
+- 浏览器、MCP Apps UI、ACP、端口、日志、OAuth 等运行配置的入口；
+- 多台 AgentDock 设备中，确认应该修改哪一台设备的运行配置。
+
+不要用本 Skill 代替：
+
+- AgentDock 源码开发、重构、测试和 PR 流程；
+- 第三方 Skill 的创作或安全审查；
+- NexusDock、ChatDock 等其他项目自己的配置说明。
+
+## 最重要的配置模型
+
+AgentDock Core 在启动时从**进程环境**读取运行配置。不同发行方式负责把自己的持久化配置转换成 Core 的启动环境：
+
+- macOS Desktop：AgentDock.app 管理自己的运行环境文件；
+- Windows Desktop：控制面板设置、运行清单和受保护凭据共同生成 Core 环境；
+- Linux 服务：systemd/OpenRC 从安装时选择的环境文件加载配置；
+- Docker：容器的 environment / env_file 等启动配置决定 Core 环境；
+- 直接运行二进制：当前 shell 或进程管理器提供环境。
+
+因此：
+
+1. **不存在一个适用于所有平台的 `agentdock.yaml`。不要创建或建议创建它。**
+2. `~/.agentdock` 主要是 AgentDock 状态、Skill、会话等数据目录，不等于所有平台的 Core 运行配置文件。
+3. 改文件不等于已生效。大多数运行配置只有在对应 Core 进程重新启动后才会重新读取。
+4. 多设备之间的运行配置默认彼此独立。修改前先确认目标设备，不要假定一个设备的配置会同步到其他设备。
+
+常用运行配置和边界见 `references/configuration.md`。
+
+## 标准处理流程
+
+### 1. 先确认真实运行环境
+
+优先确认以下事实：
+
+- 当前操作的是哪台 AgentDock 设备；
+- Core 实际运行在 macOS、Windows、Linux 还是容器里；
+- 安装方式是 Desktop、Linux 服务、Docker，还是直接启动二进制；
+- 当前 AgentDock 版本；
+- Core 当前是否运行、健康检查是否通过。
+
+如果宿主提供 `agentdock_context`，优先用它读取当前设备的 `os`、`version`、AgentDock 状态目录和默认工作目录。它只能帮助确认当前 AgentDock 实例，不能替代对 Desktop runtime、service unit、Compose 配置等真实启动来源的检查。
+
+不要因为用户在 macOS 或 Windows 上聊天，就推断 AgentDock Core 一定直接运行在该系统：它也可能实际运行在 Docker、WSL、远程 Linux 或另一台设备。
+
+### 2. 按安装方式读取对应说明
+
+- macOS Desktop：`references/macos.md`
+- Windows Desktop：`references/windows.md`
+- Linux systemd/OpenRC/手工服务：`references/linux.md`
+- Docker / Docker Compose：`references/docker.md`
+- 直接运行 `agentdock`：继续使用本文件的“直接运行二进制”说明
+
+只读取与当前环境相关的 reference；不要一次把所有平台的命令都丢给用户选择。
+
+### 3. 修改前先查看现状
+
+涉及配置变更时，先读取当前真实配置来源，再决定修改方式：
+
+- Desktop 优先使用官方设置界面；
+- Linux 先确认 service unit 实际引用的 EnvironmentFile；
+- Docker 先读取当前 Compose/container 配置；
+- 直接运行二进制先确认启动命令和进程环境来源。
+
+不要只根据默认路径直接覆盖文件。安装器通常允许用户改变安装目录、服务名、环境文件路径或容器配置。
+
+涉及认证 Token、OAuth 密码、签名密钥、Tunnel Token 等秘密时，只确认“是否已配置”或使用安全的专用配置入口，不在回复、日志或截图中回显真实值。
+
+### 4. 让配置真正生效
+
+配置修改后，重启**实际承载 Core 的运行单元**：
+
+- Desktop：由桌面控制器保存并重启，或按平台 reference 使用对应 Core 重启方式；
+- systemd/OpenRC：重启实际 AgentDock service；
+- Docker：环境或 Compose 配置变化后重建/重建容器，不能只依赖 `docker compose restart`；
+- 直接运行二进制：结束旧进程，并从新环境重新启动。
+
+如果只修改 Skill 环境、动态 MCP 注册等由 AgentDock 自己管理的独立状态，应使用对应 Tool 的管理能力，不要误重写 Core 运行配置。
+
+### 5. 修改后必须验证
+
+至少验证两层：
+
+1. **进程层**：Core 已运行，`/healthz` 正常，或平台 service status 显示 healthy；
+2. **行为层**：本次修改对应能力真的变化，例如端口、MCP Apps UI、browser、ACP 或子进程环境行为符合预期。
+
+如果当前对话连接的就是被重启的 AgentDock，连接可能短暂中断；恢复后重新读取 `agentdock_context` 或实际状态，不要把“命令执行成功”当成“新配置已经生效”。
+
+配置失败时保留原配置和错误证据，优先恢复到已知可工作的配置，再报告具体失败点。
+
+## 直接运行二进制
+
+直接从终端、脚本或其他进程管理器启动 `agentdock` 时，没有额外的通用持久化配置层：Core 使用启动进程收到的环境变量。
+
+处理方式：
+
+1. 找出真正负责启动 `agentdock` 的 shell、脚本或进程管理器；
+2. 在那个启动来源里修改环境变量，而不是只在另一个终端临时 `export`；
+3. 停止旧 Core；
+4. 从更新后的环境重新启动；
+5. 检查 `/healthz` 和目标功能。
+
+如果用户实际使用 systemd、OpenRC、Docker 或 Desktop，不要按“直接运行二进制”处理。
+
+## 回答要求
+
+给用户的最终操作说明应尽量包含：
+
+- 当前识别出的平台和安装方式；
+- 实际配置事实源；
+- 要修改的具体设置；
+- 正确的生效动作；
+- 一条明确的验证方法；
+- 如果发现当前环境与预期不一致，说明证据，而不是继续猜测。
+
+涉及修改时优先直接使用当前可用 AgentDock 工具检查和验证真实环境；只有缺少操作能力时，才让用户手工执行必要步骤。

--- a/core-skills/agentdock-user-guide/references/configuration.md
+++ b/core-skills/agentdock-user-guide/references/configuration.md
@@ -1,0 +1,51 @@
+# AgentDock 运行配置速查
+
+本文件描述 AgentDock Core 当前版本从启动环境读取的主要运行配置。它不是新的配置文件格式，也不要求所有发行方式直接暴露这些变量给用户。
+
+## 常用配置
+
+| 配置键 | 作用 | 常见入口 |
+|---|---|---|
+| `AGENTDOCK_HOST` | Core 监听地址 | Linux env、Docker environment、直接启动 |
+| `AGENTDOCK_PORT` | MCP/HTTP 监听端口，默认 8765 | Desktop 设置、Linux env、Docker environment |
+| `AGENTDOCK_AUTH_TOKEN` | Bearer Token | 安装器、平台受保护凭据或容器 secret/env |
+| `AGENTDOCK_LOG_LEVEL` | `debug` / `info` / `warn` / `error` | Desktop 设置、Linux env、Docker environment |
+| `AGENTDOCK_MCP_APPS_ENABLED` | 是否启用 MCP Apps UI，默认启用 | Desktop 设置或启动环境 |
+| `AGENTDOCK_BROWSER_ENABLED` | 是否启用浏览器能力 | Desktop 设置或启动环境 |
+| `AGENTDOCK_BROWSER_EXECUTABLE_PATH` | 显式浏览器可执行文件 | Docker/服务器/高级运行环境 |
+| `AGENTDOCK_BROWSER_CDP_URL` | 复用已有 Chromium 的 CDP 地址 | Desktop 设置或启动环境 |
+| `AGENTDOCK_BROWSER_REUSE_EXISTING_CDP` | 自动复用唯一已发现 CDP | Desktop 设置或启动环境 |
+| `AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON` | 显式允许 `exec_command` 从 Core 宿主环境复制的变量映射 | Linux/Docker/直接启动的高级配置 |
+| `AGENTDOCK_ACP_ENABLED` | 是否启用 ACP Client | Desktop 设置或启动环境 |
+| `AGENTDOCK_ACP_AGENT` | ACP Agent 预设/名称 | Desktop 设置或启动环境 |
+| `AGENTDOCK_ACP_COMMAND` | ACP Adapter 命令 | 自定义/高级 ACP 配置 |
+| `AGENTDOCK_ACP_ARGS_JSON` | ACP Adapter 参数 JSON 数组 | 自定义/高级 ACP 配置 |
+| `AGENTDOCK_ACP_ENV_FROM_ENV_JSON` | ACP 子进程环境映射 | 高级 ACP 配置 |
+| `AGENTDOCK_ACP_MAX_CONCURRENT_PROMPTS` | ACP 并发 prompt 上限 | 高级 ACP 配置 |
+| `AGENTDOCK_ACP_INTERACTION_TIMEOUT_MS` | ACP 交互超时 | 高级 ACP 配置 |
+| `AGENTDOCK_SERVER_URL` | 对外服务 Origin | 公网/OAuth 安装流程 |
+| `AGENTDOCK_OAUTH_ENABLED` | 是否启用 OAuth | 安装器/公网访问配置 |
+| `AGENTDOCK_OAUTH_PASSWORD` | OAuth 登录密码 | 平台安全存储或受保护环境 |
+| `AGENTDOCK_OAUTH_TOKEN_SECRET` | OAuth Token 签名密钥 | 平台安全存储或受保护环境 |
+| `AGENTDOCK_OAUTH_ACCESS_TOKEN_TTL` | OAuth Access Token 有效期 | Desktop/高级启动配置 |
+| `AGENTDOCK_STDIO` | 是否启用 stdio 运行模式 | 直接启动/集成场景 |
+| `AGENTDOCK_TRUSTED_PROXY_CIDRS` | 受信任反向代理网段 | 服务器/反代场景 |
+| `AGENTDOCK_INSTRUCTIONS_FILE` | 额外 Instructions 文件 | 高级启动配置 |
+
+## 重要边界
+
+- Windows Desktop 不应把认证秘密直接写入 `control-panel-settings.json`。Bearer Token、OAuth 密码、OAuth 签名密钥和 Tunnel Token 使用平台受保护存储。
+- macOS Desktop 的 `agentdock.env` 包含运行所需配置，可能含秘密；文件必须保持仅当前用户可读写。
+- Linux 官方安装器默认把环境文件按 root:root、0600 写入，并通过 systemd/OpenRC 注入服务进程；不要为了方便把权限放宽。
+- Docker 的环境变量属于容器创建配置。Compose 文件或 env file 修改后，如果容器没有被重新创建，新进程可能仍使用旧的容器配置。
+- `AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON` 只允许显式映射；它不会自动把登录 Shell 的全部环境传给 `exec_command`。
+
+## 判断“配置没生效”时
+
+按顺序检查：
+
+1. 修改的是不是实际启动来源；
+2. Core 是否真的重新启动/容器是否真的重新创建；
+3. 新进程是否健康；
+4. 目标配置对应的行为是否变化；
+5. 是否有更高层的 Desktop、service、Compose 或进程管理器重新覆盖了手工修改。

--- a/core-skills/agentdock-user-guide/references/docker.md
+++ b/core-skills/agentdock-user-guide/references/docker.md
@@ -1,0 +1,97 @@
+# Docker / Docker Compose 配置与生效
+
+适用于官方 AgentDock Docker 镜像或基于它的 Compose 部署。宿主机可能是 macOS、Windows 或 Linux，但配置事实源是**容器创建配置**，不是宿主操作系统的 Desktop 配置文件。
+
+## 配置事实源
+
+官方镜像中 Core 直接读取容器进程环境。常见来源包括：
+
+- Compose `environment:`；
+- Compose `env_file:`；
+- `docker run -e/--env-file`；
+- 编排平台提供的环境变量或 secret 注入。
+
+官方 runtime 镜像默认：
+
+```text
+HOME=/home/agentdock
+AGENTDOCK_HOST=0.0.0.0
+AGENTDOCK_PORT=8765
+```
+
+官方镜像的容器用户 HOME 默认为 `/home/agentdock`，工作目录遵循 `$HOME/AgentDock`。如果派生镜像改变 HOME，应以容器真实 HOME 为准，而不是硬编码用户目录。
+
+AgentDock 状态默认位于容器用户 HOME 下。生产部署通常应把需要持久化的状态通过 volume/bind mount 保存；不要把“修改正在运行容器里的临时文件”当成长期配置方案。
+
+## 修改方式
+
+优先修改真正创建容器的 Compose/编排配置，而不是进入容器后临时 `export`。
+
+Compose 示例：
+
+```yaml
+services:
+  agentdock:
+    environment:
+      AGENTDOCK_PORT: "8765"
+      AGENTDOCK_LOG_LEVEL: info
+      AGENTDOCK_MCP_APPS_ENABLED: "true"
+```
+
+认证 Token、OAuth 密码和签名密钥不应提交到公开 Compose 文件；使用部署环境的 secret/env 管理方式，并避免在 `docker inspect`、日志或回复中回显真实值。
+
+## 生效：不要只 restart
+
+Compose 文件、env file 或环境变量变化后，旧容器的创建配置不会因为 `docker compose restart` 自动改变。
+
+应让 Compose 根据新配置重新创建容器：
+
+```bash
+docker compose up -d
+```
+
+如果需要明确保证重建：
+
+```bash
+docker compose up -d --force-recreate
+```
+
+`docker compose restart` 只重启现有容器，不能作为“环境变量已更新”的验证手段。
+
+使用 `docker run` 的部署则需要删除/替换旧容器，并用新的 `-e`、`--env-file`、volume 和端口映射重新创建。
+
+## 端口变化要检查两层
+
+`AGENTDOCK_PORT` 改变的是**容器内 Core 监听端口**。如果宿主端口映射仍是旧值，外部访问仍会失败。
+
+例如 Core 改到 9876 时，Compose 也应同步检查：
+
+```yaml
+ports:
+  - "9876:9876"
+```
+
+不要只改一侧。
+
+## 浏览器镜像
+
+官方 Dockerfile 的 browser 变体会启用浏览器并把 Chromium 路径配置为 `/usr/bin/chromium`。普通 runtime 镜像没有同样的浏览器依赖保证。
+
+用户询问“为什么 Docker 里启用 browser 仍不可用”时，先确认实际镜像变体和容器内浏览器可执行文件，不要只把 `AGENTDOCK_BROWSER_ENABLED=true` 作为充分条件。
+
+## 验证
+
+先看容器是否基于新配置被重新创建，再检查：
+
+```bash
+docker compose ps
+docker compose logs --tail=100 agentdock
+```
+
+然后从正确网络位置访问实际端口的：
+
+```text
+/healthz
+```
+
+最后验证本次修改对应的功能。不要在验证输出中打印完整容器环境，因为其中可能包含认证秘密。

--- a/core-skills/agentdock-user-guide/references/linux.md
+++ b/core-skills/agentdock-user-guide/references/linux.md
@@ -1,0 +1,96 @@
+# Linux 配置与生效
+
+适用于官方 Linux 安装脚本创建的 systemd/OpenRC 服务，以及用户自己用服务管理器托管 AgentDock 的场景。
+
+## 配置事实源
+
+官方 Linux 安装脚本允许用户选择：
+
+- 环境文件路径；
+- 服务名；
+- 服务用户；
+- systemd / OpenRC / 不安装系统服务。
+
+默认环境文件是：
+
+```text
+/etc/agentdock/agentdock.env
+```
+
+默认服务名是：
+
+```text
+agentdock
+```
+
+这些都可以被安装参数/环境变量覆盖，所以修改前先检查真实 service 定义：
+
+```bash
+systemctl cat agentdock
+```
+
+重点确认 `EnvironmentFile=`、`ExecStart=` 和实际 service 名称。OpenRC 则检查实际 `/etc/init.d/<service>` 中引用的环境文件。
+
+官方安装器还会在环境文件所在目录写 `desktop-runtime.json`，其中记录 service manager、service name、Core binary 和 environment file 等运行信息。它是运行清单，不是所有配置键的替代文件。
+
+## 修改方式
+
+systemd/OpenRC 部署时，修改服务实际加载的环境文件，而不是另开一个 shell `export` 后期待后台服务继承。
+
+官方安装器默认以 root:root、0600 保存环境文件。修改时保持现有 owner/mode，不要把认证配置暴露给其他用户。
+
+如果需要给 `exec_command` 透传宿主环境变量，必须同时满足：
+
+1. 源变量真实存在于 AgentDock **服务进程**的环境中；
+2. `AGENTDOCK_COMMAND_ENV_FROM_ENV_JSON` 显式声明子进程变量到宿主变量的映射。
+
+服务不会自动读取某个登录用户的 `.bashrc`、`.zshrc` 或交互式 Shell 环境。
+
+## 生效
+
+systemd：
+
+```bash
+sudo systemctl restart <实际服务名>
+sudo systemctl status <实际服务名> --no-pager
+```
+
+OpenRC：
+
+```bash
+sudo rc-service <实际服务名> restart
+sudo rc-service <实际服务名> status
+```
+
+只修改 EnvironmentFile 的内容通常不需要 `daemon-reload`；如果同时修改了 systemd unit 本身，则先执行：
+
+```bash
+sudo systemctl daemon-reload
+```
+
+再重启服务。
+
+如果安装时选择了“不安装系统服务”，则按直接运行二进制处理：重新加载真实启动环境并重启进程。
+
+## 验证与排障
+
+优先检查：
+
+```bash
+curl -fsS http://127.0.0.1:<实际端口>/healthz
+```
+
+systemd 日志：
+
+```bash
+sudo journalctl -u <实际服务名> -n 100 --no-pager
+```
+
+OpenRC 默认日志位置取决于安装脚本/服务定义；官方脚本使用 `/var/log/<service>.log` 和 `/var/log/<service>.err`。
+
+如果“文件已经改了但行为没变”，重点确认：
+
+1. 是否编辑了 service 真正引用的 EnvironmentFile；
+2. 服务是否真的重启成功；
+3. 新进程是否因为配置校验失败而反复退出；
+4. 是否有 systemd unit 的额外 `Environment=`、容器层或外部进程管理器覆盖了预期值。

--- a/core-skills/agentdock-user-guide/references/macos.md
+++ b/core-skills/agentdock-user-guide/references/macos.md
@@ -1,0 +1,59 @@
+# macOS Desktop 配置与生效
+
+适用于通过 `AgentDock.app` 运行的 macOS Desktop。不要把 Linux 的 systemd 环境文件、Windows runtime root 或 Docker Compose 流程套到这里。
+
+## 配置事实源
+
+当前 macOS Desktop 的运行目录是：
+
+```text
+$HOME/Library/Application Support/AgentDock
+```
+
+Core 运行环境文件是：
+
+```text
+$HOME/Library/Application Support/AgentDock/agentdock.env
+```
+
+AgentDock.app 的高级设置控制器会读取这份文件，校验配置后原子写回，并保持私有文件权限。保存成功且 Core 已加载时，App 会重启 Core；如果新配置启动失败，会尝试恢复旧配置并再次重启。
+
+常见可编辑项包括：端口、日志级别、MCP Apps UI、浏览器、已有 CDP、ACP Agent 与 ACP Adapter 参数。
+
+## 推荐修改方式
+
+优先使用 AgentDock.app 的设置/高级设置界面。这样可以复用当前版本的校验、原子写入和失败回滚逻辑。
+
+不要把 `agentdock config update` 当成 macOS Desktop 的通用配置入口：当前非 Windows 实现明确把桌面配置交给原生配置控制器管理。
+
+只有 UI 没有覆盖的高级变量，才考虑手工编辑 `agentdock.env`。手工修改时：
+
+1. 先读取当前文件，不要覆盖未知键；
+2. 不回显认证秘密；
+3. 保持文件为普通文件且仅当前用户可读写；
+4. 修改后重启已经由 AgentDock.app 注册的 Core；
+5. 验证 `/healthz` 和目标功能。
+
+如果当前环境存在可用 `agentdock` CLI，Core 重启需要显式 runtime root：
+
+```bash
+agentdock service restart --runtime-root "$HOME/Library/Application Support/AgentDock"
+```
+
+如果 CLI 不在 PATH，优先由 AgentDock.app 自己保存设置或控制 Core，不要为了重启额外安装第二套 Core。
+
+## 不要做的事
+
+- 不要创建 `~/Library/LaunchAgents/com.uvwt.agentdock*.plist` 作为替代生命周期。当前 macOS Desktop 由 AgentDock.app 的 SMAppService 管理后台 Core/Tunnel。
+- 不要把 `~/.agentdock` 当成 macOS Desktop 的 Core 环境文件目录。
+- 不要手工覆盖 App Bundle 内的 Core 二进制来“让配置生效”。
+- 不要降低 `agentdock.env` 权限以方便其他用户读取。
+
+## 验证
+
+至少检查：
+
+1. AgentDock Core 已恢复运行；
+2. 实际监听端口对应的 `/healthz` 返回成功；
+3. 本次修改的功能真的变化；
+4. 如果 App 报告回滚，读取错误证据并确认旧配置已恢复，而不是继续覆盖文件。

--- a/core-skills/agentdock-user-guide/references/windows.md
+++ b/core-skills/agentdock-user-guide/references/windows.md
@@ -1,0 +1,60 @@
+# Windows Desktop 配置与生效
+
+适用于官方 Windows Desktop / Setup 安装。不要把 macOS `agentdock.env`、Linux EnvironmentFile 或 Docker Compose 当成 Windows Desktop 的配置事实源。
+
+## 运行目录与配置事实源
+
+官方安装器默认把二进制放在：
+
+```text
+%LOCALAPPDATA%\AgentDock\bin
+```
+
+因此默认 runtime root 是：
+
+```text
+%LOCALAPPDATA%\AgentDock
+```
+
+安装器允许改变安装目录，所以操作前应优先读取当前 `runtime.json`、控制面板显示的配置目录，或实际启动参数中的 `--runtime-root`，不要只依赖默认值。
+
+Windows Desktop 的运行配置由多部分组成：
+
+- `control-panel-settings.json`：端口、日志、MCP Apps UI、浏览器、ACP 等普通设置；
+- `runtime.json`：安装位置、Core、Tray、Tunnel 与启动方式等运行清单；
+- `auth-token.dpapi`、`oauth-password.dpapi`、`oauth-token-secret.dpapi`、`cloudflared-token.dpapi`：受当前 Windows 用户保护的秘密；
+- `server-url.txt`、Tunnel 状态文件等：公网/OAuth/Tunnel 运行状态。
+
+Core 启动时会读取这些状态并生成实际进程环境。
+
+## 推荐修改方式
+
+优先使用 AgentDock Windows 控制面板。保存设置时，控制面板会调用当前 Core 的结构化配置入口；该入口会校验新设置、保存配置、重启 Core/Tunnel，并在失败时恢复原文件后尝试恢复旧运行状态。
+
+如果必须通过 CLI 修改控制面板覆盖的普通设置，应使用当前安装目录里的 `agentdock.exe config update --runtime-root <实际目录> ...`，不要手工拼写另一份 JSON 并假定所有字段都会被读取。
+
+## 手工修改边界
+
+- 不要把 Bearer Token、OAuth 密码、OAuth 签名密钥或 Tunnel Token 写进 `control-panel-settings.json`。
+- 不要手工解密、复制或跨用户迁移 DPAPI 文件；它们绑定 Windows 用户保护上下文。
+- 不要只修改 `runtime.json` 来改变普通设置；它主要描述运行时布局与启动状态。
+- 如果手工改了 `control-panel-settings.json`，旧 Core 不会自动重新读取，仍需重启实际 Core。
+- 提权模式可能由 Scheduled Task 启动 Core；标准模式可能由普通后台进程启动。不要用“杀掉一个同名进程”代替官方 service/control-panel 操作。
+
+## 生效与验证
+
+优先通过控制面板执行保存/重启。需要 CLI 时，使用当前实际 runtime root，例如默认安装可表示为：
+
+```powershell
+agentdock service restart --runtime-root "$env:LOCALAPPDATA\AgentDock"
+agentdock service status --runtime-root "$env:LOCALAPPDATA\AgentDock"
+```
+
+如果安装目录不是默认值，把路径替换成 `runtime.json` 所在目录。
+
+验证至少包括：
+
+1. `service status` 或控制面板显示 Core running/healthy；
+2. 当前端口的 `/healthz` 成功；
+3. 本次设置对应的功能真的变化；
+4. 如果配置更新返回回滚错误，检查当前文件和 Core 状态是否已恢复，不要继续覆盖 DPAPI 或 runtime 文件。

--- a/packaging/build-core-skill-bundle.py
+++ b/packaging/build-core-skill-bundle.py
@@ -12,6 +12,7 @@ import zipfile
 from pathlib import Path
 
 CORE_SKILLS = (
+    "agentdock-user-guide",
     "skill-authoring",
     "skill-installation",
     "skill-vetter-runtime",

--- a/scripts/test/core_skill_bundle_test.go
+++ b/scripts/test/core_skill_bundle_test.go
@@ -38,7 +38,7 @@ func TestCoreSkillBundleNormalizesTextLineEndings(t *testing.T) {
 	build := func(lineEnding string) string {
 		t.Helper()
 		repoRoot := t.TempDir()
-		for _, name := range []string{"skill-authoring", "skill-installation", "skill-vetter-runtime"} {
+		for _, name := range []string{"agentdock-user-guide", "skill-authoring", "skill-installation", "skill-vetter-runtime"} {
 			skillRoot := filepath.Join(repoRoot, "core-skills", name)
 			if err := os.MkdirAll(skillRoot, 0o700); err != nil {
 				t.Fatal(err)
@@ -66,6 +66,7 @@ func TestCoreSkillBundleNormalizesTextLineEndings(t *testing.T) {
 	crlfBundle := build("\r\n")
 	for _, relative := range []string{
 		"manifest.json",
+		filepath.Join("packages", "agentdock-user-guide.zip"),
 		filepath.Join("packages", "skill-authoring.zip"),
 		filepath.Join("packages", "skill-installation.zip"),
 		filepath.Join("packages", "skill-vetter-runtime.zip"),

--- a/scripts/test/test-docker-images.sh
+++ b/scripts/test/test-docker-images.sh
@@ -174,7 +174,7 @@ wait_for_healthy "$runtime_container" runtime
 docker exec "$runtime_container" sh -c 'curl -fsS http://127.0.0.1:8765/healthz >/dev/null'
 docker exec "$runtime_container" sh -c '
   test -f "$HOME/.agentdock/skill-store/bundled-skills.json"
-  for skill in skill-authoring skill-installation skill-vetter-runtime; do
+  for skill in agentdock-user-guide skill-authoring skill-installation skill-vetter-runtime; do
     version="$(jq -r .active_version "$HOME/.agentdock/skill-store/state/$skill.json")"
     test -n "$version"
     test -f "$HOME/.agentdock/skill-store/installed/$skill/$version/SKILL.md"

--- a/scripts/test/test-install-macos.sh
+++ b/scripts/test/test-install-macos.sh
@@ -114,6 +114,7 @@ test -x "$binary"
 "$binary" --help >/dev/null 2>&1
 test -d "$state_dir"
 test -f "$state_dir/skill-store/bundled-skills.json"
+test -f "$state_dir/skill-store/installed/agentdock-user-guide/1.0.4/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-authoring/1.2.0/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-installation/1.2.0/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-vetter-runtime/0.1.5/SKILL.md"

--- a/scripts/test/test-install-windows-e2e.ps1
+++ b/scripts/test/test-install-windows-e2e.ps1
@@ -130,7 +130,7 @@ function Assert-AgentDockHealthy {
         throw "Bundled Skill list was not created: $bundledPath"
     }
     $bundled = @((Get-Content -LiteralPath $bundledPath -Raw | ConvertFrom-Json).skills)
-    foreach ($skill in @('skill-authoring', 'skill-installation', 'skill-vetter-runtime')) {
+    foreach ($skill in @('agentdock-user-guide', 'skill-authoring', 'skill-installation', 'skill-vetter-runtime')) {
         if ($bundled -notcontains $skill) {
             throw "Bundled Skill list does not contain $skill."
         }


### PR DESCRIPTION
## 变更
- 内置 `agentdock-user-guide` 官方用户指南 Skill
- 覆盖 macOS、Windows、Linux、Docker 与直接运行二进制的配置与生效方式
- 补充 ChatGPT 工具 Schema 缓存刷新说明
- 补充 NexusDock、AgentDock Skills 与文档仓库说明
- 更新 Core Skill Bundle 与安装/镜像测试

## 验证
- `skill-authoring` lint：0 error / 0 warning
- `skill_package validate`：通过
- `git diff --check`：通过
- `make check`：通过