### PR TITLE
release: 发布 v0.8.2

### DIFF
--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const Version = "0.8.1"
+const Version = "0.8.2"
 
 var (
 	Commit    string


### PR DESCRIPTION
准备 AgentDock v0.8.2 正式发布。

- 内置版本：0.8.2
- 基线：当前 main 已通过 CI / CodeQL / Windows Installer
- 本地已通过：`GOWORK=off make check`、`git diff --check`、`go run ./cmd/agentdock --version`

合并后从 main 对应提交创建 annotated tag `v0.8.2`，由 Release workflow 构建并发布 Linux / macOS / Windows 资产、GHCR / Docker Hub 镜像并执行发布后验证。
