### PR TITLE
fix(macos): 修复小屏布局和文案截断

### DIFF
--- a/desktop/macos/AgentDockApp/Resources/en.lproj/Localizable.strings
+++ b/desktop/macos/AgentDockApp/Resources/en.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 "A CDP address is required when “Connect to a specified CDP browser” is selected." = "A CDP address is required when “Connect to a specified CDP browser” is selected.";
 "A new temporary public address was generated; checking public access automatically." = "A new temporary public address was generated; checking public access automatically.";
 "About AgentDock" = "About AgentDock";
-"Advanced settings…" = "Advanced settings…";
+"Advanced settings" = "Advanced settings";
 "AgentDock Advanced Settings" = "AgentDock Advanced Settings";
 "AgentDock File Access Check" = "AgentDock File Access Check";
 "AgentDock Permission Check" = "AgentDock Permission Check";
@@ -17,7 +17,7 @@
 "Check cancelled" = "Check cancelled";
 "Check file access…" = "Check file access…";
 "Check for updates" = "Check for updates";
-"Check permissions…" = "Check permissions…";
+"Check permissions" = "Check permissions";
 "Check standard folders" = "Check standard folders";
 "Check whether AgentDock can access Desktop, Documents, Downloads, and other folders you select." = "Check whether AgentDock can access Desktop, Documents, Downloads, and other folders you select.";
 "Checking" = "Checking";

--- a/desktop/macos/AgentDockApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/desktop/macos/AgentDockApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 "A CDP address is required when “Connect to a specified CDP browser” is selected." = "选择“连接指定 CDP 浏览器”时必须填写 CDP 地址。";
 "A new temporary public address was generated; checking public access automatically." = "新的临时公网地址已生成，正在自动检测公网访问。";
 "About AgentDock" = "关于 AgentDock";
-"Advanced settings…" = "高级设置…";
+"Advanced settings" = "高级设置";
 "AgentDock Advanced Settings" = "AgentDock 高级设置";
 "AgentDock File Access Check" = "AgentDock 文件访问检查";
 "AgentDock Permission Check" = "AgentDock 权限检查";
@@ -17,7 +17,7 @@
 "Check cancelled" = "检测已取消";
 "Check file access…" = "检查文件访问…";
 "Check for updates" = "检查更新";
-"Check permissions…" = "权限检查…";
+"Check permissions" = "权限检查";
 "Check standard folders" = "检查标准目录";
 "Check whether AgentDock can access Desktop, Documents, Downloads, and other folders you select." = "检查 AgentDock 是否可以访问桌面、文稿、下载和你选择的其他目录。";
 "Checking" = "检测中";

--- a/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
@@ -51,7 +51,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private let nexusEndpoint = NSTextField(string: "")
     private let nexusPairingCode = NSSecureTextField(string: "")
     private let nexusPairButton = NSButton(title: L10n.text("Pair and restart"), target: nil, action: nil)
-    private let nexusDeviceTokenStatus = NSTextField(wrappingLabelWithString: "")
+    private let nexusDeviceTokenStatus = NSTextField(labelWithString: "")
     private let progress = NSProgressIndicator()
     private let statusLabel = NSTextField(wrappingLabelWithString: "")
     private let applyButton = NSButton(title: L10n.text("Apply and restart"), target: nil, action: nil)
@@ -85,13 +85,14 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         self.menuLoginAgent = menuLoginAgent
         self.onChanged = onChanged
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 590, height: 850),
-            styleMask: [.titled, .closable],
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 760),
+            styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.title = L10n.text("AgentDock Advanced Settings")
         window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 620, height: 520)
         window.center()
         super.init(window: window)
         configureUI()
@@ -141,6 +142,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         showStatus("", isError: false)
         setBusy(false)
         refreshApplyState()
