### PR TITLE
fix(macos): 优化设置页布局间距

### DIFF
--- a/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/AdvancedSettingsWindowController.swift
@@ -269,18 +269,18 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
         openConfig.bezelStyle = .inline
 
         let startupStack = NSStackView(views: [
-            formRow(title: L10n.text("Interface language"), control: languagePreference),
             serviceAutostart,
             menuAutostart,
+            formRow(title: L10n.text("Interface language"), control: languagePreference),
         ])
         startupStack.orientation = .vertical
         startupStack.alignment = .leading
         startupStack.spacing = 8
 
         let serviceForm = NSStackView(views: [
+            mcpAppsEnabled,
             formRow(title: L10n.text("Service port"), control: portField),
             formRow(title: L10n.text("Log level"), control: logLevel),
-            mcpAppsEnabled,
         ])
         serviceForm.orientation = .vertical
         serviceForm.alignment = .leading
@@ -320,20 +320,28 @@ final class AdvancedSettingsWindowController: NSWindowController, NSTextFieldDel
 
         let nexusEndpointRow = formRow(title: "Endpoint", control: nexusEndpoint, fillsAvailableWidth: true)
         let nexusPairingCodeRow = formRow(title: L10n.text("Pairing code"), control: nexusPairingCode, fillsAvailableWidth: true)
-        let nexusDeviceTokenRow = formRow(title: "Device Token", control: nexusDeviceTokenStatus, fillsAvailableWidth: true)
-        let nexusPairRow = NSStackView(views: [nexusPairButton, NSView()])
-        nexusPairRow.orientation = .horizontal
-        nexusPairRow.spacing = 8
+        let nexusPairRow = NSView()
+        nexusPairButton.translatesAutoresizingMaskIntoConstraints = false
+        nexusDeviceTokenStatus.translatesAutoresizingMaskIntoConstraints = false
+        nexusPairRow.addSubview(nexusPairButton)
+        nexusPairRow.addSubview(nexusDeviceTokenStatus)
+        NSLayoutConstraint.activate([
+            nexusPairButton.leadingAnchor.constraint(equalTo: nexusPairRow.leadingAnchor),
+            nexusPairButton.centerYAnchor.constraint(equalTo: nexusPairRow.centerYAnchor),
+            nexusDeviceTokenStatus.leadingAnchor.constraint(equalTo: nexusPairRow.leadingAnchor, constant: 140),
+            nexusDeviceTokenStatus.trailingAnchor.constraint(equalTo: nexusPairRow.trailingAnchor),
+            nexusDeviceTokenStatus.topAnchor.constraint(equalTo: nexusPairRow.topAnchor),
+            nexusDeviceTokenStatus.bottomAnchor.constraint(equalTo: nexusPairRow.bottomAnchor),
+        ])
         let nexusStack = NSStackView(views: [
             nexusEndpointRow,
             nexusPairingCodeRow,
             nexusPairRow,
-            nexusDeviceTokenRow,
         ])
         nexusStack.orientation = .vertical
         nexusStack.alignment = .leading
         nexusStack.spacing = 8
