### PR TITLE
fix(command): 修复 Unix 进程组终止竞态

### DIFF
--- a/internal/process/process_unix.go
+++ b/internal/process/process_unix.go
@@ -7,6 +7,12 @@ import (
 	"fmt"
 	"os/exec"
 	"syscall"
+	"time"
+)
+
+const (
+	processGroupTerminateAttempts = 5
+	processGroupTerminateDelay    = time.Millisecond
 )
 
 // Controller owns the operating-system process group created for one command.
@@ -39,13 +45,30 @@ func (c *Controller) Terminate() error {
 	if c == nil || c.pid <= 0 {
 		return nil
 	}
-	err := syscall.Kill(-c.pid, syscall.SIGKILL)
-	// 进程可能在终止请求到达前已经自然退出；如果整个进程组已不存在，
-	// shutdown 的目标已经达成，不应把 ESRCH 当成终止失败。
-	if errors.Is(err, syscall.ESRCH) {
-		return nil
+
+	// killpg 只会向调用瞬间已经属于进程组的成员发信号。shell 若正处于 fork，
+	// 新 child 可能在第一次 SIGKILL 的进程组快照之后出生并继续持有 stdout/stderr，
+	// 让 cmd.Wait 长时间无法返回。第一次成功后做有界重试：只要还能命中可终止成员，
+	// 就再给 fork 窗口一个调度周期；组消失后立即结束。
+	for attempt := 0; attempt < processGroupTerminateAttempts; attempt++ {
+		err := syscall.Kill(-c.pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		if err != nil {
+			// Darwin 对只剩 zombie、已无可 signal 成员的进程组可能返回 EPERM。
+			// 首次 kill 已成功时，这和 ESRCH 一样表示当前用户已无可继续终止的成员；
+			// 首次就 EPERM 仍然保留为真实权限错误。
+			if attempt > 0 && errors.Is(err, syscall.EPERM) {
+				return nil
+			}
+			return err
+		}
+		if attempt+1 < processGroupTerminateAttempts {
+			time.Sleep(processGroupTerminateDelay)
+		}
 	}
-	return err
+	return nil
 }
 
 // Close releases platform resources. Unix process groups do not own handles.

--- a/internal/process/process_unix_test.go
+++ b/internal/process/process_unix_test.go
@@ -1,0 +1,68 @@
+//go:build darwin || linux
+
+package process
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestTerminateDoesNotLeaveChildHoldingCommandPipes(t *testing.T) {
+	const iterations = 128
+	root := t.TempDir()
+
+	for iteration := range iterations {
+		marker := filepath.Join(root, fmt.Sprintf("started-%03d", iteration))
+		cmd := exec.Command("/bin/sh", "-c", `printf started > "$AGENTDOCK_MARKER"; sleep 30`)
+		cmd.Env = append(os.Environ(), "AGENTDOCK_MARKER="+marker)
+		var output bytes.Buffer
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+		Configure(cmd)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("iteration %d Start() error = %v", iteration, err)
+		}
+		controller, err := Attach(cmd)
+		if err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatalf("iteration %d Attach() error = %v", iteration, err)
+		}
+		waitDone := make(chan error, 1)
+		go func() { waitDone <- cmd.Wait() }()
+
+		deadline := time.Now().Add(time.Second)
+		for {
+			if _, err := os.Stat(marker); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+				<-waitDone
+				t.Fatalf("iteration %d shell did not reach fork boundary", iteration)
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+
+		if err := controller.Terminate(); err != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			<-waitDone
+			t.Fatalf("iteration %d Terminate() error = %v", iteration, err)
+		}
+		select {
+		case <-waitDone:
+		case <-time.After(500 * time.Millisecond):
+			// A child forked after a one-shot killpg keeps os/exec's stdout/stderr pipes open.
+			// Clean it up before failing so the regression test never leaks a 30-second process.
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			<-waitDone
+			t.Fatalf("iteration %d command pipes stayed open after process-group termination", iteration)
+		}
+	}
+}


### PR DESCRIPTION
## 问题
main 的 macOS CI 偶发失败：`TestRuntimeCloseCancelsForegroundCommandAndRejectsNewStarts` 在 `Runtime.Close()` 阶段等待 command reservation 3s 超时。

## 根因
Unix `killpg(SIGKILL)` 与 shell `fork` 存在竞态：第一次 group signal 返回成功且 shell 已终止后，刚好在 signal 快照之后出生的 child 仍可能存活，并继续持有 stdout/stderr pipe，导致 `cmd.Wait()` 不返回，reservation 无法释放。

## 修复
- 在 Unix process Controller 层对同一 PGID 做有界重复 SIGKILL（最多 5 次、间隔 1ms），覆盖 fork race。
- 保留首次 EPERM 为真实权限错误；兼容 macOS 首次成功后 zombie-only process group 的 EPERM。
- 不修改 Runtime/Store 生命周期，不增加 `sessionKillWait`，避免用更大超时掩盖竞态。
- 新增 Unix 进程组回归测试，覆盖 shell fork + pipe 持有场景。

## 验证
- 未修复的 origin/main + 新回归测试可真实复现 `command pipes stayed open after process-group termination`。
- 修复后 focused fork-race stress 1280 次通过。
- 原失败生命周期测试 1000 次并行压力通过，额外 200 次提交前复验通过。
- `go test ./...` 通过。
- `go test -race ./internal/process ./internal/tool/command ./internal/app` 通过。
- `go vet ./...`、Linux amd64 交叉编译、`git diff --check` 通过。
