### PR TITLE
feat(desktop): 增加界面语言切换设置

### DIFF
--- a/desktop/macos/AgentDockApp/Resources/en.lproj/Localizable.strings
+++ b/desktop/macos/AgentDockApp/Resources/en.lproj/Localizable.strings
@@ -295,3 +295,11 @@
 "Background service %@ did not converge to the unregistered state." = "Background service %@ did not converge to the unregistered state.";
 "AgentDock.app is missing the background service definition for %@. Reinstall the application." = "AgentDock.app is missing the background service definition for %@. Reinstall the application.";
 "AgentDock %@ failed." = "AgentDock %@ failed.";
+"Interface language" = "Interface language";
+"Follow system" = "Follow system";
+"Simplified Chinese" = "Simplified Chinese";
+"English" = "English";
+"Failed to restart AgentDock interface: %@" = "Failed to restart AgentDock interface: %@";
+"Change interface language?" = "Change interface language?";
+"Changing the interface language restarts the AgentDock interface. Any unsaved changes in this window will be lost." = "Changing the interface language restarts the AgentDock interface. Any unsaved changes in this window will be lost.";
+"Continue" = "Continue";

--- a/desktop/macos/AgentDockApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/desktop/macos/AgentDockApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -295,3 +295,11 @@
 "Background service %@ did not converge to the unregistered state." = "后台服务 %@ 注销后系统状态没有完成收敛。";
 "AgentDock.app is missing the background service definition for %@. Reinstall the application." = "AgentDock.app 缺少 %@ 的后台服务定义，请重新安装应用。";
 "AgentDock %@ failed." = "AgentDock %@失败。";
+"Interface language" = "界面语言";
+"Follow system" = "跟随系统";
+"Simplified Chinese" = "简体中文";
+"English" = "English";
+"Failed to restart AgentDock interface: %@" = "重启 AgentDock 界面失败：%@";
+"Change interface language?" = "切换界面语言？";
+"Changing the interface language restarts the AgentDock interface. Any unsaved changes in this window will be lost." = "切换界面语言会重启 AgentDock 界面，此窗口中未保存的更改将会丢失。";
+"Continue" = "继续";

--- a/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
@@ -33,6 +33,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private let menuLoginAgent: MenuLoginAgentController
     private let onChanged: () -> Void
 
+    private let languagePreference = NSPopUpButton(frame: .zero, pullsDown: false)
     private let serviceAutostart = NSButton(checkboxWithTitle: L10n.text("Allow AgentDock to run in the background"), target: nil, action: nil)
     private let menuAutostart = NSButton(checkboxWithTitle: L10n.text("Show AgentDock in the menu bar after sign-in"), target: nil, action: nil)
     private let portField = NSTextField(string: "8765")
