### PR TITLE
fix(macos): 保持桌面更新稳定签名身份

### DIFF
--- a/desktop/macos/AgentDockApp/Sources/ServiceController.swift
+++ b/desktop/macos/AgentDockApp/Sources/ServiceController.swift
@@ -316,12 +316,13 @@ final class ServiceController: @unchecked Sendable {
 
     func update() async throws -> String {
         try validateServiceManagementReadiness()
+        let updateEnvironment = try desktopUpdateEnvironment()
 
         let check = try await runInBackground {
             let result = try runProcess(
                 executable: self.paths.binary.path,
                 arguments: ["update", "--check"],
-                environment: ["AGENTDOCK_DESKTOP_APP_PATH": self.paths.appBundle.path]
+                environment: updateEnvironment
             )
             guard result.status == 0 else {
                 throw ValidationError(self.commandError(result.output, action: L10n.text("Check for updates")))
@@ -349,7 +350,7 @@ final class ServiceController: @unchecked Sendable {
                 let result = try runUpdateProcess(
                     executable: self.paths.binary.path,
                     arguments: ["update"],
-                    environment: ["AGENTDOCK_DESKTOP_APP_PATH": self.paths.appBundle.path],
+                    environment: updateEnvironment,
                     outputURL: self.paths.updateLog
                 )
                 guard result.status == 0 else {
@@ -396,6 +397,25 @@ final class ServiceController: @unchecked Sendable {
             ))
         }
         return output
+    }
+
+    func desktopUpdateEnvironment() throws -> [String: String] {
+        let configured = try ManagedEnvironment.load(from: paths.environment).values
+        var environment = ["AGENTDOCK_DESKTOP_APP_PATH": paths.appBundle.path]
+        // Updater 只需要本地签名配置。不要把 Auth/OAuth 等服务凭据整体继承给
+        // 更新子进程；稳定签名变量由 agentdock.env 持久化并显式白名单透传。
+        for key in [
+            "AGENTDOCK_CODESIGN_IDENTITY",
+            "AGENTDOCK_CODESIGN_KEYCHAIN",
+            "AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD",
+            "AGENTDOCK_CODESIGN_IDENTIFIER",
+            "AGENTDOCK_CODESIGN_HOME",
+        ] {
+            if let value = configured[key] {
+                environment[key] = value
+            }
+        }
+        return environment
     }
 
     func openLogs() {

--- a/desktop/macos/AgentDockApp/Tests/ServiceControllerValidationTests.swift
+++ b/desktop/macos/AgentDockApp/Tests/ServiceControllerValidationTests.swift
@@ -62,6 +62,7 @@ struct ServiceControllerValidationTests {
         testServiceRegistrationStatusClassification()
         try testNexusConnectionStateResolution(root: root)
         try testDesktopUpdateCheckDecoding()
+        try testDesktopUpdateEnvironment(root: root, appBundle: appBundle)
 
         print("service controller validation tests passed")
     }
@@ -151,6 +152,32 @@ struct ServiceControllerValidationTests {
         expectFailure(L10n.text("Unable to parse the AgentDock update check result.")) {
             _ = try DesktopUpdateCheck.decode("not-json")
         }
+    }
+
+    private static func testDesktopUpdateEnvironment(root: URL, appBundle: URL) throws {
+        let home = root.appendingPathComponent("update-environment-home", isDirectory: true)
+        let paths = AppPaths(home: home, appBundle: appBundle)
+        try FileManager.default.createDirectory(at: paths.appSupport, withIntermediateDirectories: true)
+        try Data("""
+        AGENTDOCK_AUTH_TOKEN='must-not-leak'
+        AGENTDOCK_OAUTH_PASSWORD='must-not-leak'
+        AGENTDOCK_CODESIGN_IDENTITY='stable-identity'
+        AGENTDOCK_CODESIGN_KEYCHAIN='/tmp/stable.keychain-db'
+        AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD=''
+        AGENTDOCK_CODESIGN_IDENTIFIER='com.uvwt.agentdock.core'
+        AGENTDOCK_CODESIGN_HOME='/Users/test'
+        """.utf8).write(to: paths.environment)
+
+        let environment = try ServiceController(paths: paths).desktopUpdateEnvironment()
+        precondition(environment["AGENTDOCK_DESKTOP_APP_PATH"] == appBundle.path)
+        precondition(environment["AGENTDOCK_CODESIGN_IDENTITY"] == "stable-identity")
+        precondition(environment["AGENTDOCK_CODESIGN_KEYCHAIN"] == "/tmp/stable.keychain-db")
+        precondition(environment["AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD"] == "")
+        precondition(environment["AGENTDOCK_CODESIGN_IDENTIFIER"] == "com.uvwt.agentdock.core")
+        precondition(environment["AGENTDOCK_CODESIGN_HOME"] == "/Users/test")
+        precondition(environment["AGENTDOCK_AUTH_TOKEN"] == nil)
+        precondition(environment["AGENTDOCK_OAUTH_PASSWORD"] == nil)
+        precondition(environment.count == 6)
     }
 
     private static func expectFailure(_ expected: String, operation: () throws -> Void) {

--- a/internal/selfupdate/codesign_darwin.go
+++ b/internal/selfupdate/codesign_darwin.go
@@ -1,0 +1,152 @@
+//go:build darwin
+
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type localCodeSignConfig struct {
+	identity         string
+	keychain         string
+	keychainPassword string
+	home             string
+}
+
+func localCodeSignConfigFromEnvironment(defaultHome string) (localCodeSignConfig, error) {
+	config := localCodeSignConfig{
+		identity:         strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_IDENTITY")),
+		keychain:         strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_KEYCHAIN")),
+		keychainPassword: os.Getenv("AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD"),
+		home:             strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_HOME")),
+	}
+	if config.identity == "" {
+		return config, nil
+	}
+	if config.home == "" {
+		config.home = defaultHome
+	}
+	homeInfo, err := os.Stat(config.home)
+	if err != nil || !homeInfo.IsDir() {
+		return localCodeSignConfig{}, fmt.Errorf("AGENTDOCK_CODESIGN_HOME 不是可用目录: %s", config.home)
+	}
+	if config.keychain != "" && !regularFile(config.keychain) {
+		return localCodeSignConfig{}, fmt.Errorf("代码签名钥匙串不存在或不是普通文件: %s", config.keychain)
+	}
+	return config, nil
+}
+
+func (config localCodeSignConfig) enabled() bool {
+	return config.identity != ""
+}
+
+func (config localCodeSignConfig) prepare(ctx context.Context) error {
+	if !config.enabled() {
+		return nil
+	}
+	commandEnv := environmentWithOverride(os.Environ(), "HOME", config.home)
+	if config.keychain != "" {
+		unlockCommand := exec.CommandContext(ctx, "security", "unlock-keychain", "-p", config.keychainPassword, config.keychain)
+		unlockCommand.Env = commandEnv
+		if output, err := unlockCommand.CombinedOutput(); err != nil {
+			return fmt.Errorf("解锁 macOS 代码签名钥匙串失败: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	}
+
+	identityArgs := []string{"find-identity", "-v", "-p", "codesigning"}
+	if config.keychain != "" {
+		identityArgs = append(identityArgs, config.keychain)
+	}
+	identityCommand := exec.CommandContext(ctx, "security", identityArgs...)
+	identityCommand.Env = commandEnv
+	identityOutput, err := identityCommand.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("读取 macOS 代码签名身份失败: %w: %s", err, strings.TrimSpace(string(identityOutput)))
+	}
+	if !strings.Contains(string(identityOutput), config.identity) {
+		return fmt.Errorf("找不到 macOS 代码签名身份 %s: %s", config.identity, strings.TrimSpace(string(identityOutput)))
+	}
+	return nil
+}
+
+func (config localCodeSignConfig) sign(ctx context.Context, targetPath, identifier string) error {
+	codesignArgs := []string{"--force"}
+	if config.keychain != "" {
+		codesignArgs = append(codesignArgs, "--keychain", config.keychain)
+	}
+	codesignArgs = append(codesignArgs,
+		"--sign", config.identity,
+		"--timestamp=none",
+		"--options", "runtime",
+		"--identifier", identifier,
+		targetPath,
+	)
+	commandEnv := environmentWithOverride(os.Environ(), "HOME", config.home)
+	codesignCommand := exec.CommandContext(ctx, "codesign", codesignArgs...)
+	codesignCommand.Env = commandEnv
+	if output, err := codesignCommand.CombinedOutput(); err != nil {
+		return fmt.Errorf("macOS 本地签名失败: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	verifyCommand := exec.CommandContext(ctx, "codesign", "--verify", "--strict", "--verbose=2", targetPath)
+	verifyCommand.Env = commandEnv
+	if output, err := verifyCommand.CombinedOutput(); err != nil {
+		return fmt.Errorf("macOS 本地签名验证失败: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	detailCommand := exec.CommandContext(ctx, "codesign", "-dv", "--verbose=4", targetPath)
+	detailCommand.Env = commandEnv
+	detailOutput, err := detailCommand.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("读取 macOS 签名详情失败: %w: %s", err, strings.TrimSpace(string(detailOutput)))
+	}
+	if !containsCodeSignIdentifier(string(detailOutput), identifier) {
+		return fmt.Errorf("macOS 签名 Identifier 验证失败，期望 %s: %s", identifier, strings.TrimSpace(string(detailOutput)))
+	}
+	return nil
+}
+
+func signLocalDesktopReplacement(ctx context.Context, appPath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	config, err := localCodeSignConfigFromEnvironment(home)
+	if err != nil {
+		return err
+	}
+	if !config.enabled() {
+		return nil
+	}
+	if err := config.prepare(ctx); err != nil {
+		return err
+	}
+
+	// TCC 会同时把外层 App 和实际执行桌面能力的 Core 当作责任主体。
+	// 因此稳定签名必须覆盖所有嵌套可执行文件，再最后签外层 App；
+	// 只重签 Core 或只重签 App 都无法保证升级后继续匹配原有权限记录。
+	for _, target := range []struct {
+		path       string
+		identifier string
+	}{
+		{path: filepath.Join(appPath, "Contents", "Helpers", "AgentDockLoginHelper"), identifier: "com.uvwt.agentdock.login-helper"},
+		{path: filepath.Join(appPath, "Contents", "Helpers", "agentdock"), identifier: "com.uvwt.agentdock.core"},
+		{path: filepath.Join(appPath, "Contents", "Helpers", "cloudflared"), identifier: "com.uvwt.agentdock.cloudflared"},
+		{path: appPath, identifier: "com.uvwt.agentdock"},
+	} {
+		if err := config.sign(ctx, target.path, target.identifier); err != nil {
+			return fmt.Errorf("重签 %s 失败: %w", target.identifier, err)
+		}
+	}
+
+	verifyCommand := exec.CommandContext(ctx, "codesign", "--verify", "--deep", "--strict", "--verbose=2", appPath)
+	verifyCommand.Env = environmentWithOverride(os.Environ(), "HOME", config.home)
+	if output, err := verifyCommand.CombinedOutput(); err != nil {
+		return fmt.Errorf("macOS App 本地稳定签名递归验证失败: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/internal/selfupdate/codesign_darwin_test.go
+++ b/internal/selfupdate/codesign_darwin_test.go
@@ -1,0 +1,117 @@
+//go:build darwin
+
+package selfupdate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSignLocalDesktopReplacementUsesStableIdentityForWholeBundle(t *testing.T) {
+	home := t.TempDir()
+	fakeBin := filepath.Join(home, "bin")
+	if err := os.MkdirAll(fakeBin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	callsPath := filepath.Join(home, "codesign.calls")
+	keychain := filepath.Join(home, "agentdock-codesign.keychain-db")
+	if err := os.WriteFile(keychain, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	securityScript := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "find-identity" ]; then
+  printf '  1) TESTHASH "test-identity"\n'
+fi
+`
+	codesignScript := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$SIGN_TEST_CODESIGN_CALLS"
+if [ "${1:-}" = "-dv" ]; then
+  last=""
+  for arg in "$@"; do last="$arg"; done
+  case "$last" in
+    */AgentDockLoginHelper) identifier=com.uvwt.agentdock.login-helper ;;
+    */agentdock) identifier=com.uvwt.agentdock.core ;;
+    */cloudflared) identifier=com.uvwt.agentdock.cloudflared ;;
+    *.app) identifier=com.uvwt.agentdock ;;
+    *) exit 2 ;;
+  esac
+  printf 'Identifier=%s\n' "$identifier"
+fi
+`
+	for name, content := range map[string]string{
+		"security": securityScript,
+		"codesign": codesignScript,
+	} {
+		path := filepath.Join(fakeBin, name)
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", fakeBin+":/usr/bin:/bin")
+	t.Setenv("SIGN_TEST_CODESIGN_CALLS", callsPath)
+	t.Setenv("AGENTDOCK_CODESIGN_IDENTITY", "test-identity")
+	t.Setenv("AGENTDOCK_CODESIGN_KEYCHAIN", keychain)
+	t.Setenv("AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD", "")
+	t.Setenv("AGENTDOCK_CODESIGN_HOME", home)
+
+	appPath := filepath.Join(home, "AgentDock.app")
+	if err := signLocalDesktopReplacement(context.Background(), appPath); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var signCalls []string
+	for _, line := range strings.Split(strings.TrimSpace(string(calls)), "\n") {
+		if strings.HasPrefix(line, "--force ") {
+			signCalls = append(signCalls, line)
+		}
+	}
+	wantIdentifiers := []string{
+		"com.uvwt.agentdock.login-helper",
+		"com.uvwt.agentdock.core",
+		"com.uvwt.agentdock.cloudflared",
+		"com.uvwt.agentdock",
+	}
+	if len(signCalls) != len(wantIdentifiers) {
+		t.Fatalf("stable sign calls = %d, want %d:\n%s", len(signCalls), len(wantIdentifiers), calls)
+	}
+	for index, identifier := range wantIdentifiers {
+		call := signCalls[index]
+		for _, required := range []string{
+			"--keychain " + keychain,
+			"--sign test-identity",
+			"--timestamp=none",
+			"--options runtime",
+			"--identifier " + identifier,
+		} {
+			if !strings.Contains(call, required) {
+				t.Fatalf("sign call %d missing %q: %s", index, required, call)
+			}
+		}
+	}
+	if !strings.Contains(string(calls), "--verify --deep --strict --verbose=2 "+appPath) {
+		t.Fatalf("missing final deep verification:\n%s", calls)
+	}
+}
+
+func TestSignLocalDesktopReplacementKeepsReleaseSignatureWithoutLocalIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDOCK_CODESIGN_IDENTITY", "")
+	t.Setenv("AGENTDOCK_CODESIGN_HOME", filepath.Join(home, "missing"))
+
+	if err := signLocalDesktopReplacement(context.Background(), filepath.Join(home, "AgentDock.app")); err != nil {
+		t.Fatalf("no local identity should leave the verified Release signature untouched: %v", err)
+	}
+}

--- a/internal/selfupdate/desktop_update_darwin.go
+++ b/internal/selfupdate/desktop_update_darwin.go
@@ -147,6 +147,15 @@ func extractDesktopUpdateArchive(ctx context.Context, archiveData []byte, tempDi
 	if err := validateMacOSDesktopRuntime(ctx, appPath, targetVersion); err != nil {
 		return "", err
 	}
+	// 先验证 Release 原始签名，再按本机显式配置重签 staged App。这样公共
+	// Release 可以继续使用自己的签名，而启用了稳定本地身份的设备在更新后
+	// 仍保持同一 Designated Requirement，不会因 ad-hoc CDHash 变化丢失 TCC。
+	if err := signLocalDesktopReplacement(ctx, appPath); err != nil {
+		return "", fmt.Errorf("准备 macOS App 本地稳定签名失败: %w", err)
+	}
+	if err := validateMacOSDesktopRuntime(ctx, appPath, targetVersion); err != nil {
+		return "", fmt.Errorf("本地重签后的 macOS App 验证失败: %w", err)
+	}
 	return appPath, nil
 }
 

--- a/internal/selfupdate/service_darwin.go
+++ b/internal/selfupdate/service_darwin.go
@@ -293,87 +293,26 @@ func signLocalReplacement(ctx context.Context, targetPath string) error {
 		return nil
 	}
 
-	identity := strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_IDENTITY"))
-	keychain := strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_KEYCHAIN"))
-	keychainPassword := os.Getenv("AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD")
-	identifier := strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_IDENTIFIER"))
-	if identifier == "" {
-		identifier = "com.local.agentdock"
+	config, err := localCodeSignConfigFromEnvironment(home)
+	if err != nil {
+		return err
 	}
-	signHome := strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_HOME"))
-	if signHome == "" {
-		signHome = home
-	}
-	signHomeInfo, err := os.Stat(signHome)
-	if err != nil || !signHomeInfo.IsDir() {
-		return fmt.Errorf("AGENTDOCK_CODESIGN_HOME 不是可用目录: %s", signHome)
-	}
-
 	// 没有本地身份时保留 Release 自带签名，但仍拒绝启动签名损坏的二进制。
-	if identity == "" {
+	if !config.enabled() {
 		output, verifyErr := exec.CommandContext(ctx, "codesign", "--verify", "--strict", "--verbose=2", targetPath).CombinedOutput()
 		if verifyErr != nil {
 			return fmt.Errorf("Release 代码签名验证失败: %w: %s", verifyErr, strings.TrimSpace(string(output)))
 		}
 		return nil
 	}
-
-	if keychain != "" && !regularFile(keychain) {
-		return fmt.Errorf("代码签名钥匙串不存在或不是普通文件: %s", keychain)
+	if err := config.prepare(ctx); err != nil {
+		return err
 	}
-	commandEnv := environmentWithOverride(os.Environ(), "HOME", signHome)
-	if keychain != "" {
-		unlockCommand := exec.CommandContext(ctx, "security", "unlock-keychain", "-p", keychainPassword, keychain)
-		unlockCommand.Env = commandEnv
-		if output, unlockErr := unlockCommand.CombinedOutput(); unlockErr != nil {
-			return fmt.Errorf("解锁 macOS 代码签名钥匙串失败: %w: %s", unlockErr, strings.TrimSpace(string(output)))
-		}
+	identifier := strings.TrimSpace(os.Getenv("AGENTDOCK_CODESIGN_IDENTIFIER"))
+	if identifier == "" {
+		identifier = "com.local.agentdock"
 	}
-	identityArgs := []string{"find-identity", "-v", "-p", "codesigning"}
-	if keychain != "" {
-		identityArgs = append(identityArgs, keychain)
-	}
-	identityCommand := exec.CommandContext(ctx, "security", identityArgs...)
-	identityCommand.Env = commandEnv
-	identityOutput, err := identityCommand.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("读取 macOS 代码签名身份失败: %w: %s", err, strings.TrimSpace(string(identityOutput)))
-	}
-	if !strings.Contains(string(identityOutput), identity) {
-		return fmt.Errorf("找不到 macOS 代码签名身份 %s: %s", identity, strings.TrimSpace(string(identityOutput)))
-	}
-
-	codesignArgs := []string{"--force"}
-	if keychain != "" {
-		codesignArgs = append(codesignArgs, "--keychain", keychain)
-	}
-	codesignArgs = append(codesignArgs,
-		"--sign", identity,
-		"--timestamp=none",
-		"--options", "runtime",
-		"--identifier", identifier,
-		targetPath,
-	)
-	codesignCommand := exec.CommandContext(ctx, "codesign", codesignArgs...)
-	codesignCommand.Env = commandEnv
-	if output, signErr := codesignCommand.CombinedOutput(); signErr != nil {
-		return fmt.Errorf("macOS 本地签名失败: %w: %s", signErr, strings.TrimSpace(string(output)))
-	}
-	verifyCommand := exec.CommandContext(ctx, "codesign", "--verify", "--strict", "--verbose=2", targetPath)
-	verifyCommand.Env = commandEnv
-	if output, verifyErr := verifyCommand.CombinedOutput(); verifyErr != nil {
-		return fmt.Errorf("macOS 本地签名验证失败: %w: %s", verifyErr, strings.TrimSpace(string(output)))
-	}
-	detailCommand := exec.CommandContext(ctx, "codesign", "-dv", "--verbose=4", targetPath)
-	detailCommand.Env = commandEnv
-	detailOutput, detailErr := detailCommand.CombinedOutput()
-	if detailErr != nil {
-		return fmt.Errorf("读取 macOS 签名详情失败: %w: %s", detailErr, strings.TrimSpace(string(detailOutput)))
-	}
-	if !containsCodeSignIdentifier(string(detailOutput), identifier) {
-		return fmt.Errorf("macOS 签名 Identifier 验证失败，期望 %s: %s", identifier, strings.TrimSpace(string(detailOutput)))
-	}
-	return nil
+	return config.sign(ctx, targetPath, identifier)
 }
 
 func regularFile(path string) bool {

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -11,6 +11,10 @@ OFFLINE_PAYLOAD_DIR="${AGENTDOCK_MACOS_OFFLINE_PAYLOAD_DIR:-}"
 MIN_VERSION="${AGENTDOCK_MACOS_MIN_VERSION:-13.0}"
 BUNDLE_ID="com.uvwt.agentdock"
 APP_ICON_SOURCE="$ROOT_DIR/packaging/assets/agentdock.png"
+SIGN_IDENTITY="${AGENTDOCK_CODESIGN_IDENTITY:-}"
+SIGN_KEYCHAIN="${AGENTDOCK_CODESIGN_KEYCHAIN:-}"
+SIGN_KEYCHAIN_PASSWORD="${AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD:-}"
+SIGN_HOME="${AGENTDOCK_CODESIGN_HOME:-$HOME}"
 
 usage() {
   cat <<'USAGE'
@@ -23,12 +27,59 @@ usage() {
   AGENTDOCK_MACOS_OFFLINE_PAYLOAD_DIR
                                双架构离线载荷目录，构建 DMG 时必须提供
   AGENTDOCK_MACOS_MIN_VERSION   最低 macOS 版本，默认 13.0
+  AGENTDOCK_CODESIGN_IDENTITY   可选稳定代码签名身份；未设置时保持 ad-hoc 签名
+  AGENTDOCK_CODESIGN_KEYCHAIN   可选专用签名钥匙串
+  AGENTDOCK_CODESIGN_KEYCHAIN_PASSWORD
+                               可选专用钥匙串密码，默认空字符串
+  AGENTDOCK_CODESIGN_HOME       可选 codesign/security HOME，默认当前 HOME
 USAGE
 }
 
 die() {
   print -u2 -- "ERROR: $*"
   exit 1
+}
+
+prepare_signing() {
+  [[ -n "$SIGN_IDENTITY" ]] || return 0
+  [[ -d "$SIGN_HOME" ]] || die "AGENTDOCK_CODESIGN_HOME 不是目录：$SIGN_HOME"
+  command -v security >/dev/null 2>&1 || die "缺少命令：security"
+
+  local identity_output
+  if [[ -n "$SIGN_KEYCHAIN" ]]; then
+    [[ -f "$SIGN_KEYCHAIN" && ! -L "$SIGN_KEYCHAIN" ]] || die "代码签名钥匙串不存在或不是普通文件：$SIGN_KEYCHAIN"
+    HOME="$SIGN_HOME" security unlock-keychain -p "$SIGN_KEYCHAIN_PASSWORD" "$SIGN_KEYCHAIN" >/dev/null 2>&1 || \
+      die "无法解锁代码签名钥匙串：$SIGN_KEYCHAIN"
+    identity_output="$(HOME="$SIGN_HOME" security find-identity -v -p codesigning "$SIGN_KEYCHAIN")" || \
+      die "无法读取指定钥匙串中的签名身份"
+  else
+    identity_output="$(HOME="$SIGN_HOME" security find-identity -v -p codesigning)" || \
+      die "无法读取系统钥匙串中的签名身份"
+  fi
+  [[ "$identity_output" == *"$SIGN_IDENTITY"* ]] || die "找不到代码签名身份：$SIGN_IDENTITY"
+}
+
+sign_code() {
+  local identifier="$1"
+  local target="$2"
+  if [[ -z "$SIGN_IDENTITY" ]]; then
+    codesign --force --sign - --identifier "$identifier" "$target"
+    return
+  fi
+
+  local -a sign_args
+  sign_args=(--force)
+  if [[ -n "$SIGN_KEYCHAIN" ]]; then
+    sign_args+=(--keychain "$SIGN_KEYCHAIN")
+  fi
+  sign_args+=(
+    --sign "$SIGN_IDENTITY"
+    --timestamp=none
+    --options runtime
+    --identifier "$identifier"
+    "$target"
+  )
+  HOME="$SIGN_HOME" codesign "${sign_args[@]}"
 }
 
 if (( $# > 1 )); then
@@ -333,13 +384,18 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
 PLIST
 plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
 
-print -- "==> ad-hoc 签名 AgentDock.app"
-codesign --force --sign - --identifier "com.uvwt.agentdock.login-helper" "$MENU_LOGIN_HELPER"
-codesign --force --sign - --identifier "com.uvwt.agentdock.core" "$HELPERS_DIR/agentdock"
-codesign --force --sign - --identifier "com.uvwt.agentdock.cloudflared" "$HELPERS_DIR/cloudflared"
+prepare_signing
+if [[ -n "$SIGN_IDENTITY" ]]; then
+  print -- "==> 使用稳定身份签名 AgentDock.app：$SIGN_IDENTITY"
+else
+  print -- "==> ad-hoc 签名 AgentDock.app"
+fi
+sign_code "com.uvwt.agentdock.login-helper" "$MENU_LOGIN_HELPER"
+sign_code "com.uvwt.agentdock.core" "$HELPERS_DIR/agentdock"
+sign_code "com.uvwt.agentdock.cloudflared" "$HELPERS_DIR/cloudflared"
 # 嵌套代码先分别签名，再签外层 App。不要用 --deep 做签名操作，否则会重新签
 # Core/cloudflared 并破坏它们的稳定代码身份；--deep 只用于最终递归验证。
-codesign --force --sign - --identifier "$BUNDLE_ID" "$APP_DIR"
+sign_code "$BUNDLE_ID" "$APP_DIR"
 codesign --verify --deep --strict --verbose=2 "$APP_DIR"
 
 ZIP_PATH="$OUTPUT_DIR/AgentDock-macos-universal.zip"


### PR DESCRIPTION
## 说明

- macOS App 构建在显式配置本地签名身份时，对 App、Core、cloudflared 和 login helper 使用稳定证书；未配置时继续保持公共 Release 的 ad-hoc 行为
- Desktop Update 先验证原始 Release 签名，再按本机签名配置重签 staged App，避免更新后 TCC 因 ad-hoc CDHash 变化失效
- GUI updater 仅从 agentdock.env 白名单透传 AGENTDOCK_CODESIGN_*，不透传 Auth/OAuth 服务凭据

## 验证

- go test ./...
- go vet ./...
- macOS i18n 305/305
- scripts/test/test-macos-app.sh：ad-hoc 与真实稳定证书两种模式均通过
- 真实 keychain 下 Desktop Update archive extract 测试通过
- 两份不同内容 App 的 CDHash 不同，但稳定证书 Designated Requirement 相同