### PR TITLE
fix(file): honor expected_matches=0 assertions

### DIFF
--- a/internal/tool/file/service_behavior_test.go
+++ b/internal/tool/file/service_behavior_test.go
@@ -97,6 +97,33 @@ func TestEditFileRejectsUnexpectedMatchCounts(t *testing.T) {
 	}
 }
 
+func TestEditFileExpectedZeroSucceedsWhenTextIsAbsent(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.go")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := rt.editFileTest(map[string]any{
+		"path":             "main.go",
+		"old":              "missing",
+		"new":              "beta",
+		"expected_matches": 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["matches"] != 0 || result["changed"] != false {
+		t.Fatalf("unexpected zero-match assertion result: %#v", result)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "alpha\n" {
+		t.Fatalf("zero-match assertion wrote file: %q", data)
+	}
+}
+
 func TestEditFileReplaceAll(t *testing.T) {
 	rt, root := newFileTestService(t)
 	path := filepath.Join(root, "main.go")

--- a/internal/tool/file/text_edit_prepare.go
+++ b/internal/tool/file/text_edit_prepare.go
@@ -24,7 +24,7 @@ func prepareTextReplacement(path, content string, request EditRequest) (Result, 
 	if expected == 0 && len(indexes) > 0 {
 		return nil, "", toolErrorDetails("MATCH_COUNT_MISMATCH", "old text matched but expected zero matches", "validation", map[string]any{"path": path, "matches": len(indexes), "expected_matches": expected, "nearby_context": editNearbyContext(content, indexes)})
 	}
-	if len(indexes) == 0 {
+	if expected > 0 && len(indexes) == 0 {
 		return nil, "", toolErrorDetails("MATCH_COUNT_MISMATCH", "old text did not match", "validation", map[string]any{"path": path, "matches": 0, "expected_matches": expected})
 	}
 


### PR DESCRIPTION
Summary:
- allow replace requests with expected_matches=0 to succeed when old text is absent
- return matches=0 and changed=false without writing the file
- keep rejecting requests when text is present but zero matches were expected

The public file_edit schema documents zero as a no-match assertion, but the implementation previously rejected every absent match after validating the assertion.

Tests:
- go test ./internal/tool/file