### PR TITLE
docs: document Hermes MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ English | [简体中文](./README.zh-CN.md)
 
 **Give AI agents secure, controlled access to every machine you operate.**
 
-Open ChatGPT in your browser and manage multiple computers and servers from one conversation. Write code, change configuration, run commands, and deploy in the real environment where the work belongs—without consuming a dedicated Codex coding quota.
+Open ChatGPT in your browser or connect an MCP client such as Hermes to manage multiple computers and servers from one conversation. Write code, change configuration, run commands, and deploy in the real environment where the work belongs—without consuming a dedicated Codex coding quota.
 
 <a href="https://trendshift.io/repositories/136526?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-136526" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/136526/daily?language=Go" alt="uvwt%2Fagentdock | Trendshift" width="250" height="55"/></a>
 
@@ -41,7 +41,7 @@ AgentDock does not provide a chat interface or perform model inference. It focus
 > Let AI agents operate real environments within explicit permission boundaries and return structured, traceable, and verifiable results.
 
 ```text
-              ChatGPT / Claude / Codex
+              ChatGPT / Claude / Codex / Hermes
                         │
                         │ MCP (multiple instances supported)
           ┌─────────────┼─────────────┐
@@ -106,6 +106,56 @@ AgentDock exposes tools over MCP Streamable HTTP. The exact client syntax varies
   }
 }
 ```
+
+## Connect Hermes Agent
+
+Hermes Agent has a native MCP client and can use AgentDock locally over stdio or remotely over Streamable HTTP. No OpenAI API key is required for either path.
+
+### Local stdio
+
+When Hermes and AgentDock run on the same machine, use stdio to avoid a public tunnel:
+
+```bash
+hermes mcp add agentdock \
+  --command /absolute/path/to/agentdock \
+  --args --stdio
+```
+
+The command performs tool discovery and asks which AgentDock tools to enable. For a fixed workspace, the equivalent `~/.hermes/config.yaml` entry is:
+
+```yaml
+mcp_servers:
+  agentdock:
+    command: "/absolute/path/to/agentdock"
+    args: ["--stdio"]
+    env:
+      AGENTDOCK_DEFAULT_DIR: "/absolute/path/to/workspace"
+```
+
+`AGENTDOCK_DEFAULT_DIR` is optional. Local stdio does not need an AgentDock Bearer token, OAuth password, or Cloudflare Tunnel.
+
+### Remote Streamable HTTP
+
+For an AgentDock instance on another machine or behind a tunnel, use its complete `/mcp` URL and keep authentication enabled:
+
+```yaml
+mcp_servers:
+  agentdock:
+    url: "https://agent.example.com/mcp"
+    headers:
+      Authorization: "Bearer ${MCP_AGENTDOCK_API_KEY}"
+```
+
+Store `MCP_AGENTDOCK_API_KEY` in the active Hermes profile's `.env`, not in `config.yaml`. If AgentDock uses OAuth, run `hermes mcp add agentdock --url "https://agent.example.com/mcp" --auth oauth` and complete the browser authorization flow.
+
+Verify the connection from the same Hermes profile:
+
+```bash
+hermes mcp list
+hermes mcp test agentdock
+```
+
+Start a new Hermes session after changing `mcp_servers`, because MCP tools are discovered when Hermes initializes its connections. Use `agentdock_context` for a behavioral check, then perform a harmless read-only operation in the configured workspace.
 
 ## Core capabilities
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 **让 AI 的双手，真正触达你的每一台设备。**
 
-打开网页版 ChatGPT，即可管理多台电脑与服务器：在真实设备上写代码、改配置、跑命令与部署，执行发生在你的机器上，不消耗Codex额度。
+打开网页版 ChatGPT，或接入 Hermes 这类 MCP 客户端，即可管理多台电脑与服务器：在真实设备上写代码、改配置、跑命令与部署，执行发生在你的机器上，不消耗 Codex 额度。
 
 <a href="https://trendshift.io/repositories/136526?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-136526" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/136526/daily?language=Go" alt="uvwt%2Fagentdock | Trendshift" width="250" height="55"/></a>
 
@@ -41,7 +41,7 @@ AgentDock 不提供聊天界面，也不负责模型推理。它专注于解决�
 > 让 AI Agent 在明确的权限边界内操作真实环境，并返回结构化、可追踪、可验证的执行结果。
 
 ```text
-              ChatGPT / Claude / Codex
+              ChatGPT / Claude / Codex / Hermes
                         │
                         │ MCP（可接入多台）
           ┌─────────────┼─────────────┐
@@ -110,6 +110,64 @@ AgentDock 通过 MCP Streamable HTTP 提供工具能力。下面是一个通用�
 }
 ```
 
