### PR TITLE
fix(skill): 强化 ZIP 解压路径边界校验

### DIFF
--- a/internal/skill/digest.go
+++ b/internal/skill/digest.go
@@ -121,6 +121,11 @@ func extractZip(src, dest string, maxBytes int64) error {
 		return err
 	}
 	defer reader.Close()
+	root := filepath.Clean(dest)
+	rootPrefix := root
+	if !strings.HasSuffix(rootPrefix, string(os.PathSeparator)) {
+		rootPrefix += string(os.PathSeparator)
+	}
 	var total int64
 	for _, file := range reader.File {
 		if file.Mode()&os.ModeSymlink != 0 {
@@ -130,7 +135,12 @@ func extractZip(src, dest string, maxBytes int64) error {
 		if err := validateRelativePackagePath(name); err != nil {
 			return fmt.Errorf("zip path escapes package root: %s: %w", file.Name, err)
 		}
-		target := filepath.Join(dest, filepath.FromSlash(name))
+		target := filepath.Clean(filepath.Join(root, filepath.FromSlash(name)))
+		// 段级校验负责拒绝已知危险输入；这里再校验最终落盘路径，确保后续
+		// 路径规则即使调整，也不能把 ZIP 内容写出本次临时解压目录。
+		if !strings.HasPrefix(target, rootPrefix) {
+			return fmt.Errorf("zip path escapes package root after cleaning: %s", file.Name)
+		}
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, 0o700); err != nil {
 				return err

--- a/internal/skill/install_test.go
+++ b/internal/skill/install_test.go
@@ -160,6 +160,40 @@ func TestInstallTreatsDirectoryAndZipAsSameContent(t *testing.T) {
 	}
 }
 
+func TestExtractZipRejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "malicious.zip")
+	archive, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(archive)
+	entry, err := writer.Create("../escape.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(entry, "escaped"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	destination := filepath.Join(root, "extracted")
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractZip(archivePath, destination, 1<<20); err == nil || !strings.Contains(err.Error(), "escapes package root") {
+		t.Fatalf("path traversal ZIP should be rejected: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "escape.txt")); !os.IsNotExist(err) {
+		t.Fatalf("path traversal wrote outside extraction root: %v", err)
+	}
+}
+
 func TestInstallRejectsDifferentContentForSameVersion(t *testing.T) {
 	state, err := skillstate.New(filepath.Join(t.TempDir(), "skills"))
 	if err != nil {


### PR DESCRIPTION
## 变更
- ZIP 解压前保留现有相对路径校验，并对清理后的最终落盘路径增加 extraction root containment 校验
- 增加恶意 `../escape.txt` ZIP 回归测试，验证不会写出临时解压目录

## 验证
- `go test ./...`
- `git diff --check`

对应 Code scanning #101。