+        fitWindowToVisibleScreen()
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -149,12 +151,23 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private func configureUI() {
         guard let contentView = window?.contentView else { return }
 
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(scrollView)
+
+        let scrollDocumentView = NSView()
+        scrollDocumentView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = scrollDocumentView
+
         for preference in UILanguagePreference.allCases {
             languagePreference.addItem(withTitle: preference.title)
             languagePreference.lastItem?.representedObject = preference.rawValue
         }
         selectLanguagePreference(L10n.languagePreference())
-        languagePreference.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        languagePreference.widthAnchor.constraint(equalToConstant: 220).isActive = true
         languagePreference.target = self
         languagePreference.action = #selector(languageChanged)
 
@@ -188,36 +201,32 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         browserEnabled.target = self
         browserEnabled.action = #selector(browserToggled)
         browserConnectionMode.addItems(withTitles: BrowserConnectionMode.allCases.map(\.title))
-        browserConnectionMode.widthAnchor.constraint(equalToConstant: 290).isActive = true
+        browserConnectionMode.widthAnchor.constraint(equalToConstant: 360).isActive = true
         browserConnectionMode.target = self
         browserConnectionMode.action = #selector(browserConnectionChanged)
         browserCDPURL.placeholderString = L10n.text("For example: http://127.0.0.1:9222")
         browserCDPURL.target = self
         browserCDPURL.action = #selector(markChanged)
         browserCDPURL.delegate = self
-        browserCDPURL.widthAnchor.constraint(equalToConstant: 390).isActive = true
         browserStatus.textColor = .secondaryLabelColor
         browserStatus.font = .systemFont(ofSize: 12)
 
         acpEnabled.target = self
         acpEnabled.action = #selector(acpChanged)
         acpAgent.addItems(withTitles: ACPAgentPreset.allCases.map(\.title))
-        acpAgent.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        acpAgent.widthAnchor.constraint(equalToConstant: 220).isActive = true
         acpAgent.target = self
         acpAgent.action = #selector(acpChanged)
         acpCommand.placeholderString = "/absolute/path/to/acp-adapter"
         acpCommand.target = self
         acpCommand.action = #selector(markChanged)
         acpCommand.delegate = self
-        acpCommand.widthAnchor.constraint(equalToConstant: 390).isActive = true
         acpArgsJSON.placeholderString = "[]"
         acpArgsJSON.target = self
         acpArgsJSON.action = #selector(markChanged)
         acpArgsJSON.delegate = self
-        acpArgsJSON.widthAnchor.constraint(equalToConstant: 390).isActive = true
         acpStatus.textColor = .secondaryLabelColor
         acpStatus.font = .systemFont(ofSize: 12)
-        acpStatus.widthAnchor.constraint(equalToConstant: 500).isActive = true
 
         nexusEndpoint.placeholderString = "https://nexus.example.com"
         nexusEndpoint.target = self
@@ -231,7 +240,14 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         nexusPairButton.action = #selector(pairNexusPressed)
         nexusDeviceTokenStatus.textColor = .secondaryLabelColor
         nexusDeviceTokenStatus.font = .systemFont(ofSize: 12)
-        nexusDeviceTokenStatus.widthAnchor.constraint(equalToConstant: 390).isActive = true
+        nexusDeviceTokenStatus.lineBreakMode = .byCharWrapping
+        nexusDeviceTokenStatus.maximumNumberOfLines = 2
+        nexusDeviceTokenStatus.heightAnchor.constraint(equalToConstant: 34).isActive = true
+
+        for flexibleView in [browserCDPURL, browserStatus, acpCommand, acpArgsJSON, acpStatus, nexusEndpoint, nexusPairingCode, nexusDeviceTokenStatus] {
+            flexibleView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            flexibleView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
 
         progress.style = .spinning
         progress.controlSize = .small
@@ -270,7 +286,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         serviceForm.alignment = .leading
         serviceForm.spacing = 10
 
-        let cdpRow = formRow(title: L10n.text("CDP address"), control: browserCDPURL)
+        let cdpRow = formRow(title: L10n.text("CDP address"), control: browserCDPURL, fillsAvailableWidth: true)
         browserCDPRow = cdpRow
         let browserStack = NSStackView(views: [
             browserEnabled,
@@ -281,10 +297,11 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         browserStack.orientation = .vertical
         browserStack.alignment = .leading
         browserStack.spacing = 5
-        browserStatus.widthAnchor.constraint(equalToConstant: 500).isActive = true
+        cdpRow.widthAnchor.constraint(equalTo: browserStack.widthAnchor).isActive = true
+        browserStatus.widthAnchor.constraint(equalTo: browserStack.widthAnchor).isActive = true
 
-        let commandRow = formRow(title: "Command", control: acpCommand)
-        let argsRow = formRow(title: "Args JSON", control: acpArgsJSON)
+        let commandRow = formRow(title: "Command", control: acpCommand, fillsAvailableWidth: true)
+        let argsRow = formRow(title: "Args JSON", control: acpArgsJSON, fillsAvailableWidth: true)
         acpCommandRow = commandRow
         acpArgsRow = argsRow
         let acpStack = NSStackView(views: [
@@ -297,20 +314,30 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         acpStack.orientation = .vertical
         acpStack.alignment = .leading
         acpStack.spacing = 8
+        commandRow.widthAnchor.constraint(equalTo: acpStack.widthAnchor).isActive = true
+        argsRow.widthAnchor.constraint(equalTo: acpStack.widthAnchor).isActive = true
+        acpStatus.widthAnchor.constraint(equalTo: acpStack.widthAnchor).isActive = true
 
+        let nexusEndpointRow = formRow(title: "Endpoint", control: nexusEndpoint, fillsAvailableWidth: true)
+        let nexusPairingCodeRow = formRow(title: L10n.text("Pairing code"), control: nexusPairingCode, fillsAvailableWidth: true)
+        let nexusDeviceTokenRow = formRow(title: "Device Token", control: nexusDeviceTokenStatus, fillsAvailableWidth: true)
+        let nexusPairRow = NSStackView(views: [nexusPairButton, NSView()])
+        nexusPairRow.orientation = .horizontal
+        nexusPairRow.spacing = 8
         let nexusStack = NSStackView(views: [
-            formRow(title: "Endpoint", control: nexusEndpoint),
-            formRow(title: L10n.text("Pairing code"), control: nexusPairingCode),
-            nexusPairButton,
-            formRow(title: "Device Token", control: nexusDeviceTokenStatus),
+            nexusEndpointRow,
+            nexusPairingCodeRow,
+            nexusPairRow,
+            nexusDeviceTokenRow,
         ])
         nexusStack.orientation = .vertical
         nexusStack.alignment = .leading
         nexusStack.spacing = 8
-        nexusEndpoint.widthAnchor.constraint(equalToConstant: 390).isActive = true
-        nexusPairingCode.widthAnchor.constraint(equalToConstant: 390).isActive = true
+        for row in [nexusEndpointRow, nexusPairingCodeRow, nexusDeviceTokenRow] {
+            row.widthAnchor.constraint(equalTo: nexusStack.widthAnchor).isActive = true
+        }
 
-        let utilityRow = NSStackView(views: [openLogs, openConfig])
+        let utilityRow = NSStackView(views: [openLogs, openConfig, NSView()])
         utilityRow.orientation = .horizontal
         utilityRow.spacing = 14
 
@@ -319,6 +346,7 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         actionRow.alignment = .centerY
         actionRow.spacing = 10
         statusLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        statusLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let root = NSStackView(views: [
             sectionTitle(L10n.text("Startup")),
@@ -343,14 +371,25 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         root.alignment = .leading
         root.spacing = 12
         root.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(root)
+        scrollDocumentView.addSubview(root)
+
+        for separator in root.arrangedSubviews.compactMap({ $0 as? NSBox }) {
+            separator.widthAnchor.constraint(equalTo: root.widthAnchor).isActive = true
+        }
+        for section in [startupStack, serviceForm, browserStack, acpStack, nexusStack, utilityRow, actionRow] {
+            section.widthAnchor.constraint(equalTo: root.widthAnchor).isActive = true
+        }
 
         NSLayoutConstraint.activate([
-            root.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 28),
-            root.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -28),
-            root.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
-            root.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -22),
-            actionRow.widthAnchor.constraint(equalTo: root.widthAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            scrollDocumentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+            root.leadingAnchor.constraint(equalTo: scrollDocumentView.leadingAnchor, constant: 28),
+            root.trailingAnchor.constraint(equalTo: scrollDocumentView.trailingAnchor, constant: -28),
+            root.topAnchor.constraint(equalTo: scrollDocumentView.topAnchor, constant: 24),
+            root.bottomAnchor.constraint(equalTo: scrollDocumentView.bottomAnchor, constant: -22),
         ])
     }
 
@@ -363,19 +402,50 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
     private func separator() -> NSBox {
         let box = NSBox()
         box.boxType = .separator
-        box.widthAnchor.constraint(equalToConstant: 534).isActive = true
         return box
     }
 
-    private func formRow(title: String, control: NSView) -> NSView {
+    private func formRow(title: String, control: NSView, fillsAvailableWidth: Bool = false) -> NSView {
+        let row = NSView()
         let label = NSTextField(labelWithString: title)
         label.textColor = .secondaryLabelColor
-        label.widthAnchor.constraint(equalToConstant: 92).isActive = true
-        let row = NSStackView(views: [label, control])
-        row.orientation = .horizontal
-        row.alignment = .centerY
-        row.spacing = 12
+        label.lineBreakMode = .byClipping
+        label.translatesAutoresizingMaskIntoConstraints = false
+        control.translatesAutoresizingMaskIntoConstraints = false
+        label.widthAnchor.constraint(equalToConstant: 128).isActive = true
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        if fillsAvailableWidth {
+            control.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            control.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+
+        row.addSubview(label)
+        row.addSubview(control)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            label.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            control.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 12),
+            control.topAnchor.constraint(equalTo: row.topAnchor),
+            control.bottomAnchor.constraint(equalTo: row.bottomAnchor),
+            fillsAvailableWidth
+                ? control.trailingAnchor.constraint(equalTo: row.trailingAnchor)
+                : row.trailingAnchor.constraint(equalTo: control.trailingAnchor),
+        ])
         return row
+    }
+
+    private func fitWindowToVisibleScreen() {
+        guard let window else { return }
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
+        let margin: CGFloat = 12
+        guard let visibleFrame else { return }
+
+        var frame = window.frame
+        frame.size.width = min(frame.width, visibleFrame.width - margin * 2)
+        frame.size.height = min(frame.height, visibleFrame.height - margin * 2)
+        frame.origin.x = min(max(frame.origin.x, visibleFrame.minX + margin), visibleFrame.maxX - margin - frame.width)
+        frame.origin.y = min(max(frame.origin.y, visibleFrame.minY + margin), visibleFrame.maxY - margin - frame.height)
+        window.setFrame(frame, display: false)
     }
 
     @objc private func markChanged() {

--- a/desktop/macos/AgentDockApp/Sources/AppDelegate.swift
+++ b/desktop/macos/AgentDockApp/Sources/AppDelegate.swift
@@ -208,7 +208,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(.separator())
 
         menu.addItem(item(currentStatus.installed ? L10n.text("Open AgentDock") : L10n.text("Set up AgentDock…"), #selector(showSetup)))
-        menu.addItem(item(L10n.text("Check permissions…"), #selector(openPermissions)))
+        menu.addItem(item(L10n.text("Check permissions"), #selector(openPermissions)))
         if currentStatus.installed {
             menu.addItem(.separator())
 

--- a/desktop/macos/AgentDockApp/Sources/SetupWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/SetupWindowController.swift
@@ -20,6 +20,8 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     private let stateLabel = NSTextField(labelWithString: L10n.text("Not installed"))
     private let nexusStateLabel = NSTextField(labelWithString: L10n.text("Not configured"))
 
+    private let scrollDocumentView = NSView()
+    private let contentStack = TopAlignedStackView()
     private let serviceSection = NSStackView()
     private let localAddress = NSTextField(labelWithString: L10n.text("Not installed"))
     private let publicAddress = NSTextField(labelWithString: L10n.text("Disabled"))
@@ -48,8 +50,8 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     private let progress = NSProgressIndicator()
     private let statusLabel = NSTextField(wrappingLabelWithString: "")
     private let applyButton = NSButton(title: L10n.text("Configure and enable"), target: nil, action: nil)
-    private let permissionsButton = NSButton(title: L10n.text("Check permissions…"), target: nil, action: nil)
-    private let advancedButton = NSButton(title: L10n.text("Advanced settings…"), target: nil, action: nil)
+    private let permissionsButton = NSButton(title: L10n.text("Check permissions"), target: nil, action: nil)
+    private let advancedButton = NSButton(title: L10n.text("Advanced settings"), target: nil, action: nil)
     private let logsButton = NSButton(title: L10n.text("Open logs"), target: nil, action: nil)
 
     private var currentStatus = ServiceStatus.missing
@@ -86,13 +88,14 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         self.menuLoginAgent = menuLoginAgent
         self.onChanged = onChanged
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 620, height: 590),
-            styleMask: [.titled, .closable, .miniaturizable],
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 590),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.title = "AgentDock"
         window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 620, height: 420)
         window.center()
         super.init(window: window)
         window.delegate = self
@@ -174,12 +177,32 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     private func configureUI() {
         guard let contentView = window?.contentView else { return }
 
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(scrollView)
+
+        scrollDocumentView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = scrollDocumentView
+
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = 12
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        scrollDocumentView.addSubview(contentStack)
+
         titleLabel.font = .systemFont(ofSize: 25, weight: .semibold)
         subtitleLabel.textColor = .secondaryLabelColor
         stateLabel.alignment = .right
         stateLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        stateLabel.lineBreakMode = .byTruncatingMiddle
+        stateLabel.setContentCompressionResistancePriority(.fittingSizeCompression, for: .horizontal)
         nexusStateLabel.alignment = .left
         nexusStateLabel.font = .systemFont(ofSize: 12, weight: .regular)
+        nexusStateLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        nexusStateLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let headerText = NSStackView(views: [titleLabel, subtitleLabel])
         headerText.orientation = .vertical
@@ -188,19 +211,27 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         let header = NSStackView(views: [headerText, NSView(), stateLabel])
         header.orientation = .horizontal
         header.alignment = .centerY
-        header.widthAnchor.constraint(equalToConstant: 564).isActive = true
 
         for field in [localAddress, publicAddress, authToken, oauthPassword] {
-            field.lineBreakMode = .byTruncatingMiddle
             field.isSelectable = true
             field.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+            field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         }
+        for field in [localAddress, authToken, oauthPassword] {
+            field.lineBreakMode = .byTruncatingMiddle
+        }
+        publicAddress.lineBreakMode = .byCharWrapping
+        publicAddress.maximumNumberOfLines = 2
+        publicAddress.setContentCompressionResistancePriority(.fittingSizeCompression, for: .horizontal)
+        publicAddress.cell?.wraps = true
 
         publicCheckStatus.font = .systemFont(ofSize: 11.5)
         publicCheckStatus.textColor = .secondaryLabelColor
         publicCheckStatus.isHidden = true
         publicCheckStatus.lineBreakMode = .byTruncatingTail
-        publicCheckStatus.widthAnchor.constraint(equalToConstant: 450).isActive = true
+        publicCheckStatus.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        publicCheckStatus.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         publicTestButton.bezelStyle = .inline
         publicTestButton.target = self
         publicTestButton.action = #selector(testPublicAddressPressed)
@@ -219,12 +250,12 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         serviceSection.alignment = .leading
         serviceSection.spacing = 8
         serviceSection.addArrangedSubview(sectionTitle(L10n.text("Connection information")))
-        serviceSection.addArrangedSubview(valueRow(title: L10n.text("Local MCP"), field: localAddress, actions: [copyButton(#selector(copyLocalAddress))]))
-        serviceSection.addArrangedSubview(valueRow(title: L10n.text("Public MCP"), field: publicAddress, actions: [publicTestButton, publicCopyButton]))
-        serviceSection.addArrangedSubview(valueDetailRow(publicCheckStatus))
-        serviceSection.addArrangedSubview(valueRow(title: "Nexus", field: nexusStateLabel, actions: []))
-        serviceSection.addArrangedSubview(valueRow(title: "Bearer Token", field: authToken, actions: [authReveal, copyButton(#selector(copyAuthToken))]))
-        serviceSection.addArrangedSubview(valueRow(title: L10n.text("OAuth password"), field: oauthPassword, actions: [oauthReveal, copyButton(#selector(copyOAuthPassword))]))
+        addFullWidth(valueRow(title: L10n.text("Local MCP"), field: localAddress, actions: [copyButton(#selector(copyLocalAddress))]), to: serviceSection)
+        addFullWidth(valueRow(title: L10n.text("Public MCP"), field: publicAddress, actions: [publicTestButton, publicCopyButton]), to: serviceSection)
+        addFullWidth(valueDetailRow(publicCheckStatus), to: serviceSection)
+        addFullWidth(valueRow(title: "Nexus", field: nexusStateLabel, actions: []), to: serviceSection)
+        addFullWidth(valueRow(title: "Bearer Token", field: authToken, actions: [authReveal, copyButton(#selector(copyAuthToken))]), to: serviceSection)
+        addFullWidth(valueRow(title: L10n.text("OAuth password"), field: oauthPassword, actions: [oauthReveal, copyButton(#selector(copyOAuthPassword))]), to: serviceSection)
 
         startStopButton.target = self
         startStopButton.action = #selector(startStopPressed)
@@ -232,10 +263,10 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         restartButton.action = #selector(restartPressed)
         updateButton.target = self
         updateButton.action = #selector(updatePressed)
-        let serviceActions = NSStackView(views: [startStopButton, restartButton, updateButton])
+        let serviceActions = NSStackView(views: [startStopButton, restartButton, updateButton, NSView()])
         serviceActions.orientation = .horizontal
         serviceActions.spacing = 8
-        serviceSection.addArrangedSubview(serviceActions)
+        addFullWidth(serviceActions, to: serviceSection)
 
         publicMode.target = self
         publicMode.action = #selector(modeChanged)
@@ -243,12 +274,13 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         publicMode.widthAnchor.constraint(equalToConstant: 360).isActive = true
         modeDescription.textColor = .secondaryLabelColor
         modeDescription.font = .systemFont(ofSize: 12)
-        modeDescription.widthAnchor.constraint(equalToConstant: 564).isActive = true
 
         serverURLField.placeholderString = "https://mini.example.com"
         tunnelTokenField.placeholderString = L10n.text("Paste Cloudflare Tunnel Token")
-        serverURLField.widthAnchor.constraint(equalToConstant: 430).isActive = true
-        tunnelTokenField.widthAnchor.constraint(equalToConstant: 430).isActive = true
+        for field in [serverURLField, tunnelTokenField] {
+            field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
         serverURLField.target = self
         serverURLField.action = #selector(configurationEdited)
         tunnelTokenField.target = self
@@ -257,14 +289,16 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         namedFields.orientation = .vertical
         namedFields.alignment = .leading
         namedFields.spacing = 7
-        namedFields.addArrangedSubview(formRow(title: L10n.text("Public address"), control: serverURLField))
-        namedFields.addArrangedSubview(formRow(title: "Tunnel Token", control: tunnelTokenField))
+        addFullWidth(formRow(title: L10n.text("Public address"), control: serverURLField), to: namedFields)
+        addFullWidth(formRow(title: "Tunnel Token", control: tunnelTokenField), to: namedFields)
 
         progress.style = .spinning
         progress.controlSize = .small
         progress.isDisplayedWhenStopped = false
         statusLabel.textColor = .secondaryLabelColor
+        statusLabel.lineBreakMode = .byTruncatingTail
         statusLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        statusLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         statusLabel.isHidden = true
 
         logsButton.bezelStyle = .inline
@@ -285,31 +319,28 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         footer.orientation = .horizontal
         footer.alignment = .centerY
         footer.spacing = 10
-        footer.widthAnchor.constraint(equalToConstant: 564).isActive = true
 
-        let root = NSStackView(views: [
-            header,
-            separator(),
-            serviceSection,
-            separator(),
-            sectionTitle(L10n.text("Public access")),
-            publicMode,
-            modeDescription,
-            namedFields,
-            separator(),
-            footer,
-        ])
-        root.orientation = .vertical
-        root.alignment = .leading
-        root.spacing = 12
-        root.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(root)
+        addFullWidth(header, to: contentStack)
+        addFullWidth(separator(), to: contentStack)
+        addFullWidth(serviceSection, to: contentStack)
+        addFullWidth(separator(), to: contentStack)
+        contentStack.addArrangedSubview(sectionTitle(L10n.text("Public access")))
+        contentStack.addArrangedSubview(publicMode)
+        addFullWidth(modeDescription, to: contentStack)
+        addFullWidth(namedFields, to: contentStack)
+        addFullWidth(separator(), to: contentStack)
+        addFullWidth(footer, to: contentStack)
 
         NSLayoutConstraint.activate([
-            root.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 28),
-            root.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -28),
-            root.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
-            root.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -22),
+            scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            scrollDocumentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollDocumentView.leadingAnchor, constant: 28),
+            contentStack.trailingAnchor.constraint(equalTo: scrollDocumentView.trailingAnchor, constant: -28),
+            contentStack.topAnchor.constraint(equalTo: scrollDocumentView.topAnchor, constant: 24),
+            contentStack.bottomAnchor.constraint(equalTo: scrollDocumentView.bottomAnchor, constant: -22),
         ])
     }
 
@@ -774,14 +805,24 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func updateWindowHeight() {
-        let installedHeight: CGFloat = selectedMode == .named ? 675 : 580
+        let installedHeight: CGFloat = selectedMode == .named ? 620 : 580
         let installHeight: CGFloat = selectedMode == .named ? 455 : 360
-        let target = currentStatus.installed ? installedHeight : installHeight
+        let desiredHeight = currentStatus.installed ? installedHeight : installHeight
         guard let window else { return }
+
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
+        let verticalMargin: CGFloat = 12
+        let maximumHeight = visibleFrame.map { max(window.minSize.height, $0.height - verticalMargin * 2) }
+        let targetHeight = min(desiredHeight, maximumHeight ?? desiredHeight)
+
+        // 保持窗口顶部尽量不跳动，同时确保整个窗口始终位于菜单栏和 Dock 之间的可用区域。
         var frame = window.frame
-        let delta = target - frame.height
-        frame.origin.y -= delta
-        frame.size.height = target
+        frame.origin.y = frame.maxY - targetHeight
+        frame.size.height = targetHeight
+        if let visibleFrame {
+            frame.origin.y = min(frame.origin.y, visibleFrame.maxY - verticalMargin - targetHeight)
+            frame.origin.y = max(frame.origin.y, visibleFrame.minY + verticalMargin)
+        }
         window.setFrame(frame, display: true, animate: window.isVisible)
     }
 
@@ -794,7 +835,6 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     private func separator() -> NSBox {
         let box = NSBox()
         box.boxType = .separator
-        box.widthAnchor.constraint(equalToConstant: 564).isActive = true
         return box
     }
 
@@ -823,12 +863,16 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         let label = NSTextField(labelWithString: title)
         label.textColor = .secondaryLabelColor
         label.widthAnchor.constraint(equalToConstant: 94).isActive = true
-        field.widthAnchor.constraint(equalToConstant: actions.count > 1 ? 310 : 370).isActive = true
         let row = NSStackView(views: [label, field] + actions)
         row.orientation = .horizontal
         row.alignment = .centerY
         row.spacing = 8
         return row
+    }
+
+    private func addFullWidth(_ view: NSView, to stack: NSStackView, widthAdjustment: CGFloat = 0) {
+        stack.addArrangedSubview(view)
+        view.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: widthAdjustment).isActive = true
     }
 
     private func copyButton(_ action: Selector) -> NSButton {

--- a/scripts/test/macos_advanced_settings_window_test.go
+++ b/scripts/test/macos_advanced_settings_window_test.go
@@ -1,0 +1,48 @@
+package scripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMacOSAdvancedSettingsUsesResponsiveScrollableLayout(t *testing.T) {
+	path := filepath.Join("..", "..", "desktop", "macos", "AgentDockApp", "Sources", "AdvancedSettingsWindowController.swift")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read AdvancedSettingsWindowController.swift: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		`contentRect: NSRect(x: 0, y: 0, width: 680, height: 760)`,
+		`styleMask: [.titled, .closable, .resizable]`,
+		`window.minSize = NSSize(width: 620, height: 520)`,
+		`let scrollView = NSScrollView()`,
+		`scrollView.hasVerticalScroller = true`,
+		`scrollView.documentView = scrollDocumentView`,
+		`scrollDocumentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor)`,
+		`root.bottomAnchor.constraint(equalTo: scrollDocumentView.bottomAnchor, constant: -22)`,
+		`label.widthAnchor.constraint(equalToConstant: 128)`,
+		`browserConnectionMode.widthAnchor.constraint(equalToConstant: 360)`,
+		`let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("macOS advanced settings missing responsive layout contract %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`contentRect: NSRect(x: 0, y: 0, width: 590, height: 850)`,
+		`label.widthAnchor.constraint(equalToConstant: 92)`,
+		`browserConnectionMode.widthAnchor.constraint(equalToConstant: 290)`,
+		`nexusEndpoint.widthAnchor.constraint(equalToConstant: 390)`,
+		`nexusPairingCode.widthAnchor.constraint(equalToConstant: 390)`,
+		`box.widthAnchor.constraint(equalToConstant: 534)`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("macOS advanced settings still contains fixed/truncated layout contract %q", forbidden)
+		}
+	}
+}

--- a/scripts/test/macos_setup_window_test.go
+++ b/scripts/test/macos_setup_window_test.go
@@ -1,0 +1,77 @@
+package scripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMacOSSetupWindowUsesResponsiveScrollableLayout(t *testing.T) {
+	root := filepath.Join("..", "..", "desktop", "macos", "AgentDockApp")
+	setupData, err := os.ReadFile(filepath.Join(root, "Sources", "SetupWindowController.swift"))
+	if err != nil {
+		t.Fatalf("read SetupWindowController.swift: %v", err)
+	}
+	setup := string(setupData)
+
+	for _, want := range []string{
+		`styleMask: [.titled, .closable, .miniaturizable, .resizable]`,
+		`window.minSize = NSSize(width: 620, height: 420)`,
+		`let scrollView = NSScrollView()`,
+		`scrollView.hasVerticalScroller = true`,
+		`scrollView.documentView = scrollDocumentView`,
+		`scrollDocumentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor)`,
+		`contentStack.leadingAnchor.constraint(equalTo: scrollDocumentView.leadingAnchor, constant: 28)`,
+		`contentStack.bottomAnchor.constraint(equalTo: scrollDocumentView.bottomAnchor, constant: -22)`,
+		`let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame`,
+		`let installedHeight: CGFloat = selectedMode == .named ? 620 : 580`,
+		`publicAddress.lineBreakMode = .byCharWrapping`,
+		`publicAddress.maximumNumberOfLines = 2`,
+		`L10n.text("Check permissions")`,
+		`L10n.text("Advanced settings")`,
+	} {
+		if !strings.Contains(setup, want) {
+			t.Fatalf("macOS setup window missing responsive layout contract %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`widthAnchor.constraint(equalToConstant: 564)`,
+		`publicCheckStatus.widthAnchor.constraint(equalToConstant: 450)`,
+		`serverURLField.widthAnchor.constraint(equalToConstant: 430)`,
+		`field.widthAnchor.constraint(equalToConstant: actions.count > 1 ? 310 : 370)`,
+		`L10n.text("Check permissions…")`,
+		`L10n.text("Advanced settings…")`,
+	} {
+		if strings.Contains(setup, forbidden) {
+			t.Fatalf("macOS setup window still contains fixed/truncated layout contract %q", forbidden)
+		}
+	}
+
+	resources := map[string][]string{
+		filepath.Join("Resources", "en.lproj", "Localizable.strings"): {
+			`"Check permissions" = "Check permissions";`,
+			`"Advanced settings" = "Advanced settings";`,
+		},
+		filepath.Join("Resources", "zh-Hans.lproj", "Localizable.strings"): {
+			`"Check permissions" = "权限检查";`,
+			`"Advanced settings" = "高级设置";`,
+		},
+	}
+	for relativePath, wants := range resources {
+		data, err := os.ReadFile(filepath.Join(root, relativePath))
+		if err != nil {
+			t.Fatalf("read %s: %v", relativePath, err)
+		}
+		content := string(data)
+		for _, want := range wants {
+			if !strings.Contains(content, want) {
+				t.Fatalf("macOS localization missing %q in %s", want, relativePath)
+			}
+		}
+		if strings.Contains(content, "Check permissions…") || strings.Contains(content, "Advanced settings…") {
+			t.Fatalf("macOS localization must not keep ellipsis in setup/menu button labels: %s", relativePath)
+		}
+	}
+}


### PR DESCRIPTION
修复 macOS AgentDock Setup / Advanced Settings 在小屏幕上的布局问题。

- Setup / Advanced Settings 支持滚动和窗口缩放，并按 screen visibleFrame 限高
- 长 URL、状态、Command / Nexus 字段不再撑宽或被截断
- 英文 Interface language / Connection mode 等标签完整显示
- 权限检查 / 高级设置按钮中英文去掉尾部省略号
- 新增 macOS 布局源契约回归测试

验证：
- git diff --check
- go test ./scripts/test
- go test ./...
- Swift/AppKit 运行时布局 harness：Setup / Advanced horizontalOverflow=0, ambiguous=0；最小窗口滚动正常
- build-app.sh 构建通过，codesign --verify --deep --strict 通过，DMG hdiutil verify 通过