+
+## 接入 Hermes Agent
+
+Hermes Agent 内置 MCP 客户端，可以通过本机 stdio 或远程 Streamable HTTP 使用 AgentDock。两种方式都不需要 OpenAI API Key。
+
+### 本机 stdio
+
+当 Hermes 和 AgentDock 运行在同一台设备时，优先使用 stdio，避免暴露公网地址：
+
+```bash
+hermes mcp add agentdock \
+  --command /absolute/path/to/agentdock \
+  --args --stdio
+```
+
+该命令会先连接并发现工具，然后询问要启用哪些 AgentDock 工具。若要固定工作目录，也可以直接在 `~/.hermes/config.yaml` 中配置：
+
+```yaml
+mcp_servers:
+  agentdock:
+    command: "/absolute/path/to/agentdock"
+    args: ["--stdio"]
+    env:
+      AGENTDOCK_DEFAULT_DIR: "/absolute/path/to/workspace"
+```
+
+`AGENTDOCK_DEFAULT_DIR` 是可选的。本机 stdio 不需要 AgentDock Bearer Token、OAuth 密码或 Cloudflare Tunnel。
+
+### 远程 Streamable HTTP
+
+当 Hermes 与 AgentDock 位于不同设备、容器或隧道后面时，使用完整的 `/mcp` 地址，并保持认证开启：
+
+```yaml
+mcp_servers:
+  agentdock:
+    url: "https://agent.example.com/mcp"
+    headers:
+      Authorization: "Bearer ${MCP_AGENTDOCK_API_KEY}"
+```
+
+将 `MCP_AGENTDOCK_API_KEY` 放入当前 Hermes Profile 的 `.env`，不要写进 `config.yaml`。如果 AgentDock 使用 OAuth，可以运行：
+
+```bash
+hermes mcp add agentdock \
+  --url "https://agent.example.com/mcp" \
+  --auth oauth
+```
+
+然后按浏览器提示完成授权。不要把 OAuth 密码、Tunnel Token 或 Access Token 放进 MCP URL。
+
+在同一个 Hermes Profile 下验证连接：
+
+```bash
+hermes mcp list
+hermes mcp test agentdock
+```
+
+修改 `mcp_servers` 后请新开 Hermes 会话，因为 MCP 工具会在 Hermes 初始化连接时发现。先让 Hermes 调用 `agentdock_context` 检查运行环境，再执行一个无副作用的只读操作验证工作目录。
 
 ## 核心能力
 

--- a/core-skills/agentdock-user-guide/SKILL.md
+++ b/core-skills/agentdock-user-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agentdock-user-guide
-description: 当用户询问 AgentDock 是什么、如何使用、配置在哪里、不同平台或安装方式怎样修改配置并生效、如何重启或验证配置、如何发现并配置 Codex/Claude/Grok 等 Coding Agent 的 ACP，以及常见运行问题时使用；覆盖 macOS Desktop、Windows Desktop、Linux 服务、Docker 和直接运行二进制，不用于源码开发与贡献流程。
-version: 1.1.0
+description: 当用户询问 AgentDock 是什么、如何使用、配置在哪里、不同平台或安装方式怎样修改配置并生效、如何重启或验证配置、如何发现并配置 Codex/Claude/Grok 等 Coding Agent 的 ACP、如何接入 Hermes Agent，以及常见运行问题时使用；覆盖 macOS Desktop、Windows Desktop、Linux 服务、Docker 和直接运行二进制，不用于源码开发与贡献流程。
+version: 1.2.0
 ---
 
 # AgentDock User Guide
@@ -12,7 +12,7 @@ version: 1.1.0
 
 ## AgentDock 是什么
 
-AgentDock 是面向 AI Agent 的独立工具运行层。它把文件、命令、Git、Skill、动态 MCP、浏览器、任务等能力通过 MCP 提供给 ChatGPT、Claude、Codex 等客户端；它本身不是聊天界面，也不负责模型推理。
+AgentDock 是面向 AI Agent 的独立工具运行层。它把文件、命令、Git、Skill、动态 MCP、浏览器、任务等能力通过 MCP 提供给 ChatGPT、Claude、Codex、Hermes 等客户端；它本身不是聊天界面，也不负责模型推理。
 
 一个 AgentDock 实例对应一个实际运行环境。客户端可以连接本机 AgentDock，也可以连接远程服务器、容器或其他设备上的 AgentDock。多设备场景下，先确认当前工具实际连到哪一个实例，再解释或修改该实例的配置。
 
@@ -55,6 +55,15 @@ AgentDock 主仓库的 `core-skills/` 只保留必须随 AgentDock 运行时一�
 
 官方仓库：<https://github.com/uvwt/agentdock-skills>
 
