### PR TITLE
fix(windows): bind interactive task starts to active session

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -55,6 +55,13 @@ jobs:
           & .\scripts\test\test-windows-runtime-launch-diagnostics.ps1 `
             -LauncherPath .\scripts\install\launch-windows-process.ps1
 
+      - name: Test Task Scheduler session selection
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & .\scripts\test\test-windows-task-scheduler.ps1 `
+            -ManagerPath .\scripts\install\manage-windows.ps1
+
       - name: Download and validate exact installer bytes
         shell: powershell
         run: |

--- a/desktop/windows/control-panel/Services/TaskAdminService.cs
+++ b/desktop/windows/control-panel/Services/TaskAdminService.cs
@@ -314,10 +314,6 @@ internal static class TaskAdminService
         {
             task.SetSecurityDescriptor(state.SecurityDescriptor, 0);
         }
-        if (state.WasRunning)
-        {
-            task.Run(null);
-        }
     }
 
     private static string ReadTaskUserId(string xml)

--- a/internal/desktopruntime/service_windows.go
+++ b/internal/desktopruntime/service_windows.go
@@ -71,7 +71,7 @@ func startCore(ctx context.Context, manifest Manifest, runtimeRoot string) error
 		return nil
 	}
 	if manifest.UsesScheduledTask() {
-		if err := runScheduledTaskCommand(ctx, "/Run", "/TN", scheduledTaskPath(manifest.AgentDockTaskName)); err != nil {
+		if err := StartInteractiveScheduledTask(ctx, runtimeRoot, manifest.AgentDockTaskName); err != nil {
 			return err
 		}
 	} else if err := startDetachedCore(manifest, runtimeRoot); err != nil {

--- a/internal/desktopruntime/task_scheduler_windows.go
+++ b/internal/desktopruntime/task_scheduler_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package desktopruntime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// StartInteractiveScheduledTask starts an InteractiveToken task through the
+// shared Windows Task Scheduler helper so every caller uses the same session
+// selection, user-SID validation, and RunEx(TASK_RUN_USE_SESSION_ID) behavior.
+func StartInteractiveScheduledTask(ctx context.Context, runtimeRoot, taskName string) error {
+	runtimeRoot = strings.TrimSpace(runtimeRoot)
+	if runtimeRoot == "" {
+		return fmt.Errorf("Windows runtime root is empty while starting scheduled task")
+	}
+
+	scriptPath := filepath.Join(runtimeRoot, "installer", "manage-windows.ps1")
+	info, err := os.Stat(scriptPath)
+	if err != nil || info.IsDir() {
+		if err == nil {
+			err = fmt.Errorf("path is a directory")
+		}
+		return fmt.Errorf("Windows task-session helper is unavailable at %s: %w", scriptPath, err)
+	}
+
+	taskName = strings.TrimLeft(strings.TrimSpace(taskName), `\`)
+	if taskName == "" {
+		taskName = "AgentDock"
+	}
+	command := exec.CommandContext(
+		ctx,
+		"powershell.exe",
+		"-NoLogo",
+		"-NoProfile",
+		"-NonInteractive",
+		"-WindowStyle", "Hidden",
+		"-ExecutionPolicy", "Bypass",
+		"-File", scriptPath,
+		"-Action", "task-run-session",
+		"-ScheduledTaskName", taskName,
+		"-ScheduledTaskPath", `\`,
+	)
+	command.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			return fmt.Errorf("start Windows scheduled task %s through session helper: %w", taskName, err)
+		}
+		return fmt.Errorf("start Windows scheduled task %s through session helper: %w: %s", taskName, err, message)
+	}
+	return nil
+}

--- a/internal/selfupdate/apply_windows.go
+++ b/internal/selfupdate/apply_windows.go
@@ -412,7 +412,7 @@ func restartWindowsMode(ctx context.Context, plan windowsUpdatePlan) error {
 		if strings.TrimSpace(plan.TaskName) == "" {
 			return errors.New("Windows 计划任务名称为空")
 		}
-		if err := runWindowsCommand(ctx, "schtasks.exe", "/Run", "/TN", `\`+plan.TaskName); err != nil {
+		if err := desktopruntime.StartInteractiveScheduledTask(ctx, plan.RuntimeRoot, plan.TaskName); err != nil {
 			return fmt.Errorf("启动 Windows AgentDock 计划任务失败: %w", err)
 		}
 		return nil

--- a/internal/selfupdate/desktop_apply_windows.go
+++ b/internal/selfupdate/desktop_apply_windows.go
@@ -51,6 +51,7 @@ func applyWindowsDesktopOnlyUpdate(ctx context.Context, request applyRequest) (a
 	}
 	taskWasRunning := manifest.UsesScheduledTask() && coreWasRunning
 	taskName := windowsScheduledTaskPath(manifest.AgentDockTaskName)
+	runtimeRoot := filepath.Dir(filepath.Dir(request.CurrentPath))
 
 	update, err := prepareWindowsDesktopUpdate(request.CurrentPath, request.DesktopTargetPath, request.DesktopStagedPath)
 	if err != nil {
@@ -77,7 +78,7 @@ func applyWindowsDesktopOnlyUpdate(ctx context.Context, request applyRequest) (a
 			failures = append(failures, "恢复旧控制面板失败: "+restoreErr.Error())
 		}
 		if taskWasRunning {
-			if restartErr := runWindowsCommand(ctx, "schtasks.exe", "/Run", "/TN", taskName); restartErr != nil {
+			if restartErr := desktopruntime.StartInteractiveScheduledTask(ctx, runtimeRoot, taskName); restartErr != nil {
 				failures = append(failures, "重新启动旧核心计划任务失败: "+restartErr.Error())
 			} else if waitErr := waitForVersion(ctx, []string{manifest.HealthURL()}, request.CurrentVersion, 30*time.Second); waitErr != nil {
 				failures = append(failures, "旧核心健康检查失败: "+waitErr.Error())
@@ -97,16 +98,16 @@ func applyWindowsDesktopOnlyUpdate(ctx context.Context, request applyRequest) (a
 			return applyResult{}, fmt.Errorf("停止 Windows 管理员核心计划任务失败: %w", err)
 		}
 		if stopped, waitErr := desktopruntime.WaitBinaryStopped(ctx, request.CurrentPath, 15*time.Second); waitErr != nil {
-			_ = runWindowsCommand(context.Background(), "schtasks.exe", "/Run", "/TN", taskName)
+			_ = desktopruntime.StartInteractiveScheduledTask(context.Background(), runtimeRoot, taskName)
 			return applyResult{}, fmt.Errorf("等待 Windows 管理员核心退出失败: %w", waitErr)
 		} else if !stopped {
-			_ = runWindowsCommand(context.Background(), "schtasks.exe", "/Run", "/TN", taskName)
+			_ = desktopruntime.StartInteractiveScheduledTask(context.Background(), runtimeRoot, taskName)
 			return applyResult{}, errors.New("Windows 管理员核心未在 15s 内退出")
 		}
 	}
 	if err := update.StopTray(ctx); err != nil {
 		if taskWasRunning {
-			_ = runWindowsCommand(context.Background(), "schtasks.exe", "/Run", "/TN", taskName)
+			_ = desktopruntime.StartInteractiveScheduledTask(context.Background(), runtimeRoot, taskName)
 		}
 		return applyResult{}, err
 	}
@@ -115,7 +116,7 @@ func applyWindowsDesktopOnlyUpdate(ctx context.Context, request applyRequest) (a
 		return applyResult{}, rollback(err)
 	}
 	if taskWasRunning {
-		if err := runWindowsCommand(ctx, "schtasks.exe", "/Run", "/TN", taskName); err != nil {
+		if err := desktopruntime.StartInteractiveScheduledTask(ctx, runtimeRoot, taskName); err != nil {
 			return applyResult{}, rollback(fmt.Errorf("重新启动 Windows 管理员核心计划任务失败: %w", err))
 		}
 		if err := waitForVersion(ctx, []string{manifest.HealthURL()}, request.TargetVersion, 30*time.Second); err != nil {

--- a/packaging/windows/AgentDock.iss
+++ b/packaging/windows/AgentDock.iss
@@ -68,6 +68,7 @@ Name: "chinesesimplified"; MessagesFile: "compiler:Default.isl, languages\Chines
 [Files]
 Source: "..\..\scripts\install\install.ps1"; Flags: dontcopy
 Source: "..\..\scripts\install\launch-windows-process.ps1"; Flags: dontcopy
+Source: "..\..\scripts\install\manage-windows.ps1"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\agentdock_windows_{#PayloadArchitecture}.zip"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\agentdock_windows_{#PayloadArchitecture}.zip.sha256"; Flags: dontcopy
 Source: "{#OfflinePayloadDir}\cloudflared.exe"; Flags: dontcopy

--- a/packaging/windows/includes/code.iss
+++ b/packaging/windows/includes/code.iss
@@ -438,6 +438,7 @@ begin
     InstallProgressPage.SetProgress(1, 4);
     ExtractTemporaryFile('install.ps1');
     ExtractTemporaryFile('launch-windows-process.ps1');
+    ExtractTemporaryFile('manage-windows.ps1');
     ExtractTemporaryFile('agentdock_windows_{#PayloadArchitecture}.zip');
     ExtractTemporaryFile('agentdock_windows_{#PayloadArchitecture}.zip.sha256');
     ExtractTemporaryFile('cloudflared.exe');

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -662,7 +662,15 @@ function Enable-AgentDockTask {
 }
 
 function Start-AgentDockTask {
-    Start-ScheduledTask -TaskName 'AgentDock' -TaskPath '\' -ErrorAction Stop
+    param([Parameter(Mandatory = $true)][string] $ManagerScriptPath)
+
+    if (-not (Test-Path -LiteralPath $ManagerScriptPath -PathType Leaf)) {
+        throw "Windows manager was not found: $ManagerScriptPath"
+    }
+    & $ManagerScriptPath `
+        -Action task-run-session `
+        -ScheduledTaskName 'AgentDock' `
+        -ScheduledTaskPath '\'
 }
 
 function Stop-ProcessesForUpgrade {
@@ -1537,7 +1545,7 @@ exit `$LASTEXITCODE
 
         if ($RegisterStartup) {
             if ($effectivePrivilegeMode -eq 'elevated') {
-                Start-AgentDockTask
+                Start-AgentDockTask -ManagerScriptPath $managerScriptPath
             } elseif ($InstallChannel -eq 'setup') {
                 Invoke-SetupRuntimeProcess `
                     -FilePath $destinationBinary `
@@ -1779,7 +1787,15 @@ exit `$LASTEXITCODE
             }
         }
 
-        $taskWillRestartAgentDock = $taskRestored -and $taskState.WasRunning
+        $taskWillRestartAgentDock = $false
+        if ($taskRestored -and $taskState.WasRunning) {
+            & $sourceManagerScript `
+                -Action task-run-session `
+                -ScheduledTaskName 'AgentDock' `
+                -ScheduledTaskPath '\' `
+                -ExpectedUserSid $taskUser.Sid
+            $taskWillRestartAgentDock = $true
+        }
         if ($processWasRunning -and -not $taskWillRestartAgentDock -and
             (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
             Start-AgentDockLauncher -LauncherPath $launcherPath

--- a/scripts/install/launch-windows-process.ps1
+++ b/scripts/install/launch-windows-process.ps1
@@ -69,8 +69,12 @@ if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
 }
 
 $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
-if ($null -eq $identity -or [string]::IsNullOrWhiteSpace($identity.Name)) {
+if ($null -eq $identity -or $null -eq $identity.User -or [string]::IsNullOrWhiteSpace($identity.Name)) {
     throw 'Unable to resolve the current Windows identity for runtime launch.'
+}
+$managerScriptPath = Join-Path $PSScriptRoot 'manage-windows.ps1'
+if (-not (Test-Path -LiteralPath $managerScriptPath -PathType Leaf)) {
+    throw "Windows manager was not found: $managerScriptPath"
 }
 
 $taskName = 'AgentDock Setup Runtime ' + [Guid]::NewGuid().ToString('N')
@@ -169,7 +173,11 @@ try {
         -Settings $settings `
         -Force | Out-Null
     $registered = $true
-    Start-ScheduledTask -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+    & $managerScriptPath `
+        -Action task-run-session `
+        -ScheduledTaskName $taskName `
+        -ScheduledTaskPath '\' `
+        -ExpectedUserSid $identity.User.Value
 
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     do {

--- a/scripts/install/manage-windows.ps1
+++ b/scripts/install/manage-windows.ps1
@@ -14,6 +14,7 @@ param(
         'launch-core',
         'launch-tunnel',
         'set-task-startup',
+        'task-run-session',
         'task-start',
         'task-stop'
     )]
@@ -26,7 +27,10 @@ param(
     [ValidateSet('core', 'tray')]
     [string] $Component = 'core',
     [ValidateSet('true', 'false')]
-    [string] $Enabled = 'false'
+    [string] $Enabled = 'false',
+    [string] $ScheduledTaskName = 'AgentDock',
+    [string] $ScheduledTaskPath = '\',
+    [string] $ExpectedUserSid = ''
 )
 
 Set-StrictMode -Version Latest
@@ -37,6 +41,290 @@ $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 [Console]::OutputEncoding = $Utf8NoBom
 $global:OutputEncoding = $Utf8NoBom
 Add-Type -AssemblyName System.Security
+
+$script:TaskLogonInteractiveToken = 3
+$script:TaskRunUseSessionId = 4
+$script:WtsActive = 0
+$script:WtsUserName = 5
+$script:WtsDomainName = 7
+$script:NoConsoleSession = [uint32]::MaxValue
+
+if (-not ('AgentDock.WindowsTaskSession.NativeMethods' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace AgentDock.WindowsTaskSession
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct WtsSessionInfo
+    {
+        public int SessionId;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string WinStationName;
+        public int State;
+    }
+
+    public static class NativeMethods
+    {
+        [DllImport("wtsapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool WTSEnumerateSessions(
+            IntPtr server,
+            int reserved,
+            int version,
+            out IntPtr sessionInfo,
+            out int count);
+
+        [DllImport("wtsapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool WTSQuerySessionInformation(
+            IntPtr server,
+            int sessionId,
+            int infoClass,
+            out IntPtr buffer,
+            out int bytesReturned);
+
+        [DllImport("wtsapi32.dll")]
+        public static extern void WTSFreeMemory(IntPtr memory);
+
+        [DllImport("kernel32.dll")]
+        public static extern uint WTSGetActiveConsoleSessionId();
+
+        public static int WtsSessionInfoSize()
+        {
+            return Marshal.SizeOf(typeof(WtsSessionInfo));
+        }
+
+        public static WtsSessionInfo ReadWtsSessionInfo(IntPtr address)
+        {
+            return (WtsSessionInfo)Marshal.PtrToStructure(address, typeof(WtsSessionInfo));
+        }
+    }
+}
+'@
+}
+
+function ConvertTo-WindowsUserSid {
+    param([Parameter(Mandatory = $true)][string] $Account)
+
+    $value = $Account.Trim()
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw 'Windows account is empty while resolving the scheduled-task user.'
+    }
+    try {
+        return ([Security.Principal.SecurityIdentifier] $value).Value
+    } catch {
+        try {
+            $ntAccount = New-Object Security.Principal.NTAccount($value)
+            return $ntAccount.Translate([Security.Principal.SecurityIdentifier]).Value
+        } catch {
+            throw "Unable to resolve Windows account '$value' to a SID: $($_.Exception.Message)"
+        }
+    }
+}
+
+function Get-WtsSessionText {
+    param(
+        [Parameter(Mandatory = $true)][int] $SessionId,
+        [Parameter(Mandatory = $true)][int] $InfoClass
+    )
+
+    $buffer = [IntPtr]::Zero
+    $bytesReturned = 0
+    try {
+        $ok = [AgentDock.WindowsTaskSession.NativeMethods]::WTSQuerySessionInformation(
+            [IntPtr]::Zero,
+            $SessionId,
+            $InfoClass,
+            [ref] $buffer,
+            [ref] $bytesReturned)
+        if (-not $ok -or $buffer -eq [IntPtr]::Zero -or $bytesReturned -le 2) {
+            return ''
+        }
+        return [Runtime.InteropServices.Marshal]::PtrToStringUni($buffer).TrimEnd([char] 0)
+    } finally {
+        if ($buffer -ne [IntPtr]::Zero) {
+            [AgentDock.WindowsTaskSession.NativeMethods]::WTSFreeMemory($buffer)
+        }
+    }
+}
+
+function Get-WindowsInteractiveSessions {
+    $buffer = [IntPtr]::Zero
+    $count = 0
+    try {
+        $ok = [AgentDock.WindowsTaskSession.NativeMethods]::WTSEnumerateSessions(
+            [IntPtr]::Zero,
+            0,
+            1,
+            [ref] $buffer,
+            [ref] $count)
+        if (-not $ok) {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "Unable to enumerate Windows sessions (Win32 error $errorCode)."
+        }
+
+        $sessionSize = [AgentDock.WindowsTaskSession.NativeMethods]::WtsSessionInfoSize()
+        $sessions = @()
+        for ($index = 0; $index -lt $count; $index++) {
+            $entryAddress = [IntPtr] ($buffer.ToInt64() + ($index * $sessionSize))
+            $entry = [AgentDock.WindowsTaskSession.NativeMethods]::ReadWtsSessionInfo($entryAddress)
+            $userName = Get-WtsSessionText -SessionId $entry.SessionId -InfoClass $script:WtsUserName
+            $domain = Get-WtsSessionText -SessionId $entry.SessionId -InfoClass $script:WtsDomainName
+            $account = if ([string]::IsNullOrWhiteSpace($userName)) {
+                ''
+            } elseif ([string]::IsNullOrWhiteSpace($domain)) {
+                $userName
+            } else {
+                "$domain\$userName"
+            }
+            $sid = ''
+            if (-not [string]::IsNullOrWhiteSpace($account)) {
+                try {
+                    $sid = ConvertTo-WindowsUserSid -Account $account
+                } catch {
+                    $sid = ''
+                }
+            }
+            $sessions += [pscustomobject]@{
+                SessionId = [int] $entry.SessionId
+                State = [int] $entry.State
+                UserName = $account
+                UserSid = $sid
+            }
+        }
+        return $sessions
+    } finally {
+        if ($buffer -ne [IntPtr]::Zero) {
+            [AgentDock.WindowsTaskSession.NativeMethods]::WTSFreeMemory($buffer)
+        }
+    }
+}
+
+function Select-InteractiveTaskSessionId {
+    param(
+        [Parameter(Mandatory = $true)][object[]] $Sessions,
+        [Parameter(Mandatory = $true)][string] $ExpectedUserSid,
+        [Parameter(Mandatory = $true)][int] $CurrentSessionId,
+        [Parameter(Mandatory = $true)][string] $CurrentUserSid,
+        [Parameter(Mandatory = $true)][uint32] $ConsoleSessionId
+    )
+
+    $expectedSid = ConvertTo-WindowsUserSid -Account $ExpectedUserSid
+    $currentSession = @($Sessions | Where-Object {
+        $_.SessionId -eq $CurrentSessionId -and
+        $_.State -eq $script:WtsActive -and
+        -not [string]::IsNullOrWhiteSpace([string] $_.UserSid) -and
+        [string]::Equals([string] $_.UserSid, $expectedSid, [StringComparison]::OrdinalIgnoreCase)
+    })
+
+    # UAC elevation preserves the interactive Session ID. Prefer that verified session so RDP/cloud desktops are not redirected to console.
+    if ($CurrentSessionId -gt 0 -and
+        [string]::Equals($CurrentUserSid, $expectedSid, [StringComparison]::OrdinalIgnoreCase) -and
+        $currentSession.Count -eq 1) {
+        return $CurrentSessionId
+    }
+
+    $matchingSessions = @($Sessions | Where-Object {
+        $_.State -eq $script:WtsActive -and
+        -not [string]::IsNullOrWhiteSpace([string] $_.UserSid) -and
+        [string]::Equals([string] $_.UserSid, $expectedSid, [StringComparison]::OrdinalIgnoreCase)
+    })
+    if ($matchingSessions.Count -eq 0) {
+        throw "No active interactive Windows session was found for scheduled-task user SID $expectedSid. InteractiveToken tasks cannot be started from Session 0 or a disconnected-only login."
+    }
+    if ($matchingSessions.Count -eq 1) {
+        return [int] $matchingSessions[0].SessionId
+    }
+
+    if ($ConsoleSessionId -ne $script:NoConsoleSession) {
+        $consoleMatches = @($matchingSessions | Where-Object { $_.SessionId -eq [int] $ConsoleSessionId })
+        if ($consoleMatches.Count -eq 1) {
+            return [int] $ConsoleSessionId
+        }
+    }
+
+    $ids = (($matchingSessions | ForEach-Object { [string] $_.SessionId }) -join ', ')
+    throw "Multiple active interactive Windows sessions match scheduled-task user SID $expectedSid (sessions: $ids), and the caller/console session does not disambiguate them. Refusing to guess a target session."
+}
+
+function Resolve-InteractiveTaskSessionId {
+    param([Parameter(Mandatory = $true)][string] $ExpectedUserSid)
+
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    if ($null -eq $identity -or $null -eq $identity.User) {
+        throw 'Unable to resolve the current Windows identity while selecting an interactive session.'
+    }
+    $currentSessionId = [Diagnostics.Process]::GetCurrentProcess().SessionId
+    $consoleSessionId = [AgentDock.WindowsTaskSession.NativeMethods]::WTSGetActiveConsoleSessionId()
+    $sessions = @(Get-WindowsInteractiveSessions)
+    return Select-InteractiveTaskSessionId `
+        -Sessions $sessions `
+        -ExpectedUserSid $ExpectedUserSid `
+        -CurrentSessionId $currentSessionId `
+        -CurrentUserSid $identity.User.Value `
+        -ConsoleSessionId $consoleSessionId
+}
+
+function Start-InteractiveScheduledTask {
+    param(
+        [Parameter(Mandatory = $true)][string] $TaskName,
+        [string] $TaskPath = '\',
+        [string] $ExpectedUserSid = ''
+    )
+
+    $service = $null
+    $folder = $null
+    $task = $null
+    $runningTask = $null
+    try {
+        $service = New-Object -ComObject 'Schedule.Service'
+        $service.Connect()
+        $folder = $service.GetFolder($TaskPath)
+        $task = $folder.GetTask($TaskName)
+
+        $taskUserSid = ConvertTo-WindowsUserSid -Account ([string] $task.Definition.Principal.UserId)
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedUserSid)) {
+            $expectedSid = ConvertTo-WindowsUserSid -Account $ExpectedUserSid
+            if (-not [string]::Equals($taskUserSid, $expectedSid, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Scheduled task '$TaskPath$TaskName' belongs to SID $taskUserSid, not expected SID $expectedSid."
+            }
+        }
+        if ([int] $task.Definition.Principal.LogonType -ne $script:TaskLogonInteractiveToken) {
+            throw "Scheduled task '$TaskPath$TaskName' is not an InteractiveToken task; refusing the session-bound start path."
+        }
+
+        $sessionId = Resolve-InteractiveTaskSessionId -ExpectedUserSid $taskUserSid
+        $wasEnabled = [bool] $task.Enabled
+        if (-not $wasEnabled) {
+            $task.Enabled = $true
+        }
+        try {
+            $runningTask = $task.RunEx($null, $script:TaskRunUseSessionId, $sessionId, $null)
+        } finally {
+            if (-not $wasEnabled) {
+                $task.Enabled = $false
+            }
+        }
+        Write-Verbose "Started scheduled task '$TaskPath$TaskName' in interactive session $sessionId."
+    } finally {
+        foreach ($comObject in @($runningTask, $task, $folder, $service)) {
+            if ($null -ne $comObject -and [Runtime.InteropServices.Marshal]::IsComObject($comObject)) {
+                [void] [Runtime.InteropServices.Marshal]::FinalReleaseComObject($comObject)
+            }
+        }
+    }
+}
+
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+if ($Action -eq 'task-run-session') {
+    Start-InteractiveScheduledTask `
+        -TaskName $ScheduledTaskName `
+        -TaskPath $ScheduledTaskPath `
+        -ExpectedUserSid $ExpectedUserSid
+    exit 0
+}
 
 function Convert-ToBoolean {
     param(
@@ -496,20 +784,9 @@ exit `$LASTEXITCODE
 }
 
 function Start-TaskPreservingStartupState {
-    $task = Get-ScheduledTask -TaskName $TaskName -TaskPath '\' -ErrorAction Stop
-    $wasEnabled = [bool] $task.Settings.Enabled
-
-    # 用户关闭开机启动后仍应允许手动启动。这里临时启用任务，启动后恢复原状态。
-    if (-not $wasEnabled) {
-        Enable-ScheduledTask -TaskName $TaskName -TaskPath '\' -ErrorAction Stop | Out-Null
-    }
-    try {
-        Start-ScheduledTask -TaskName $TaskName -TaskPath '\' -ErrorAction Stop
-    } finally {
-        if (-not $wasEnabled) {
-            Disable-ScheduledTask -TaskName $TaskName -TaskPath '\' -ErrorAction Stop | Out-Null
-        }
-    }
+    Start-InteractiveScheduledTask `
+        -TaskName $TaskName `
+        -TaskPath '\'
 }
 
 function Set-TaskStartupState {

--- a/scripts/test/install_windows_test.go
+++ b/scripts/test/install_windows_test.go
@@ -509,7 +509,9 @@ func TestWindowsSetupLaunchesRuntimeOutsideRedirectionGuardTree(t *testing.T) {
 		"-LogonType Interactive",
 		"-RunLevel Limited",
 		"Register-ScheduledTask",
-		"Start-ScheduledTask",
+		"$managerScriptPath = Join-Path $PSScriptRoot 'manage-windows.ps1'",
+		"-Action task-run-session",
+		"-ScheduledTaskName $taskName",
 		"if ($WaitForExit) {",
 		"$process.WaitForExit()",
 		"RedirectStandardOutput = $true",
@@ -533,7 +535,9 @@ func TestWindowsSetupLaunchesRuntimeOutsideRedirectionGuardTree(t *testing.T) {
 
 	for _, want := range []string{
 		"Source: \"..\\..\\scripts\\install\\launch-windows-process.ps1\"; Flags: dontcopy",
+		"Source: \"..\\..\\scripts\\install\\manage-windows.ps1\"; Flags: dontcopy",
 		"ExtractTemporaryFile('launch-windows-process.ps1')",
+		"ExtractTemporaryFile('manage-windows.ps1')",
 		"function LaunchRuntimeProcess(",
 		"LaunchRuntimeProcess(ExpandConstant('{app}\\bin\\agentdock-tray.exe'), '')",
 	} {

--- a/scripts/test/test-install-windows.ps1
+++ b/scripts/test/test-install-windows.ps1
@@ -46,6 +46,22 @@ if ($managerBytes.Length -lt 3 -or
     $managerBytes[2] -ne 0xBF) {
     throw "$ManagerPath must use UTF-8 with BOM for Windows PowerShell 5.1"
 }
+$managerContent = Get-Content -LiteralPath $resolvedManager -Raw
+foreach ($requiredManagerText in @(
+    "'task-run-session'",
+    'WTSGetActiveConsoleSessionId',
+    'Select-InteractiveTaskSessionId',
+    '$task.RunEx($null, $script:TaskRunUseSessionId, $sessionId, $null)',
+    'Multiple active interactive Windows sessions',
+    'No active interactive Windows session'
+)) {
+    if (-not $managerContent.Contains($requiredManagerText)) {
+        throw "$ManagerPath is missing the shared InteractiveToken RunEx contract: $requiredManagerText"
+    }
+}
+if ($managerContent.Contains('Start-ScheduledTask')) {
+    throw "$ManagerPath must not bypass the shared InteractiveToken RunEx path with Start-ScheduledTask"
+}
 
 $content = Get-Content -LiteralPath $resolvedInstaller -Raw
 $bytes = [IO.File]::ReadAllBytes($resolvedInstaller)
@@ -164,6 +180,8 @@ foreach ($required in @(
     'Set-RunValue -RegistryPath $runKey -Name $cloudflaredRunValueName',
     'Start-AgentDockLauncher -LauncherPath $launcherPath',
     'Start-CloudflaredLauncher -LauncherPath $cloudflaredLauncherPath',
+    'Start-AgentDockTask -ManagerScriptPath $managerScriptPath',
+    '-Action task-run-session',
     'Release archive does not contain manage-windows.ps1',
     'Initialize-OAuthCredentials',
     'named-server-url.txt',

--- a/scripts/test/test-windows-setup-e2e.ps1
+++ b/scripts/test/test-windows-setup-e2e.ps1
@@ -127,6 +127,14 @@ function Assert-CoreRunsWithoutConsole {
     }
 }
 
+function Start-AgentDockScheduledTask {
+    $managerPath = Join-Path $InstallRoot 'installer\manage-windows.ps1'
+    if (-not (Test-Path -LiteralPath $managerPath -PathType Leaf)) {
+        throw "Installed Windows manager is missing: $managerPath"
+    }
+    & $managerPath -Action task-run-session -ScheduledTaskName 'AgentDock' -ScheduledTaskPath '\'
+}
+
 function Assert-TaskStopKillsCore {
     Stop-ScheduledTask -TaskName 'AgentDock' -TaskPath '\' -ErrorAction Stop
     $deadline = [DateTime]::UtcNow.AddSeconds(15)
@@ -145,7 +153,7 @@ function Assert-TaskStopKillsCore {
         Start-Sleep -Milliseconds 250
     } while ($true)
 
-    Start-ScheduledTask -TaskName 'AgentDock' -TaskPath '\' -ErrorAction Stop
+    Start-AgentDockScheduledTask
     $deadline = [DateTime]::UtcNow.AddSeconds(20)
     do {
         Start-Sleep -Milliseconds 250
@@ -381,7 +389,7 @@ try {
         -Trigger $legacyTaskTrigger `
         -Description 'AgentDock legacy migration test' `
         -Force | Out-Null
-    Start-ScheduledTask -TaskName 'AgentDock' -TaskPath '\'
+    Start-AgentDockScheduledTask
     $legacyDeadline = [DateTime]::UtcNow.AddSeconds(20)
     do {
         Start-Sleep -Milliseconds 500

--- a/scripts/test/test-windows-task-scheduler.ps1
+++ b/scripts/test/test-windows-task-scheduler.ps1
@@ -1,0 +1,86 @@
+[CmdletBinding()]
+param(
+    [string] $ManagerPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($ManagerPath)) {
+    $ManagerPath = Join-Path $PSScriptRoot '..\install\manage-windows.ps1'
+}
+. $ManagerPath -Action task-run-session
+
+function Assert-Equal {
+    param($Actual, $Expected, [string] $Message)
+    if ($Actual -ne $Expected) {
+        throw "$Message Expected=$Expected Actual=$Actual"
+    }
+}
+
+function Assert-ThrowsLike {
+    param([scriptblock] $Action, [string] $ExpectedText)
+    try {
+        & $Action
+    } catch {
+        if ($_.Exception.Message -notlike "*$ExpectedText*") {
+            throw "Expected error containing '$ExpectedText', got: $($_.Exception.Message)"
+        }
+        return
+    }
+    throw "Expected an error containing '$ExpectedText', but no error was thrown."
+}
+
+$targetSid = 'S-1-5-21-1000-1000-1000-1001'
+$otherSid = 'S-1-5-18'
+
+$currentSession = @(
+    [pscustomobject]@{ SessionId = 2; State = 0; UserSid = $targetSid },
+    [pscustomobject]@{ SessionId = 4; State = 0; UserSid = $targetSid }
+)
+Assert-Equal `
+    (Select-InteractiveTaskSessionId -Sessions $currentSession -ExpectedUserSid $targetSid -CurrentSessionId 2 -CurrentUserSid $targetSid -ConsoleSessionId 4) `
+    2 `
+    'Current active caller session should win over another active session.'
+
+$sessionZero = @(
+    [pscustomobject]@{ SessionId = 2; State = 0; UserSid = $targetSid },
+    [pscustomobject]@{ SessionId = 3; State = 4; UserSid = $targetSid }
+)
+Assert-Equal `
+    (Select-InteractiveTaskSessionId -Sessions $sessionZero -ExpectedUserSid $targetSid -CurrentSessionId 0 -CurrentUserSid $otherSid -ConsoleSessionId 2) `
+    2 `
+    'Session 0 caller should resolve the unique active target-user session.'
+
+$consoleChoice = @(
+    [pscustomobject]@{ SessionId = 2; State = 0; UserSid = $targetSid },
+    [pscustomobject]@{ SessionId = 4; State = 0; UserSid = $targetSid }
+)
+Assert-Equal `
+    (Select-InteractiveTaskSessionId -Sessions $consoleChoice -ExpectedUserSid $targetSid -CurrentSessionId 0 -CurrentUserSid $otherSid -ConsoleSessionId 4) `
+    4 `
+    'Matching active console session should disambiguate multiple active sessions.'
+
+Assert-ThrowsLike {
+    Select-InteractiveTaskSessionId `
+        -Sessions $consoleChoice `
+        -ExpectedUserSid $targetSid `
+        -CurrentSessionId 0 `
+        -CurrentUserSid $otherSid `
+        -ConsoleSessionId 9
+} 'Multiple active interactive Windows sessions'
+
+$noActiveSession = @(
+    [pscustomobject]@{ SessionId = 2; State = 4; UserSid = $targetSid },
+    [pscustomobject]@{ SessionId = 0; State = 0; UserSid = $otherSid }
+)
+Assert-ThrowsLike {
+    Select-InteractiveTaskSessionId `
+        -Sessions $noActiveSession `
+        -ExpectedUserSid $targetSid `
+        -CurrentSessionId 0 `
+        -CurrentUserSid $otherSid `
+        -ConsoleSessionId ([uint32]::MaxValue)
+} 'No active interactive Windows session'
+
+Write-Host 'Windows Task Scheduler session-selection tests passed.'


### PR DESCRIPTION
## Summary
- start InteractiveToken scheduled tasks via Task Scheduler COM RunEx with explicit active session id
- unify Setup, installer, control-panel/service, self-update and rollback task starts through manage-windows.ps1
- add Windows session-selection and installer regression coverage

## Validation
- Windows PowerShell 5.1 task/session + Setup runtime + installer tests
- go test ./...
- Control Panel Release build
- Tianyi live: Session 0 -> Session 2 minimal task, disabled-state restore, AgentDock task start, Setup in-place upgrade, health 200, injected rollback recovery, Control Panel start/restart