### PR TITLE
fix(desktop): auto-recover unreadable DPAPI credentials on launch/install

### DIFF
--- a/internal/desktopruntime/service_environment_windows.go
+++ b/internal/desktopruntime/service_environment_windows.go
@@ -79,12 +79,9 @@ func platformPrepareCoreEnvironment(runtimeRoot string) error {
 	if err := os.Remove(legacyNexusTokenPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("删除已废弃的 Nexus Token 失败: %w", err)
 	}
-	authToken, err := readProtectedText(filepath.Join(root, "auth-token.dpapi"), "agentdock.startup.v1")
+	authToken, err := readOrCreateProtectedText(filepath.Join(root, "auth-token.dpapi"), "agentdock.startup.v1", 32, "Bearer Token")
 	if err != nil {
-		return fmt.Errorf("读取 Bearer Token 失败: %w", err)
-	}
-	if strings.TrimSpace(authToken) == "" {
-		return errors.New("Bearer Token 为空，请运行 Setup.exe 修复安装")
+		return err
 	}
 
 	managed := map[string]string{
@@ -130,13 +127,13 @@ func platformPrepareCoreEnvironment(runtimeRoot string) error {
 		if err := writeRuntimeText(filepath.Join(root, "server-url.txt"), serverURL); err != nil {
 			return err
 		}
-		oauthPassword, passwordErr := readProtectedText(filepath.Join(root, "oauth-password.dpapi"), "agentdock.oauth.password.v1")
+		oauthPassword, passwordErr := readOrCreateProtectedText(filepath.Join(root, "oauth-password.dpapi"), "agentdock.oauth.password.v1", 12, "OAuth 密码")
 		if passwordErr != nil {
-			return fmt.Errorf("读取 OAuth 密码失败: %w", passwordErr)
+			return passwordErr
 		}
-		oauthSecret, secretErr := readProtectedText(filepath.Join(root, "oauth-token-secret.dpapi"), "agentdock.oauth.secret.v1")
+		oauthSecret, secretErr := readOrCreateProtectedText(filepath.Join(root, "oauth-token-secret.dpapi"), "agentdock.oauth.secret.v1", 32, "OAuth 签名密钥")
 		if secretErr != nil {
-			return fmt.Errorf("读取 OAuth 签名密钥失败: %w", secretErr)
+			return secretErr
 		}
 		managed["AGENTDOCK_SERVER_URL"] = serverURL
 		managed["AGENTDOCK_OAUTH_ENABLED"] = "true"

--- a/internal/desktopruntime/tunnel_state_windows.go
+++ b/internal/desktopruntime/tunnel_state_windows.go
@@ -166,6 +166,28 @@ func readSecretFile(path string) (string, error) {
 	return value, nil
 }
 
+// readOrCreateProtectedText 读取受 DPAPI 保护的文本；文件缺失或已存在但无法解密时
+// （例如目录从其它机器/用户迁移、Windows 账户密码被重置导致 DPAPI 主密钥失效），
+// 按“不存在”处理并重新生成，避免启动/安装/隧道配置在恢复路径上反复失败。
+func readOrCreateProtectedText(path, entropy string, byteCount int, name string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err == nil && strings.TrimSpace(string(data)) != "" {
+		if value, decryptErr := readProtectedText(path, entropy); decryptErr == nil {
+			return value, nil
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("读取 %s 失败: %w", name, err)
+	}
+	value, err := randomHex(byteCount)
+	if err != nil {
+		return "", fmt.Errorf("生成 %s 失败: %w", name, err)
+	}
+	if err := writeProtectedText(path, value, entropy); err != nil {
+		return "", fmt.Errorf("保存 %s 失败: %w", name, err)
+	}
+	return value, nil
+}
+
 func ensureDesktopCredentials(runtimeRoot string) error {
 	credentials := []struct {
 		name    string
@@ -178,22 +200,8 @@ func ensureDesktopCredentials(runtimeRoot string) error {
 		{name: "OAuth 签名密钥", path: filepath.Join(runtimeRoot, "oauth-token-secret.dpapi"), entropy: "agentdock.oauth.secret.v1", bytes: 32},
 	}
 	for _, credential := range credentials {
-		data, err := os.ReadFile(credential.path)
-		if err == nil && strings.TrimSpace(string(data)) != "" {
-			if _, decryptErr := readProtectedText(credential.path, credential.entropy); decryptErr != nil {
-				return fmt.Errorf("%s 无法解密: %w", credential.name, decryptErr)
-			}
-			continue
-		}
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("读取 %s 失败: %w", credential.name, err)
-		}
-		value, err := randomHex(credential.bytes)
-		if err != nil {
-			return fmt.Errorf("生成 %s 失败: %w", credential.name, err)
-		}
-		if err := writeProtectedText(credential.path, value, credential.entropy); err != nil {
-			return fmt.Errorf("保存 %s 失败: %w", credential.name, err)
+		if _, err := readOrCreateProtectedText(credential.path, credential.entropy, credential.bytes, credential.name); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/desktopruntime/tunnel_state_windows_test.go
+++ b/internal/desktopruntime/tunnel_state_windows_test.go
@@ -2,7 +2,12 @@
 
 package desktopruntime
 
-import "testing"
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeHTTPSOriginAcceptsMCPURL(t *testing.T) {
 	for _, input := range []string{
@@ -24,5 +29,44 @@ func TestNormalizeHTTPSOriginAcceptsMCPURL(t *testing.T) {
 func TestNormalizeHTTPSOriginRejectsOtherPaths(t *testing.T) {
 	if _, err := normalizeHTTPSOrigin("https://yc.188166.top:18443/oauth/token"); err == nil {
 		t.Fatal("normalizeHTTPSOrigin() should reject non-MCP paths")
+	}
+}
+
+func TestReadOrCreateProtectedTextRegeneratesUndecryptable(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "auth-token.dpapi")
+	const entropy = "agentdock.startup.v1"
+
+	first, err := readOrCreateProtectedText(path, entropy, 32, "Bearer Token")
+	if err != nil {
+		t.Fatalf("readOrCreateProtectedText() first call error = %v", err)
+	}
+	if len(first) != 64 {
+		t.Fatalf("generated token length = %d, want 64", len(first))
+	}
+
+	same, err := readOrCreateProtectedText(path, entropy, 32, "Bearer Token")
+	if err != nil {
+		t.Fatalf("readOrCreateProtectedText() read-back error = %v", err)
+	}
+	if same != first {
+		t.Fatalf("read-back token changed: got %q, want %q", same, first)
+	}
+
+	// 写入“可解析但不是 DPAPI 密文”的内容，模拟跨机器/跨用户迁移后的损坏凭据，
+	// 应被视为缺失并重新生成，而不是返回错误。
+	garbage := base64.StdEncoding.EncodeToString([]byte("garbage-not-a-dpapi-blob"))
+	if err := os.WriteFile(path, []byte(garbage), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	regenerated, err := readOrCreateProtectedText(path, entropy, 32, "Bearer Token")
+	if err != nil {
+		t.Fatalf("readOrCreateProtectedText() after corruption error = %v", err)
+	}
+	if regenerated == first {
+		t.Fatal("expected token to be regenerated after corruption")
+	}
+	if len(regenerated) != 64 {
+		t.Fatalf("regenerated token length = %d, want 64", len(regenerated))
 	}
 }

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -170,13 +170,20 @@ function Read-ProtectedText {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
         return ''
     }
-    $protectedBytes = [Convert]::FromBase64String([IO.File]::ReadAllText($Path).Trim())
-    $plainBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
-        $protectedBytes,
-        [Text.Encoding]::UTF8.GetBytes($Entropy),
-        [System.Security.Cryptography.DataProtectionScope]::CurrentUser
-    )
-    return [Text.Encoding]::UTF8.GetString($plainBytes)
+    try {
+        $protectedBytes = [Convert]::FromBase64String([IO.File]::ReadAllText($Path).Trim())
+        $plainBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
+            $protectedBytes,
+            [Text.Encoding]::UTF8.GetBytes($Entropy),
+            [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+        )
+        return [Text.Encoding]::UTF8.GetString($plainBytes)
+    } catch {
+        # 已存在但无法解密的凭据（目录从其它机器/用户迁移、Windows 账户密码被重置等）
+        # 按“不存在”处理，由调用方重新生成或重新提示输入，
+        # 避免 Setup 的“修复安装”路径与启动失败同因（DPAPI 无法解密）而中止。
+        return ''
+    }
 }
 
 function Read-TextFile {


### PR DESCRIPTION
## 问题

Windows 桌面上出现"AgentDock 管理程序执行失败，退出码：1"（点击托盘"启动"时），根因是 **DPAPI 凭据无法解密**：

```
agentdock: 读取 Bearer Token 失败: Key not valid for use in specified state.
```

Windows DPAPI（`CurrentUser` 作用域）的密文与"加密时的用户上下文"强绑定（用户账户 + 机器 + DPAPI 主密钥）。运行目录下的 `*.dpapi` 凭据文件出现以下任一情况时，`CryptUnprotectData` 都会失败：

- 目录从**另一台机器 / 另一个 Windows 用户**复制过来（迁移、备份还原、新装拷贝旧数据）
- Windows 账户密码被**修改/重置**导致 DPAPI 主密钥失效
- 用户配置文件被还原/重建、虚拟机快照回滚

## 现状（死循环）

1. **核心启动**：`launch-core` → `platformPrepareCoreEnvironment` 读 `auth-token.dpapi` 失败即返回错误，启动直接退出；
2. **修复路径同样失败**：错误提示"请运行 Setup.exe 修复安装"，但 Setup 的 `install.ps1` 在 `Read-ProtectedText`（`PrepareToInstall`）读取"存在但无法解密"的 token 时直接**抛异常中止安装** —— 修复工具与故障同因；
3. `ensureDesktopCredentials`（tunnel configure 路径）对"无法解密"同样返回错误，而不是重建。

## 修改

统一把"已存在但无法解密"的凭据按"缺失"处理并**自动重新生成**（生成的 token 会轮换，控制面板可见新值）：

- `internal/desktopruntime/tunnel_state_windows.go`：新增 `readOrCreateProtectedText` 助手（缺失/不可解密 → `randomHex` 重建并 `writeProtectedText` 写回），`ensureDesktopCredentials` 改为复用该助手；
- `internal/desktopruntime/service_environment_windows.go`：`launch-core` 路径的 Bearer Token / OAuth 密码 / OAuth 签名密钥改用 `readOrCreateProtectedText`，启动自愈，不再以"读取 Bearer Token 失败"退出；
- `scripts/install/install.ps1`：`Read-ProtectedText` 对解密失败 `catch` 后返回 `''`，调用方（auth token / OAuth / 隧道令牌）自然回退到重新生成或重新提示输入，Setup 修复路径不再中止；
- `internal/desktopruntime/tunnel_state_windows_test.go`：新增 Windows 单测 `TestReadOrCreateProtectedTextRegeneratesUndecryptable`，覆盖"文件存在但内容为垃圾 → 自动重建"行为。

> 注：`cloudflared-token.dpapi`（Cloudflare 隧道令牌）是用户账号凭据，无法自动生成 —— 缺失/不可解密时仍要求用户重新提供（named 模式下提示输入），本 PR 不改变该行为。

## 验证

- CI：`go test ./...`（含 windows-latest 任务）+ gofmt 检查；
- 本机实测：修复前 `start-agentdock.ps1` 报 `Key not valid for use in specified state`；按本 PR 逻辑重建后核心正常启动、healthz 200、隧道自愈。