+### Hermes Agent
+
+Hermes Agent 内置 MCP 客户端，可以连接 AgentDock 的本机 stdio 或远程 Streamable HTTP 端点。两种传输都不需要 OpenAI API Key；本机 stdio 不需要公网地址、Bearer Token、OAuth 密码或 Cloudflare Tunnel。
+
+- 本机连接优先使用 `agentdock --stdio`，并可通过 `AGENTDOCK_DEFAULT_DIR` 设定工作目录边界；
+- 远程连接使用完整的 `https://<host>/mcp` 地址，并保留 Bearer 或 OAuth 认证；
+- 配置完成后用 `hermes mcp test agentdock` 验证工具发现，再新开 Hermes 会话；
+- 详细配置和安全边界见 `references/hermes.md`。
+
 ### ChatGPT 的工具 Schema 缓存
 
 使用 ChatGPT 平台连接 AgentDock 时，工具定义还存在一层平台侧缓存。AgentDock 已经完成工具变更，不代表当前 ChatGPT 会话会立即拿到新的 Schema。
@@ -82,6 +91,7 @@ AgentDock 主仓库的 `core-skills/` 只保留必须随 AgentDock 运行时一�
 - macOS、Windows、Linux、Docker、直接运行二进制之间的配置差异；
 - Core 的启动、停止、重启、健康检查和配置生效验证；
 - 浏览器、MCP Apps UI、端口、日志、OAuth 等运行配置的入口；
+- 通过 Hermes Agent 本机 stdio 或远程 HTTP MCP 接入 AgentDock；
 - 发现本机已有 Codex、Claude、Grok 等 Coding Agent，补齐缺失 ACP Adapter，并把 ACP 正确接入 AgentDock；
 - 多台 AgentDock 设备中，确认应该修改哪一台设备的运行配置。
 
@@ -132,10 +142,11 @@ AgentDock Core 在启动时从**进程环境**读取运行配置。不同发行�
 - Windows Desktop：`references/windows.md`
 - Linux systemd/OpenRC/手工服务：`references/linux.md`
 - Docker / Docker Compose：`references/docker.md`
+- Hermes Agent MCP 客户端：`references/hermes.md`
 - Coding Agent / ACP：`references/acp.md`
 - 直接运行 `agentdock`：继续使用本文件的“直接运行二进制”说明
 
-只读取与当前环境相关的 reference；处理 ACP 时除平台 reference 外，再读取 `references/acp.md`。不要一次把所有平台的命令都丢给用户选择。
+只读取与当前环境相关的 reference；处理 Hermes MCP 时读取 `references/hermes.md`；处理 ACP 时除平台 reference 外，再读取 `references/acp.md`。不要一次把所有平台的命令都丢给用户选择。
 
 ### 3. 修改前先查看现状
 

