### PR TITLE
fix(browser): 兼容 Edge 内置远程调试复用

### DIFF
--- a/internal/tool/browser/cdp_discovery.go
+++ b/internal/tool/browser/cdp_discovery.go
@@ -21,7 +21,7 @@ const cdpProbeTimeout = 500 * time.Millisecond
 
 var (
 	remoteDebuggingPortPattern = regexp.MustCompile(`--remote-debugging-port(?:=|\s+)(\d+)`)
-	userDataDirPattern         = regexp.MustCompile(`--user-data-dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s]+))`)
+	userDataDirPattern         = regexp.MustCompile(`(?i)(?:"--user-data-dir(?:=|\s+)([^"]+)"|'--user-data-dir(?:=|\s+)([^']+)'|--user-data-dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s"]+)))`)
 )
 
 type cdpCandidate struct {
@@ -137,15 +137,26 @@ func resolveCDPWebSocket(parent context.Context, rawURL string, timeout time.Dur
 }
 
 func discoverCDPEndpoints(ctx context.Context) ([]cdpCandidate, error) {
-	candidateByURL := make(map[string]cdpCandidate)
+	candidateByListener := make(map[string]cdpCandidate)
 	add := func(rawURL, source string) {
 		rawURL = strings.TrimSpace(rawURL)
 		if rawURL == "" {
 			return
 		}
-		if _, exists := candidateByURL[rawURL]; !exists {
-			candidateByURL[rawURL] = cdpCandidate{URL: rawURL, Source: source}
+		parsed, err := url.Parse(rawURL)
+		if err != nil || parsed.Host == "" {
+			return
 		}
+		listener := strings.ToLower(parsed.Host)
+		candidate := cdpCandidate{URL: rawURL, Source: source}
+		if existing, exists := candidateByListener[listener]; exists {
+			// 同一个 CDP listener 可能同时从进程参数和 DevToolsActivePort 被发现。
+			// DevToolsActivePort 给出的 browser WebSocket 更精确，也能兼容 Edge 不暴露 /json/version 的模式。
+			if !isBrowserWebSocketURL(rawURL) || isBrowserWebSocketURL(existing.URL) {
+				return
+			}
+		}
+		candidateByListener[listener] = candidate
 	}
 
 	lines, _ := browserProcessCommandLines(ctx)
@@ -174,18 +185,44 @@ func discoverCDPEndpoints(ctx context.Context) ([]cdpCandidate, error) {
 		}
 	}
 
-	urls := make([]string, 0, len(candidateByURL))
-	for rawURL := range candidateByURL {
-		urls = append(urls, rawURL)
+	candidates := make([]cdpCandidate, 0, len(candidateByListener))
+	for _, candidate := range candidateByListener {
+		candidates = append(candidates, candidate)
 	}
-	sort.Strings(urls)
-	valid := make([]cdpCandidate, 0, len(urls))
-	for _, rawURL := range urls {
-		if err := probeCDPEndpoint(ctx, rawURL); err == nil {
-			valid = append(valid, candidateByURL[rawURL])
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].URL < candidates[j].URL })
+	valid := make([]cdpCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if err := probeCDPEndpoint(ctx, candidate.URL); err == nil {
+			valid = append(valid, candidate)
 		}
 	}
 	return valid, nil
+}
+
+func isBrowserWebSocketURL(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return (scheme == "ws" || scheme == "wss") && hasBrowserWebSocketPath(parsed)
+}
+
+func hasBrowserWebSocketPath(parsed *url.URL) bool {
+	const prefix = "/devtools/browser/"
+	if parsed == nil || !strings.HasPrefix(parsed.Path, prefix) {
+		return false
+	}
+	id := strings.TrimPrefix(parsed.Path, prefix)
+	return id != "" && !strings.ContainsAny(id, `/\\`)
+}
+
+func validDevToolsBrowserPath(rawPath string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawPath))
+	if err != nil || parsed.Scheme != "" || parsed.Host != "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return false
+	}
+	return hasBrowserWebSocketPath(parsed)
 }
 
 func extractUserDataDir(line string) string {
@@ -215,13 +252,53 @@ func candidateFromDevToolsActivePort(userDataDir string) (cdpCandidate, bool) {
 	if err != nil || port < 1 || port > 65535 {
 		return cdpCandidate{}, false
 	}
+	if len(lines) >= 2 {
+		browserPath := strings.TrimSpace(lines[1])
+		if validDevToolsBrowserPath(browserPath) {
+			return cdpCandidate{
+				URL:    fmt.Sprintf("ws://127.0.0.1:%d%s", port, browserPath),
+				Source: "devtools_active_port",
+			}, true
+		}
+	}
 	return cdpCandidate{URL: fmt.Sprintf("http://127.0.0.1:%d", port), Source: "devtools_active_port"}, true
 }
 
 func probeCDPEndpoint(parent context.Context, baseURL string) error {
+	if err := validateCDPURL(baseURL); err != nil {
+		return err
+	}
+	parsed, _ := url.Parse(strings.TrimSpace(baseURL))
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "ws" || scheme == "wss" {
+		if !hasBrowserWebSocketPath(parsed) {
+			return fmt.Errorf("CDP endpoint did not expose a browser websocket")
+		}
+		port := parsed.Port()
+		if port == "" {
+			if scheme == "wss" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		ctx, cancel := context.WithTimeout(parent, cdpProbeTimeout)
+		defer cancel()
+		conn, err := (&net.Dialer{Timeout: cdpProbeTimeout}).DialContext(ctx, "tcp", net.JoinHostPort(parsed.Hostname(), port))
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}
+
 	ctx, cancel := context.WithTimeout(parent, cdpProbeTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/json/version", nil)
+	endpoint := *parsed
+	endpoint.Path = "/json/version"
+	endpoint.RawPath = ""
+	endpoint.RawQuery = ""
+	endpoint.Fragment = ""
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/tool/browser/cdp_discovery_test.go
+++ b/internal/tool/browser/cdp_discovery_test.go
@@ -3,6 +3,7 @@ package browser
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -108,9 +109,10 @@ func TestResolveCDPWebSocketPinsEndpointHost(t *testing.T) {
 
 func TestExtractUserDataDir(t *testing.T) {
 	cases := map[string]string{
-		`chrome --user-data-dir=/tmp/a --remote-debugging-port=9222`:         "/tmp/a",
-		`chrome --user-data-dir="/tmp/with space" --remote-debugging-port=0`: "/tmp/with space",
-		`chrome --user-data-dir '/tmp/single space'`:                         "/tmp/single space",
+		`chrome --user-data-dir=/tmp/a --remote-debugging-port=9222`:                                                         "/tmp/a",
+		`chrome --user-data-dir="/tmp/with space" --remote-debugging-port=0`:                                                 "/tmp/with space",
+		`chrome --user-data-dir '/tmp/single space'`:                                                                         "/tmp/single space",
+		`msedge.exe "--user-data-dir=C:\Users\Administrator\AppData\Local\Microsoft\Edge\User Data" --type=crashpad-handler`: `C:\Users\Administrator\AppData\Local\Microsoft\Edge\User Data`,
 	}
 	for command, want := range cases {
 		if got := extractUserDataDir(command); got != want {
@@ -120,13 +122,48 @@ func TestExtractUserDataDir(t *testing.T) {
 }
 
 func TestCandidateFromDevToolsActivePort(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "DevToolsActivePort"), []byte("49152\n/devtools/browser/test\n"), 0o600); err != nil {
+	cases := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "browser websocket", data: "49152\n/devtools/browser/test\n", want: "ws://127.0.0.1:49152/devtools/browser/test"},
+		{name: "single line fallback", data: "49152\n", want: "http://127.0.0.1:49152"},
+		{name: "absolute URL fallback", data: "49152\nws://169.254.169.254/devtools/browser/test\n", want: "http://127.0.0.1:49152"},
+		{name: "network path fallback", data: "49152\n//example.invalid/devtools/browser/test\n", want: "http://127.0.0.1:49152"},
+		{name: "query fallback", data: "49152\n/devtools/browser/test?token=unexpected\n", want: "http://127.0.0.1:49152"},
+		{name: "nested path fallback", data: "49152\n/devtools/browser/test/extra\n", want: "http://127.0.0.1:49152"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "DevToolsActivePort"), []byte(tc.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			candidate, ok := candidateFromDevToolsActivePort(dir)
+			if !ok || candidate.URL != tc.want || candidate.Source != "devtools_active_port" {
+				t.Fatalf("candidate = %#v, ok=%v, want URL %q", candidate, ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeCDPEndpointAcceptsBrowserWebSocketListenerWithoutHTTPDiscovery(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
 		t.Fatal(err)
 	}
-	candidate, ok := candidateFromDevToolsActivePort(dir)
-	if !ok || candidate.URL != "http://127.0.0.1:49152" || candidate.Source != "devtools_active_port" {
-		t.Fatalf("candidate = %#v, ok=%v", candidate, ok)
+	endpoint := "ws://" + listener.Addr().String() + "/devtools/browser/test"
+	if err := probeCDPEndpoint(context.Background(), endpoint); err != nil {
+		listener.Close()
+		t.Fatal(err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := probeCDPEndpoint(context.Background(), endpoint); err == nil {
+		t.Fatal("closed browser websocket listener unexpectedly passed probe")
 	}
 }
 

--- a/internal/tool/browser/external_integration_test.go
+++ b/internal/tool/browser/external_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -114,14 +115,22 @@ func TestExternalCDPAttachKeepsBrowserAliveAndIsolatesTargets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	expectedEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
 	found := false
 	for _, candidate := range candidates {
-		if candidate.URL == endpoint {
+		candidateURL, parseErr := url.Parse(candidate.URL)
+		if parseErr != nil || candidateURL.Host != expectedEndpoint.Host {
+			continue
+		}
+		if candidate.Source == "devtools_active_port" && isBrowserWebSocketURL(candidate.URL) {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("auto-discovery did not find random-port external browser %s: %#v", endpoint, candidates)
+		t.Fatalf("auto-discovery did not find DevToolsActivePort browser websocket for %s: %#v", endpoint, candidates)
 	}
 }

--- a/internal/tool/browser/service.go
+++ b/internal/tool/browser/service.go
@@ -107,7 +107,12 @@ func (s *Service) start(ctx context.Context, req StartRequest) (StartResult, err
 			}
 		}
 		allocatorCtx, allocatorCancel := chromedp.NewRemoteAllocator(context.Background(), wsURL, chromedp.NoModifyURL)
-		browserCtx, browserCancel := chromedp.NewContext(allocatorCtx)
+		// Edge 内置 Remote Debugging 首次连接会等待用户在浏览器里确认授权。
+		// chromedp 默认只有 10 秒 dial timeout，这里与 browser_session 的请求 timeout 对齐。
+		browserCtx, browserCancel := chromedp.NewContext(
+			allocatorCtx,
+			chromedp.WithBrowserOption(chromedp.WithDialTimeout(req.Timeout)),
+		)
 		sess = &session{
 			id:              newSessionID(),
 			kind:            BrowserAuto,


### PR DESCRIPTION
## Summary
- use the browser WebSocket path from `DevToolsActivePort` for Edge built-in remote debugging
- correctly parse quoted Windows `--user-data-dir` arguments and deduplicate candidates by listener
- align chromedp WebSocket dial timeout with the browser session timeout

## Verification
- `go test ./internal/tool/browser`
- `go test ./...` on Windows before final rebase
- Tianyi Edge 152: `/json/version` returned 404, discovery found the `DevToolsActivePort` WebSocket, and the real session connected as `external_discovered`

Closes #80