-        for row in [nexusEndpointRow, nexusPairingCodeRow, nexusDeviceTokenRow] {
+        for row in [nexusEndpointRow, nexusPairingCodeRow, nexusPairRow] {
             row.widthAnchor.constraint(equalTo: nexusStack.widthAnchor).isActive = true
         }
 

--- a/desktop/macos/AgentDockApp/Sources/PermissionUIComponents.swift
+++ b/desktop/macos/AgentDockApp/Sources/PermissionUIComponents.swift
@@ -4,6 +4,10 @@ final class TopAlignedStackView: NSStackView {
     override var isFlipped: Bool { true }
 }
 
+final class TopAlignedDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
 enum PermissionUI {
     static func statusLabel(_ text: String = L10n.text("Not checked")) -> NSTextField {
         let label = NSTextField(labelWithString: text)

--- a/desktop/macos/AgentDockApp/Sources/SetupWindowController.swift
+++ b/desktop/macos/AgentDockApp/Sources/SetupWindowController.swift
@@ -20,7 +20,8 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
     private let stateLabel = NSTextField(labelWithString: L10n.text("Not installed"))
     private let nexusStateLabel = NSTextField(labelWithString: L10n.text("Not configured"))
 
-    private let scrollDocumentView = NSView()
+    // 文档内容不足一屏时保持顶部对齐，把剩余空间自然留在底部。
+    private let scrollDocumentView = TopAlignedDocumentView()
     private let contentStack = TopAlignedStackView()
     private let serviceSection = NSStackView()
     private let localAddress = NSTextField(labelWithString: L10n.text("Not installed"))
@@ -320,6 +321,10 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         footer.alignment = .centerY
         footer.spacing = 10
 
+        // 给配置区和底部操作留出明确的呼吸空间；小窗口仍由外层滚动区承载。
+        let footerSpacer = NSView()
+        footerSpacer.heightAnchor.constraint(equalToConstant: 8).isActive = true
+
         addFullWidth(header, to: contentStack)
         addFullWidth(separator(), to: contentStack)
         addFullWidth(serviceSection, to: contentStack)
@@ -329,6 +334,7 @@ final class SetupWindowController: NSWindowController, NSWindowDelegate {
         addFullWidth(modeDescription, to: contentStack)
         addFullWidth(namedFields, to: contentStack)
         addFullWidth(separator(), to: contentStack)
+        addFullWidth(footerSpacer, to: contentStack)
         addFullWidth(footer, to: contentStack)
 
         NSLayoutConstraint.activate([

--- a/scripts/test/macos_advanced_settings_window_test.go
+++ b/scripts/test/macos_advanced_settings_window_test.go
@@ -13,7 +13,7 @@ func TestMacOSAdvancedSettingsUsesResponsiveScrollableLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read AdvancedSettingsWindowController.swift: %v", err)
 	}
-	content := string(data)
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
 
 	for _, want := range []string{
 		`contentRect: NSRect(x: 0, y: 0, width: 680, height: 760)`,

--- a/scripts/test/macos_advanced_settings_window_test.go
+++ b/scripts/test/macos_advanced_settings_window_test.go
@@ -27,6 +27,10 @@ func TestMacOSAdvancedSettingsUsesResponsiveScrollableLayout(t *testing.T) {
 		`label.widthAnchor.constraint(equalToConstant: 128)`,
 		`browserConnectionMode.widthAnchor.constraint(equalToConstant: 360)`,
 		`let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame`,
+		`let nexusPairRow = NSView()`,
+		`nexusDeviceTokenStatus.leadingAnchor.constraint(equalTo: nexusPairRow.leadingAnchor, constant: 140)`,
+		"let startupStack = NSStackView(views: [\n            serviceAutostart,\n            menuAutostart,\n            formRow(title: L10n.text(\"Interface language\"), control: languagePreference),",
+		"let serviceForm = NSStackView(views: [\n            mcpAppsEnabled,\n            formRow(title: L10n.text(\"Service port\"), control: portField),\n            formRow(title: L10n.text(\"Log level\"), control: logLevel),",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("macOS advanced settings missing responsive layout contract %q", want)
@@ -40,6 +44,7 @@ func TestMacOSAdvancedSettingsUsesResponsiveScrollableLayout(t *testing.T) {
 		`nexusEndpoint.widthAnchor.constraint(equalToConstant: 390)`,
 		`nexusPairingCode.widthAnchor.constraint(equalToConstant: 390)`,
 		`box.widthAnchor.constraint(equalToConstant: 534)`,
+		`formRow(title: "Device Token", control: nexusDeviceTokenStatus`,
 	} {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("macOS advanced settings still contains fixed/truncated layout contract %q", forbidden)

--- a/scripts/test/macos_setup_window_test.go
+++ b/scripts/test/macos_setup_window_test.go
@@ -18,10 +18,13 @@ func TestMacOSSetupWindowUsesResponsiveScrollableLayout(t *testing.T) {
 	for _, want := range []string{
 		`styleMask: [.titled, .closable, .miniaturizable, .resizable]`,
 		`window.minSize = NSSize(width: 620, height: 420)`,
+		`private let scrollDocumentView = TopAlignedDocumentView()`,
 		`let scrollView = NSScrollView()`,
 		`scrollView.hasVerticalScroller = true`,
 		`scrollView.documentView = scrollDocumentView`,
 		`scrollDocumentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor)`,
+		`let footerSpacer = NSView()`,
+		`footerSpacer.heightAnchor.constraint(equalToConstant: 8)`,
 		`contentStack.leadingAnchor.constraint(equalTo: scrollDocumentView.leadingAnchor, constant: 28)`,
 		`contentStack.bottomAnchor.constraint(equalTo: scrollDocumentView.bottomAnchor, constant: -22)`,
 		`let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame`,
@@ -33,6 +36,20 @@ func TestMacOSSetupWindowUsesResponsiveScrollableLayout(t *testing.T) {
 	} {
 		if !strings.Contains(setup, want) {
 			t.Fatalf("macOS setup window missing responsive layout contract %q", want)
+		}
+	}
+
+	componentsData, err := os.ReadFile(filepath.Join(root, "Sources", "PermissionUIComponents.swift"))
+	if err != nil {
+		t.Fatalf("read PermissionUIComponents.swift: %v", err)
+	}
+	components := string(componentsData)
+	for _, want := range []string{
+		`final class TopAlignedDocumentView: NSView`,
+		`override var isFlipped: Bool { true }`,
+	} {
+		if !strings.Contains(components, want) {
+			t.Fatalf("macOS setup window missing top-aligned document contract %q", want)
 		}
 	}
 


### PR DESCRIPTION
## 变更
- 首页内容顶部对齐，减少顶部大面积留白，并保留底部适量呼吸空间
- 高级设置调整启动/服务项顺序，缩短视觉跳跃
- 删除 Device Token 左侧标签，将保存状态与配对操作对齐展示
- 补充 macOS 布局回归测试

## 验证
- go test ./scripts/test
- AppKit layout harness：Setup / Advanced 均 0 overflow、0 ambiguity，小窗口滚动正常
- 已基于该分支生成并挂载验证 Universal DMG（arm64 + x86_64）
- 用户已确认预览效果