@@ -148,6 +149,15 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private func configureUI() {
         guard let contentView = window?.contentView else { return }
 
+        for preference in UILanguagePreference.allCases {
+            languagePreference.addItem(withTitle: preference.title)
+            languagePreference.lastItem?.representedObject = preference.rawValue
+        }
+        selectLanguagePreference(L10n.languagePreference())
+        languagePreference.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        languagePreference.target = self
+        languagePreference.action = #selector(languageChanged)
+
         serviceAutostart.target = self
         serviceAutostart.action = #selector(markChanged)
         menuAutostart.target = self
@@ -242,7 +252,11 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         let openConfig = NSButton(title: L10n.text("Open configuration folder"), target: self, action: #selector(openConfigurationPressed))
         openConfig.bezelStyle = .inline
 
-        let startupStack = NSStackView(views: [serviceAutostart, menuAutostart])
+        let startupStack = NSStackView(views: [
+            formRow(title: L10n.text("Interface language"), control: languagePreference),
+            serviceAutostart,
+            menuAutostart,
+        ])
         startupStack.orientation = .vertical
         startupStack.alignment = .leading
         startupStack.spacing = 8
@@ -366,6 +380,37 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
     @objc private func markChanged() {
         refreshApplyState()
+    }
+
+    @objc private func languageChanged() {
+        let previous = L10n.languagePreference()
+        let selected = selectedLanguagePreference()
+        guard selected != previous else { return }
+
+        let warning = NSAlert()
+        warning.messageText = L10n.text("Change interface language?")
+        warning.informativeText = L10n.text("Changing the interface language restarts the AgentDock interface. Any unsaved changes in this window will be lost.")
+        warning.alertStyle = .warning
+        warning.addButton(withTitle: L10n.text("Continue"))
+        warning.addButton(withTitle: L10n.text("Cancel"))
+        guard warning.runModal() == .alertFirstButtonReturn else {
+            selectLanguagePreference(previous)
+            return
+        }
+
+        L10n.setLanguagePreference(selected)
+        let relaunch = Process()
+        relaunch.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        relaunch.arguments = ["-n", Bundle.main.bundlePath]
+        do {
+            // AppKit 的静态控件在创建时取本地化文本；只重启菜单栏 UI，Core/Tunnel 不受影响。
+            try relaunch.run()
+            NSApp.terminate(nil)
+        } catch {
+            L10n.setLanguagePreference(previous)
+            selectLanguagePreference(previous)
+            showStatus(L10n.format("Failed to restart AgentDock interface: %@", error.localizedDescription), isError: true)
+        }
     }
 
     func controlTextDidChange(_ obj: Notification) {
@@ -514,6 +559,22 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     @objc private func openLogsPressed() { service.openLogs() }
     @objc private func openConfigurationPressed() { service.openConfiguration() }
 
+    private func selectedLanguagePreference() -> UILanguagePreference {
+        guard let rawValue = languagePreference.selectedItem?.representedObject as? String,
+              let preference = UILanguagePreference(rawValue: rawValue) else {
+            return .system
+        }
+        return preference
+    }
+
+    private func selectLanguagePreference(_ preference: UILanguagePreference) {
+        for item in languagePreference.itemArray where (item.representedObject as? String) == preference.rawValue {
+            languagePreference.select(item)
+            return
+        }
+        languagePreference.selectItem(at: 0)
+    }
+
     private func selectedACPAgent() -> ACPAgentPreset {
         let title = acpAgent.titleOfSelectedItem ?? ""
         return ACPAgentPreset.allCases.first { $0.title == title } ?? .codex
@@ -645,7 +706,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
     private func setBusy(_ busy: Bool) {
         isBusy = busy
-        for control in [serviceAutostart, menuAutostart, portField, logLevel, mcpAppsEnabled, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, acpAgent, acpCommand, acpArgsJSON, nexusEndpoint, nexusPairingCode, nexusPairButton] {
+        for control in [languagePreference, serviceAutostart, menuAutostart, portField, logLevel, mcpAppsEnabled, browserEnabled, browserConnectionMode, browserCDPURL, acpEnabled, acpAgent, acpCommand, acpArgsJSON, nexusEndpoint, nexusPairingCode, nexusPairButton] {
             control.isEnabled = !busy
         }
         refreshBrowserStatus()

--- a/desktop/macos/AgentDockApp/Sources/Localization.swift
+++ b/desktop/macos/AgentDockApp/Sources/Localization.swift
@@ -1,11 +1,61 @@
 import Foundation
 
+enum UILanguagePreference: String, CaseIterable {
+    case system
+    case simplifiedChinese = "zh-Hans"
+    case english = "en"
+
+    var title: String {
+        switch self {
+        case .system:
+            return L10n.text("Follow system")
+        case .simplifiedChinese:
+            return L10n.text("Simplified Chinese")
+        case .english:
+            return L10n.text("English")
+        }
+    }
+}
+
 enum L10n {
+    private static let languagePreferenceKey = "AgentDockUILanguage"
+
+    static func languagePreference(defaults: UserDefaults = .standard) -> UILanguagePreference {
+        guard let rawValue = defaults.string(forKey: languagePreferenceKey),
+              let preference = UILanguagePreference(rawValue: rawValue) else {
+            return .system
+        }
+        return preference
+    }
+
+    static func setLanguagePreference(_ preference: UILanguagePreference, defaults: UserDefaults = .standard) {
+        if preference == .system {
+            defaults.removeObject(forKey: languagePreferenceKey)
+        } else {
+            defaults.set(preference.rawValue, forKey: languagePreferenceKey)
+        }
+    }
+
     static func text(_ key: String) -> String {
-        NSLocalizedString(key, tableName: nil, bundle: .main, value: key, comment: "")
+        NSLocalizedString(
+            key,
+            tableName: nil,
+            bundle: localizationBundle(for: languagePreference()),
+            value: key,
+            comment: ""
+        )
     }
 
     static func format(_ key: String, _ arguments: CVarArg...) -> String {
         String(format: text(key), locale: Locale.current, arguments: arguments)
+    }
+
+    private static func localizationBundle(for preference: UILanguagePreference) -> Bundle {
+        guard preference != .system,
+              let path = Bundle.main.path(forResource: preference.rawValue, ofType: "lproj"),
+              let bundle = Bundle(path: path) else {
+            return .main
+        }
+        return bundle
     }
 }

--- a/desktop/macos/AgentDockApp/Tests/LocalizationPreferenceTests.swift
+++ b/desktop/macos/AgentDockApp/Tests/LocalizationPreferenceTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@main
+struct LocalizationPreferenceTests {
+    static func main() {
+        let suiteName = "AgentDock.LocalizationPreferenceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("failed to create isolated UserDefaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        precondition(L10n.languagePreference(defaults: defaults) == .system)
+
+        L10n.setLanguagePreference(.english, defaults: defaults)
+        precondition(L10n.languagePreference(defaults: defaults) == .english)
+
+        L10n.setLanguagePreference(.simplifiedChinese, defaults: defaults)
+        precondition(L10n.languagePreference(defaults: defaults) == .simplifiedChinese)
+
+        defaults.set("zh-TW", forKey: "AgentDockUILanguage")
+        precondition(L10n.languagePreference(defaults: defaults) == .system)
+
+        L10n.setLanguagePreference(.english, defaults: defaults)
+        L10n.setLanguagePreference(.system, defaults: defaults)
+        precondition(L10n.languagePreference(defaults: defaults) == .system)
+        precondition(defaults.object(forKey: "AgentDockUILanguage") == nil)
+
+        precondition(L10n.text("Change interface language?") != "")
+        precondition(L10n.text("Changing the interface language restarts the AgentDock interface. Any unsaved changes in this window will be lost.") != "")
+        precondition(L10n.text("Continue") != "")
+
+        print("localization preference tests passed")
+    }
+}

--- a/desktop/windows/control-panel/App.xaml.cs
+++ b/desktop/windows/control-panel/App.xaml.cs
@@ -197,6 +197,46 @@ public partial class App : System.Windows.Application
         });
     }
 
+    public async Task ApplyLanguagePreferenceAsync(string preference)
+    {
+        var previousPreference = UiText.ReadPreference();
+        UiText.SetPreference(preference);
+        try
+        {
+            var previousWindow = ControlPanelWindow;
+            var wasVisible = previousWindow.IsVisible;
+            var previousState = previousWindow.WindowState;
+            var left = previousWindow.Left;
+            var top = previousWindow.Top;
+
+            var replacement = new MainWindow(Runtime)
+            {
+                Left = left,
+                Top = top,
+                WindowState = previousState == WindowState.Minimized ? WindowState.Normal : previousState
+            };
+            ControlPanelWindow = replacement;
+            MainWindow = replacement;
+            previousWindow.CloseForReplacement();
+
+            if (_trayMenu is not null && !_trayMenu.Visible)
+            {
+                PopulateTrayMenu(_trayMenu, _traySnapshot);
+            }
+            if (wasVisible)
+            {
+                replacement.Show();
+                replacement.Activate();
+                await replacement.RefreshAsync();
+            }
+        }
+        catch
+        {
+            UiText.SetPreference(previousPreference);
+            throw;
+        }
+    }
+
     public void RequestExit()
     {
         _exitRequested = true;
@@ -264,7 +304,7 @@ public partial class App : System.Windows.Application
             _traySnapshot = await Runtime.GetSnapshotAsync();
             if (_notifyIcon is not null)
             {
-                _notifyIcon.Text = TruncateNotifyIconText($"AgentDock：{GetTrayStatusText(_traySnapshot)}");
+                _notifyIcon.Text = TruncateNotifyIconText($"AgentDock: {GetTrayStatusText(_traySnapshot)}");
             }
             if (_trayMenu is not null && !_trayMenu.Visible)
             {

--- a/desktop/windows/control-panel/Localization/UiText.cs
+++ b/desktop/windows/control-panel/Localization/UiText.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.IO;
 using System.Resources;
 using System.Windows.Markup;
 
@@ -6,18 +7,76 @@ namespace AgentDock.ControlPanel;
 
 internal static class UiText
 {
-    private const string EnglishLocale = "en";
-    private const string SimplifiedChineseLocale = "zh-CN";
+    internal const string SystemPreference = "system";
+    internal const string EnglishPreference = "en";
+    internal const string SimplifiedChinesePreference = "zh-CN";
+
+    private static readonly string SystemLocale = NormalizeCultureName(CultureInfo.CurrentUICulture.Name);
     private static readonly ResourceManager Resources = new(
         "AgentDock.ControlPanel.Resources.UiStrings",
         typeof(UiText).Assembly);
 
+    private static string PreferencePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "AgentDock",
+        "ui-language");
+
     public static void ConfigureCurrentUICulture()
     {
-        var locale = NormalizeCultureName(CultureInfo.CurrentUICulture.Name);
-        var culture = CultureInfo.GetCultureInfo(locale);
-        CultureInfo.CurrentUICulture = culture;
-        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        ApplyPreference(ReadPreference());
+    }
+
+    internal static string ReadPreference()
+    {
+        try
+        {
+            return NormalizePreference(File.ReadAllText(PreferencePath));
+        }
+        catch (IOException)
+        {
+            return SystemPreference;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SystemPreference;
+        }
+    }
+
+    internal static void SetPreference(string preference)
+    {
+        var normalized = NormalizePreference(preference);
+        if (normalized == SystemPreference)
+        {
+            File.Delete(PreferencePath);
+            ApplyPreference(normalized);
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(PreferencePath)
+            ?? throw new InvalidOperationException("AgentDock UI preference directory is unavailable.");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(PreferencePath, normalized);
+        ApplyPreference(normalized);
+    }
+
+    internal static string NormalizePreference(string? value)
+    {
+        return value?.Trim() switch
+        {
+            EnglishPreference => EnglishPreference,
+            SimplifiedChinesePreference => SimplifiedChinesePreference,
+            _ => SystemPreference
+        };
+    }
+
+    internal static string ResolveLocale(string preference, string systemCultureName)
+    {
+        return NormalizePreference(preference) switch
+        {
+            EnglishPreference => EnglishPreference,
+            SimplifiedChinesePreference => SimplifiedChinesePreference,
+            _ => NormalizeCultureName(systemCultureName)
+        };
     }
 
     internal static string NormalizeCultureName(string? value)
@@ -25,13 +84,13 @@ internal static class UiText
         var locale = value?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(locale))
         {
-            return EnglishLocale;
+            return EnglishPreference;
         }
         if (locale is "zh" or "zh-cn" or "zh-sg" or "zh-hans" || locale.StartsWith("zh-hans-", StringComparison.Ordinal))
         {
-            return SimplifiedChineseLocale;
+            return SimplifiedChinesePreference;
         }
-        return EnglishLocale;
+        return EnglishPreference;
     }
 
     public static string Get(string key)
@@ -42,6 +101,14 @@ internal static class UiText
     public static string Format(string key, params object?[] args)
     {
         return string.Format(CultureInfo.CurrentCulture, Get(key), args);
+    }
+
+    private static void ApplyPreference(string preference)
+    {
+        var locale = ResolveLocale(preference, SystemLocale);
+        var culture = CultureInfo.GetCultureInfo(locale);
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
     }
 }
 

--- a/desktop/windows/control-panel/MainWindow.xaml
+++ b/desktop/windows/control-panel/MainWindow.xaml
@@ -165,6 +165,7 @@
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="{local:Loc Port}" VerticalAlignment="Center" Margin="0,0,0,10" />
                 <TextBox x:Name="PortTextBox" Grid.Column="1" Width="130" HorizontalAlignment="Left" Margin="0,0,0,10" />
@@ -175,7 +176,13 @@
                   <ComboBoxItem Content="warn" />
                   <ComboBoxItem Content="error" />
                 </ComboBox>
-                <CheckBox x:Name="McpAppsEnabledCheckBox" Grid.Row="2" Grid.ColumnSpan="2" Content="{local:Loc EnableMcpAppsUi}" Margin="0,4,0,4" />
+                <TextBlock Text="{local:Loc InterfaceLanguage}" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,0,10" />
+                <ComboBox x:Name="LanguageComboBox" Grid.Row="2" Grid.Column="1" Width="180" HorizontalAlignment="Left" Margin="0,0,0,10" SelectionChanged="LanguageComboBox_SelectionChanged">
+                  <ComboBoxItem Content="{local:Loc FollowSystem}" Tag="system" />
+                  <ComboBoxItem Content="{local:Loc SimplifiedChinese}" Tag="zh-CN" />
+                  <ComboBoxItem Content="{local:Loc EnglishLanguage}" Tag="en" />
+                </ComboBox>
+                <CheckBox x:Name="McpAppsEnabledCheckBox" Grid.Row="3" Grid.ColumnSpan="2" Content="{local:Loc EnableMcpAppsUi}" Margin="0,4,0,4" />
               </Grid>
             </GroupBox>
 

--- a/desktop/windows/control-panel/MainWindow.xaml.cs
+++ b/desktop/windows/control-panel/MainWindow.xaml.cs
@@ -36,7 +36,16 @@ public partial class MainWindow : Window
     {
         _runtime = runtime;
         InitializeComponent();
+        _updatingUi = true;
+        SelectUiLanguage(UiText.ReadPreference());
+        _updatingUi = false;
         Closing += MainWindow_Closing;
+    }
+
+    internal void CloseForReplacement()
+    {
+        Closing -= MainWindow_Closing;
+        Close();
     }
 
     public async Task RefreshAsync()
@@ -406,6 +415,63 @@ public partial class MainWindow : Window
             ? new SolidColorBrush(Color.FromRgb(217, 45, 32))
             : new SolidColorBrush(Color.FromRgb(102, 112, 133));
     }
+
+    private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_updatingUi || Application.Current is not App app)
+        {
+            return;
+        }
+
+        var preference = SelectedUiLanguage();
+        if (preference == UiText.ReadPreference())
+        {
+            return;
+        }
+
+        var confirm = MessageBox.Show(
+            this,
+            UiText.Get("LanguageChangeDiscardWarning"),
+            "AgentDock",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+        if (confirm != MessageBoxResult.Yes)
+        {
+            _updatingUi = true;
+            SelectUiLanguage(UiText.ReadPreference());
+            _updatingUi = false;
+            return;
+        }
+
+        try
+        {
+            await app.ApplyLanguagePreferenceAsync(preference);
+        }
+        catch (Exception ex)
+        {
+            _updatingUi = true;
+            SelectUiLanguage(UiText.ReadPreference());
+            _updatingUi = false;
+            SettingsStatusText.Text = UiText.Format("LanguageChangeFailed", ex.Message);
+            MessageBox.Show(this, SettingsStatusText.Text, "AgentDock", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private void SelectUiLanguage(string preference)
+    {
+        foreach (var item in LanguageComboBox.Items.OfType<ComboBoxItem>())
+        {
+            if (string.Equals(item.Tag?.ToString(), preference, StringComparison.Ordinal))
+            {
+                LanguageComboBox.SelectedItem = item;
+                return;
+            }
+        }
+        LanguageComboBox.SelectedIndex = 0;
+    }
+
+    private string SelectedUiLanguage() =>
+        (LanguageComboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? UiText.SystemPreference;
 
     private async void SaveSettingsButton_Click(object sender, RoutedEventArgs e)
     {

--- a/desktop/windows/control-panel/Resources/UiStrings.resx
+++ b/desktop/windows/control-panel/Resources/UiStrings.resx
@@ -599,4 +599,22 @@ Update now?</value>
   <data name="AcpDetectedPathDetails" xml:space="preserve">
     <value>Detected · {0} · {1}</value>
   </data>
+  <data name="InterfaceLanguage" xml:space="preserve">
+    <value>Interface language</value>
+  </data>
+  <data name="FollowSystem" xml:space="preserve">
+    <value>Follow system</value>
+  </data>
+  <data name="SimplifiedChinese" xml:space="preserve">
+    <value>Simplified Chinese</value>
+  </data>
+  <data name="EnglishLanguage" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="LanguageChangeFailed" xml:space="preserve">
+    <value>Failed to change interface language: {0}</value>
+  </data>
+  <data name="LanguageChangeDiscardWarning" xml:space="preserve">
+    <value>Changing the interface language reloads this window. Any unsaved changes will be lost. Continue?</value>
+  </data>
 </root>

--- a/desktop/windows/control-panel/Resources/UiStrings.zh-CN.resx
+++ b/desktop/windows/control-panel/Resources/UiStrings.zh-CN.resx
@@ -599,4 +599,22 @@
   <data name="AcpDetectedPathDetails" xml:space="preserve">
     <value>已检测到 · {0} · {1}</value>
   </data>
+  <data name="InterfaceLanguage" xml:space="preserve">
+    <value>界面语言</value>
+  </data>
+  <data name="FollowSystem" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
+  <data name="SimplifiedChinese" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="EnglishLanguage" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="LanguageChangeFailed" xml:space="preserve">
+    <value>切换界面语言失败：{0}</value>
+  </data>
+  <data name="LanguageChangeDiscardWarning" xml:space="preserve">
+    <value>切换界面语言会重新加载此窗口，未保存的更改将会丢失。是否继续？</value>
+  </data>
 </root>

--- a/desktop/windows/tray/locale_windows.go
+++ b/desktop/windows/tray/locale_windows.go
@@ -3,6 +3,8 @@
 package tray
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"unsafe"
 
@@ -142,13 +144,39 @@ func currentTrayText() trayText {
 		uintptr(unsafe.Pointer(&localeName[0])),
 		uintptr(len(localeName)),
 	)
-	if result == 0 {
-		return trayTextEnglish
+	var systemLocale string
+	if result != 0 {
+		systemLocale = windows.UTF16ToString(localeName[:])
 	}
-	if isSimplifiedChineseLocale(windows.UTF16ToString(localeName[:])) {
+	if resolveTrayLocale(readTrayLanguagePreference(), systemLocale) == "zh-CN" {
 		return trayTextChinese
 	}
 	return trayTextEnglish
+}
+
+func readTrayLanguagePreference() string {
+	localAppData := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
+	if localAppData == "" {
+		return "system"
+	}
+	data, err := os.ReadFile(filepath.Join(localAppData, "AgentDock", "ui-language"))
+	if err != nil {
+		return "system"
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func resolveTrayLocale(preference, systemLocale string) string {
+	switch strings.TrimSpace(preference) {
+	case "en":
+		return "en"
+	case "zh-CN":
+		return "zh-CN"
+	}
+	if isSimplifiedChineseLocale(systemLocale) {
+		return "zh-CN"
+	}
+	return "en"
 }
 
 func isSimplifiedChineseLocale(value string) bool {

--- a/desktop/windows/tray/locale_windows_test.go
+++ b/desktop/windows/tray/locale_windows_test.go
@@ -2,7 +2,11 @@
 
 package tray
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestIsSimplifiedChineseLocale(t *testing.T) {
 	tests := []struct {
@@ -27,5 +31,48 @@ func TestIsSimplifiedChineseLocale(t *testing.T) {
 				t.Fatalf("isSimplifiedChineseLocale(%q)=%v want=%v", test.locale, got, test.want)
 			}
 		})
+	}
+}
+
+func TestResolveTrayLocaleHonorsExplicitPreference(t *testing.T) {
+	tests := []struct {
+		name         string
+		preference   string
+		systemLocale string
+		want         string
+	}{
+		{name: "explicit English overrides Chinese system", preference: "en", systemLocale: "zh-CN", want: "en"},
+		{name: "explicit Chinese overrides English system", preference: "zh-CN", systemLocale: "en-US", want: "zh-CN"},
+		{name: "system follows simplified Chinese", preference: "system", systemLocale: "zh-SG", want: "zh-CN"},
+		{name: "system follows English", preference: "system", systemLocale: "en-US", want: "en"},
+		{name: "invalid preference follows system", preference: "invalid", systemLocale: "zh-Hans", want: "zh-CN"},
+		{name: "traditional Chinese falls back to English", preference: "system", systemLocale: "zh-TW", want: "en"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveTrayLocale(test.preference, test.systemLocale); got != test.want {
+				t.Fatalf("resolveTrayLocale(%q, %q)=%q want=%q", test.preference, test.systemLocale, got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadTrayLanguagePreference(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("LOCALAPPDATA", root)
+	if got := readTrayLanguagePreference(); got != "system" {
+		t.Fatalf("missing preference=%q want=system", got)
+	}
+
+	preferenceDir := filepath.Join(root, "AgentDock")
+	if err := os.MkdirAll(preferenceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(preferenceDir, "ui-language"), []byte("zh-CN\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readTrayLanguagePreference(); got != "zh-CN" {
+		t.Fatalf("stored preference=%q want=zh-CN", got)
 	}
 }

--- a/scripts/test/test-macos-app.sh
+++ b/scripts/test/test-macos-app.sh
@@ -20,6 +20,14 @@ swiftc \
   -swift-version 5 \
   -parse-as-library \
   "$ROOT_DIR/desktop/macos/AgentDockApp/Sources/Localization.swift" \
+  "$ROOT_DIR/desktop/macos/AgentDockApp/Tests/LocalizationPreferenceTests.swift" \
+  -o "$TMP_ROOT/localization-preference-tests"
+"$TMP_ROOT/localization-preference-tests"
+
+swiftc \
+  -swift-version 5 \
+  -parse-as-library \
+  "$ROOT_DIR/desktop/macos/AgentDockApp/Sources/Localization.swift" \
   "$ROOT_DIR/desktop/macos/AgentDockApp/Sources/InstallerConfiguration.swift" \
   "$ROOT_DIR/desktop/macos/AgentDockApp/Sources/AppVersion.swift" \
   "$ROOT_DIR/desktop/macos/AgentDockApp/Sources/DesktopUpdateResult.swift" \

--- a/scripts/test/windows_ui_test.go
+++ b/scripts/test/windows_ui_test.go
@@ -27,6 +27,50 @@ func TestWindowsControlPanelPrivilegeModeCopyStaysUserFacing(t *testing.T) {
 	}
 }
 
+func TestWindowsControlPanelSupportsPersistentLanguagePreference(t *testing.T) {
+	root := filepath.Join("..", "..", "desktop", "windows", "control-panel")
+	checks := map[string][]string{
+		"MainWindow.xaml": {
+			`x:Name="LanguageComboBox"`,
+			`Tag="system"`,
+			`Tag="zh-CN"`,
+			`Tag="en"`,
+			`SelectionChanged="LanguageComboBox_SelectionChanged"`,
+		},
+		"MainWindow.xaml.cs": {
+			`UiText.ReadPreference()`,
+			`UiText.Get("LanguageChangeDiscardWarning")`,
+			`MessageBoxButton.YesNo`,
+			`SelectUiLanguage(UiText.ReadPreference())`,
+			`ApplyLanguagePreferenceAsync(preference)`,
+		},
+		"App.xaml.cs": {
+			`UiText.SetPreference(preference)`,
+			`new MainWindow(Runtime)`,
+			`previousWindow.CloseForReplacement()`,
+		},
+		filepath.Join("Localization", "UiText.cs"): {
+			`"AgentDock",`,
+			`"ui-language"`,
+			`File.Delete(PreferencePath)`,
+			`ResolveLocale(string preference, string systemCultureName)`,
+		},
+	}
+
+	for relativePath, wants := range checks {
+		data, err := os.ReadFile(filepath.Join(root, relativePath))
+		if err != nil {
+			t.Fatalf("read %s: %v", relativePath, err)
+		}
+		content := string(data)
+		for _, want := range wants {
+			if !strings.Contains(content, want) {
+				t.Fatalf("Windows language preference contract missing %q in %s", want, relativePath)
+			}
+		}
+	}
+}
+
 func TestWindowsUpdateProgressWindowSizesToContent(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "desktop", "windows", "control-panel", "UpdateProgressWindow.xaml"))
 	if err != nil {


### PR DESCRIPTION
## 变更
- Windows 控制面板增加“跟随系统 / 简体中文 / English”界面语言设置，并与 Go 托盘共享偏好
- macOS 高级设置增加同样三档语言设置，显式语言只重启 UI，不重启 Core/Tunnel
- `system` 模式清除显式覆盖；桌面切换前提示未保存更改会丢失
- 补充 Windows/macOS 语言偏好回归测试

## 验证
- `go test ./...`
- Windows WPF Release build：0 warning / 0 error
- Windows 编译产物跨进程验证 en / zh-CN / system 持久化与 system 删除覆盖文件
- macOS i18n Gate：305/305
- Mac mini 真机 `scripts/test/test-macos-app.sh`：Swift tests、AgentDock.app、ZIP、DMG、plist、codesign 全部通过