--- a/core-skills/agentdock-user-guide/references/hermes.md
+++ b/core-skills/agentdock-user-guide/references/hermes.md
@@ -1,0 +1,91 @@
+# 将 AgentDock 接入 Hermes Agent
+
+Hermes Agent 内置 MCP 客户端，因此可以不通过浏览器桥接、也不需要 OpenAI API Key 使用 AgentDock。根据 Hermes 与 AgentDock 的部署位置选择传输方式：
+
+- **本机 stdio**：Hermes 和 AgentDock 在同一台设备上时的推荐方式，不需要公网地址或 Token。
+- **Streamable HTTP**：Hermes 连接另一台设备、容器或公网隧道中的 AgentDock 时使用，必须保留 Bearer 或 OAuth 认证。
+
+## 本机 stdio（推荐）
+
+通过 Hermes 启动 AgentDock，不需要监听网络端口：
+
+```bash
+hermes mcp add agentdock \
+  --command /absolute/path/to/agentdock \
+  --args --stdio
+```
+
+`hermes mcp add` 会先连接并发现工具，然后询问要启用哪些工具。`--args` 必须放在最后，因为它后面的参数都会传给 AgentDock。
+
+如果要固定 AgentDock 的工作目录，可以在 stdio Server 环境中指定绝对路径：
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  agentdock:
+    command: "/absolute/path/to/agentdock"
+    args: ["--stdio"]
+    env:
+      AGENTDOCK_DEFAULT_DIR: "/absolute/path/to/workspace"
+    connect_timeout: 60
+    timeout: 180
+```
+
+`AGENTDOCK_DEFAULT_DIR` 是可选的。省略时，AgentDock 使用当前用户的默认目录。
+
+本机 stdio 不需要 `AGENTDOCK_AUTH_TOKEN` 或 OAuth。Hermes 负责管理子进程管道，不要为了这条连接单独配置公网隧道。
+
+## Streamable HTTP
+
+当 Hermes 与 AgentDock 位于不同运行环境时，使用公网或本地 HTTP MCP 地址：
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  agentdock:
+    url: "https://agent.example.com/mcp"
+    headers:
+      Authorization: "Bearer ${MCP_AGENTDOCK_API_KEY}"
+    connect_timeout: 60
+    timeout: 180
+```
+
+把 Token 放在 Hermes 当前 Profile 的环境文件中，不要写入 `config.yaml`：
+
+```text
+# ~/.hermes/.env
+MCP_AGENTDOCK_API_KEY=<the AgentDock Bearer token>
+```
+
+使用 `--profile` 运行 Hermes 时，应使用对应 Profile 的实际目录。不要把真实 Token 提交到仓库，或粘贴到 Issue、日志、截图和公开聊天中。URL 必须包含 `/mcp`，公网部署必须使用 HTTPS。
+
+如果 AgentDock 端点配置为 OAuth，可以使用 Hermes 的发现流程：
+
+```bash
+hermes mcp add agentdock \
+  --url "https://agent.example.com/mcp" \
+  --auth oauth
+```
+
+按照浏览器授权提示操作。不要把 OAuth 密码、Tunnel Token 或 Access Token 放进 MCP URL。
+
+## 验证连接
+
+在同一个 Hermes Profile 下执行：
+
+```bash
+hermes mcp list
+hermes mcp test agentdock
+```
+
+成功时应能看到 AgentDock 的传输方式和大于零的工具发现数量。修改 `mcp_servers` 后请新开 Hermes 会话，因为 MCP 工具会在 Hermes 初始化 Server 连接时发现。
+
+行为验证时，让 Hermes 调用 `agentdock_context`，确认返回的运行时、操作系统、默认目录和能力信息；然后在配置的工作目录中执行一次无副作用的只读操作。
+
+## 边界与排障
+
+- `--stdio` 启动的 AgentDock 继承 Hermes 进程的操作系统权限。建议将 `AGENTDOCK_DEFAULT_DIR` 指向专用工作区，并把秘密文件放在工作区之外。
+- HTTP 连接必须使用完整的 MCP 端点（`/mcp`），不能只填公网 Origin 或健康检查 URL。
+- 临时公网地址可能在隧道重启后变化；地址变化后要更新 Hermes 配置并重新授权。
+- 如果工具缺失，运行 `hermes mcp test agentdock`，检查 Hermes 是否保存了 `tools.include` 过滤器，然后新开会话。
+- 如果连接失败，先检查 AgentDock 进程或 `/healthz`，再查看 Hermes 的 MCP 启动输出。配置文件写入成功不等于客户端已经连接。

--- a/scripts/test/test-install-macos.sh
+++ b/scripts/test/test-install-macos.sh
@@ -114,7 +114,7 @@ test -x "$binary"
 "$binary" --help >/dev/null 2>&1
 test -d "$state_dir"
 test -f "$state_dir/skill-store/bundled-skills.json"
-test -f "$state_dir/skill-store/installed/agentdock-user-guide/1.1.0/SKILL.md"
+test -f "$state_dir/skill-store/installed/agentdock-user-guide/1.2.0/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-authoring/1.2.0/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-installation/1.2.1/SKILL.md"
 test -f "$state_dir/skill-store/installed/skill-vetter-runtime/0.1.5/SKILL.md"


### PR DESCRIPTION
## Summary

- Document Hermes Agent as a supported MCP client in the English and Chinese READMEs.
- Add a bundled `agentdock-user-guide` reference covering local stdio, remote Streamable HTTP, Bearer/OAuth authentication, workspace boundaries, and verification.
- Bump the user-guide Skill to `1.2.0` and update the macOS installer assertion for the new bundled version.

The existing `agentdock --stdio` and Streamable HTTP implementations already support the required MCP transports; this change makes the Hermes connection path discoverable and reproducible rather than adding a client-specific protocol fork.

## Validation

- `skill-authoring` lint: PASS (`portable=true`, 0 errors, 0 warnings).
- Core Skill bundle build and archive inspection: PASS (`agentdock-user-guide` `1.2.0`, includes `references/hermes.md`).
- `make test-scripts-macos`: PASS.
- `go test ./internal/config ./internal/mcp ./scripts/test`: PASS.
- `go build ./cmd/agentdock`: PASS.
- Real Hermes MCP client checks with temporary configuration: PASS for local stdio and HTTP + Bearer; both discovered 16 AgentDock tools and completed read-only tool calls.

`go test ./...` was also run. All packages passed except the existing macOS `internal/selfupdate` tests, which fail while probing the embedded `cloudflared` binary with `signal: killed`; this is unrelated to the documentation/Skill changes.
