### PR TITLE
release: 发布 v0.8.3

### DIFF
--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const Version = "0.8.2"
+const Version = "0.8.3"
 
 var (
 	Commit    string


### PR DESCRIPTION
## 变更
- 将 AgentDock 唯一版本源从 `0.8.2` 更新为 `0.8.3`
- 为 `v0.8.3` Release workflow 做发布准备

## 验证
- `git diff --check`
- `go test ./...`
- `go run ./cmd/agentdock --version` → `AgentDock v0.8.3`
