### PR TITLE
fix(windows): 修复动态界面语言回退

### DIFF
--- a/desktop/windows/control-panel/Localization/UiText.cs
+++ b/desktop/windows/control-panel/Localization/UiText.cs
@@ -15,6 +15,7 @@ internal static class UiText
     private static readonly ResourceManager Resources = new(
         "AgentDock.ControlPanel.Resources.UiStrings",
         typeof(UiText).Assembly);
+    private static CultureInfo _resourceCulture = CultureInfo.GetCultureInfo(SystemLocale);
 
     private static string PreferencePath => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -95,7 +96,7 @@ internal static class UiText
 
     public static string Get(string key)
     {
-        return Resources.GetString(key, CultureInfo.CurrentUICulture) ?? key;
+        return Resources.GetString(key, _resourceCulture) ?? key;
     }
 
     public static string Format(string key, params object?[] args)
@@ -107,6 +108,8 @@ internal static class UiText
     {
         var locale = ResolveLocale(preference, SystemLocale);
         var culture = CultureInfo.GetCultureInfo(locale);
+        // 资源查找使用显式 culture，避免 async 事件恢复旧 CurrentUICulture 后动态文案回退。
+        _resourceCulture = culture;
         CultureInfo.CurrentUICulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
     }

--- a/scripts/test/windows_ui_test.go
+++ b/scripts/test/windows_ui_test.go
@@ -71,6 +71,27 @@ func TestWindowsControlPanelSupportsPersistentLanguagePreference(t *testing.T) {
 	}
 }
 
+func TestWindowsControlPanelDynamicTextUsesSelectedResourceCulture(t *testing.T) {
+	path := filepath.Join("..", "..", "desktop", "windows", "control-panel", "Localization", "UiText.cs")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read UiText.cs: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`private static CultureInfo _resourceCulture`,
+		`Resources.GetString(key, _resourceCulture)`,
+		`_resourceCulture = culture;`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("Windows dynamic localization contract missing %q", want)
+		}
+	}
+	if strings.Contains(content, `Resources.GetString(key, CultureInfo.CurrentUICulture)`) {
+		t.Fatal("Windows dynamic localization must not depend on ambient CurrentUICulture")
+	}
+}
+
 func TestWindowsUpdateProgressWindowSizesToContent(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "desktop", "windows", "control-panel", "UpdateProgressWindow.xaml"))
 	if err != nil {


### PR DESCRIPTION
## 变更
- Windows Control Panel 动态资源使用显式 UI culture，不再依赖可被 async ExecutionContext 恢复的 CurrentUICulture
- 保持 zh-CN / English / 跟随系统现有架构不变
- 增加动态文案语言回退契约测试


## 验证
- go test ./...
- dotnet build desktop/windows/control-panel/AgentDock.ControlPanel.csproj -c Release --no-restore（0 warning / 0 error）
- 天翼真实界面：English Advanced settings 汉字计数 0；zh-CN 对应动态文案正常