### PR TITLE
fix(windows): hide background tool subprocess windows

### DIFF
--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -24,7 +24,7 @@ type Controller struct {
 }
 
 // Configure 在后台子进程启动前禁用控制台窗口，同时保留调用方已有的创建标志。
-// 标准命令、WSL 文件辅助进程和 stdio MCP 通过该入口启动；ACP 为兼容 Windows sandbox 使用独立启动策略。
+// 标准命令、短生命周期后台 CLI、WSL 文件辅助进程和 stdio MCP 通过该入口启动；ACP 为兼容 Windows sandbox 使用独立启动策略。
 func Configure(cmd *exec.Cmd) {
 	if cmd == nil {
 		return

--- a/internal/tool/browser/process_discovery_windows.go
+++ b/internal/tool/browser/process_discovery_windows.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+
+	processcontrol "github.com/uvwt/agentdock/internal/process"
 )
 
 const browserProcessPowerShell = `$ErrorActionPreference='Stop'; Get-CimInstance Win32_Process | Where-Object { $_.Name -match '^(chrome|chromium|msedge)\.exe$' -and $_.CommandLine } | ForEach-Object { $_.CommandLine }`
 
 func browserProcessCommandLines(ctx context.Context) ([]string, error) {
-	output, err := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command", browserProcessPowerShell).Output()
+	command := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command", browserProcessPowerShell)
+	processcontrol.Configure(command)
+	output, err := command.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tool/file/git_apply_patch.go
+++ b/internal/tool/file/git_apply_patch.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	processcontrol "github.com/uvwt/agentdock/internal/process"
 	"github.com/uvwt/agentdock/internal/textutil"
 	workspacepkg "github.com/uvwt/agentdock/internal/workspace"
 )
@@ -35,6 +36,7 @@ func (svc *Service) applyPatch(ctx context.Context, request EditRequest) (Result
 	}
 	cmd.Dir = workdir.Abs
 	cmd.Stdin = strings.NewReader(patch)
+	processcontrol.Configure(cmd)
 	output, outputTotal, outputTruncated, err := runBoundedCombinedOutput(cmd, 1<<20)
 	if err != nil {
 		outputText, _ := truncateBytes(output, 1<<20)

--- a/internal/tool/file/search.go
+++ b/internal/tool/file/search.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	processcontrol "github.com/uvwt/agentdock/internal/process"
 	"github.com/uvwt/agentdock/internal/workspace"
 )
 
@@ -121,6 +122,7 @@ func (svc *Service) searchTextRG(ctx context.Context, p workspace.Path, opts Sea
 	defer cancel()
 	cmd := exec.CommandContext(ctx, rg, args...)
 	cmd.Dir = p.Abs
+	processcontrol.Configure(cmd)
 	output, err := cmd.Output()
 	if err != nil {
 		if exit, ok := err.(*exec.ExitError); ok && exit.ExitCode() == 1 {


### PR DESCRIPTION
Fixes #52

- apply the shared process configuration to `search_text` ripgrep subprocesses
- apply the same policy to `git apply` and Windows browser-process discovery PowerShell calls
- keep ACP, GUI launches, detached services/tunnels and self-update lifecycle paths unchanged

Validation:
- `go test ./internal/process ./internal/tool/file ./internal/tool/browser`
- `go test ./internal/...`
- Windows runtime verification: a 30s `search_text -> rg` call completed with no extra Windows Terminal/console window observed
- reviewed with TianYi agy (PASS)