### PR TITLE
feat(file): 增强 structured patch 兼容性

### DIFF
--- a/internal/app/file_runtime_other_test.go
+++ b/internal/app/file_runtime_other_test.go
@@ -3,8 +3,20 @@
 package app
 
 import (
+	"strings"
 	"testing"
 )
+
+func TestFileEditPatchSchemaDescribesStructuredEnvelope(t *testing.T) {
+	properties := testInputSchema("file_edit")["properties"].(map[string]any)
+	patch := properties["patch"].(map[string]any)
+	description, _ := patch["description"].(string)
+	for _, marker := range []string{"*** Begin Patch", "*** Update File: <path>", "@@ [<optional context line>]", "*** End of File"} {
+		if !strings.Contains(description, marker) {
+			t.Fatalf("file_edit patch description missing %q: %q", marker, description)
+		}
+	}
+}
 
 func TestNonWindowsFileToolSchemasDoNotExposeWSLRuntime(t *testing.T) {
 	for _, name := range []string{"read_file", "list_dir", "search_text", "file_edit"} {

--- a/internal/app/output_contract_coverage_test.go
+++ b/internal/app/output_contract_coverage_test.go
@@ -19,7 +19,7 @@ var outputContractCoverageInventory = map[string]outputContractCoverageEntry{
 	"read_file":                {Variants: []string{"success"}},
 	"list_dir":                 {Variants: []string{"success"}},
 	"search_text":              {Variants: []string{"success"}},
-	"file_edit":                {Variants: []string{"replace", "add", "move", "delete"}},
+	"file_edit":                {Variants: []string{"replace", "patch", "add", "move", "delete"}},
 	"exec_command":             {Variants: []string{"success"}},
 	"session_observe":          {Variants: []string{"list"}},
 	"session_act":              {Variants: []string{"kill_all"}},

--- a/internal/app/tool_migration_test.go
+++ b/internal/app/tool_migration_test.go
@@ -22,6 +22,44 @@ func TestFileEditReplace(t *testing.T) {
 	}
 }
 
+func TestFileEditPatch(t *testing.T) {
+	rt, root := newCodeToolsRuntime(t)
+	path := filepath.Join(root, "patch.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: patch.txt\n@@\n-alpha\n+beta\n*** End Patch"
+	result, err := rt.Call(context.Background(), "file_edit", map[string]any{"action": "patch", "patch": patch, "dry_run": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolResultMatchestestOutputSchema(t, "file_edit", result)
+	if result["action"] != "patch" || result["dry_run"] != true || result["files_changed"] != 1 {
+		t.Fatalf("unexpected file_edit patch result: %#v", result)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "alpha\n" {
+		t.Fatalf("dry-run patch changed file: %q", content)
+	}
+}
+
+func TestFileEditUnifiedDiffOutputContract(t *testing.T) {
+	rt, root := newCodeToolsRuntime(t)
+	path := filepath.Join(root, "unified.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "diff --git a/unified.txt b/unified.txt\n--- a/unified.txt\n+++ b/unified.txt\n@@ -1 +1 @@\n-alpha\n+beta\n"
+	result, err := rt.Call(context.Background(), "file_edit", map[string]any{"action": "patch", "patch": patch, "dry_run": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolResultMatchestestOutputSchema(t, "file_edit", result)
+}
+
 func TestFileEditAddMoveDelete(t *testing.T) {
 	rt, root := newCodeToolsRuntime(t)
 	result, err := rt.Call(context.Background(), "file_edit", map[string]any{"action": "add", "path": "draft.txt", "content": "hello\n"})

--- a/internal/tool/file/contract.go
+++ b/internal/tool/file/contract.go
@@ -7,6 +7,21 @@ const (
 	ToolListDir    = "list_dir"
 	ToolSearchText = "search_text"
 	ToolFileEdit   = "file_edit"
+
+	structuredPatchGrammarDescription = ` Structured envelope format:
+*** Begin Patch
+*** Add File: <path>
++<added line>
+*** Delete File: <path>
+*** Update File: <path>
+[*** Move to: <new path>]
+@@ [<optional context line>]
+ <context line>
+-<removed line>
++<added line>
+[*** End of File]
+*** End Patch
+Add/Delete/Update operations may repeat in one envelope. Update lines use a leading space for context, '-' for removal, and '+' for addition; @@ may be used without context or with one context line.`
 )
 
 func InputSchema(name string) (map[string]any, bool) {
@@ -130,7 +145,22 @@ func OutputSchema(name string) (map[string]any, bool) {
 		props["path"] = stringProp("Host path. Relative paths resolve from ~/AgentDock.")
 		props["new_path"] = stringProp("Move destination path.")
 		props["workdir"] = stringProp("Patch working directory.")
-		props["affected_files"] = map[string]any{"type": "array", "description": "Files affected by a patch.", "items": map[string]any{"type": "string"}}
+		props["affected_files"] = map[string]any{
+			"type":        "array",
+			"description": "Files affected by a patch. Structured-envelope results use operation/move_to; unified-diff results use status/binary.",
+			"items": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []string{"path"},
+				"properties": map[string]any{
+					"path":      stringProp("Affected file path."),
+					"operation": map[string]any{"type": "string", "enum": []string{"add", "delete", "update", "move"}},
+					"move_to":   stringProp("Move destination for operation=move."),
+					"status":    stringProp("Unified diff file status."),
+					"binary":    boolProp("Whether a unified diff file is binary."),
+				},
+			},
+		}
 		props["dry_run"] = boolProp("Whether this was a dry run.")
 		props["matches"] = intProp("Match count for replace.")
 		props["changed"] = boolProp("Whether content changed.")

--- a/internal/tool/file/file_runtime_other.go
+++ b/internal/tool/file/file_runtime_other.go
@@ -23,4 +23,6 @@ func ToolDescription(base string) string { return base }
 
 func EditDescription(base string) string { return base }
 
-func PatchDescription(base string) string { return base }
+func PatchDescription(base string) string {
+	return base + structuredPatchGrammarDescription + " Prefer the structured envelope for multi-file edits so AgentDock can stage, conflict-check, and roll back the change set. Unified git diff remains accepted on the Host runtime."
+}

--- a/internal/tool/file/file_runtime_windows.go
+++ b/internal/tool/file/file_runtime_windows.go
@@ -52,5 +52,5 @@ func EditDescription(base string) string {
 }
 
 func PatchDescription(base string) string {
-	return base + " With runtime=wsl, patch must use the structured *** Begin Patch envelope and contain exactly one file operation per call."
+	return base + structuredPatchGrammarDescription + " With runtime=wsl, this structured envelope is required and must contain exactly one file operation per call. With runtime=windows, structured envelopes use the Host staged commit path; unified git diff is also accepted."
 }

--- a/internal/tool/file/patch.go
+++ b/internal/tool/file/patch.go
@@ -94,7 +94,7 @@ func (svc *Service) applyEnvelopePatch(patch string, dryRun bool, basePath strin
 				content := string(original)
 				current = stagedPatchFile{Abs: source.Abs, Display: source.Display, Content: &content, Mode: info.Mode().Perm(), Original: original, OriginalExists: true}
 			}
-			updated, err := applyUpdateHunks(*current.Content, op.Hunks, source.Display)
+			updated, err := applyUpdateHunks(*current.Content, op.Chunks, source.Display)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/tool/file/patch_parse.go
+++ b/internal/tool/file/patch_parse.go
@@ -2,11 +2,17 @@ package file
 
 import "strings"
 
+type patchUpdateChunk struct {
+	Anchor    string
+	Lines     []string
+	EndOfFile bool
+}
+
 type patchOperation struct {
 	Kind       string
 	Path       string
 	AddContent string
-	Hunks      [][]string
+	Chunks     []patchUpdateChunk
 	MoveTo     string
 }
 
@@ -18,6 +24,7 @@ func parseEnvelopePatch(patch string) ([]patchOperation, error) {
 	if len(lines) < 2 || strings.TrimSpace(lines[0]) != "*** Begin Patch" || strings.TrimSpace(lines[len(lines)-1]) != "*** End Patch" {
 		return nil, toolError("PATCH_FAILED", "patch must use begin/end envelope", "validation")
 	}
+
 	operations := make([]patchOperation, 0)
 	for i := 1; i < len(lines)-1; {
 		line := lines[i]
@@ -52,23 +59,51 @@ func parseEnvelopePatch(patch string) ([]patchOperation, error) {
 				moveTo = strings.TrimSpace(strings.TrimPrefix(lines[i], "*** Move to: "))
 				i++
 			}
-			hunks := make([][]string, 0)
-			current := make([]string, 0)
-			for i < len(lines)-1 && !strings.HasPrefix(lines[i], "*** ") {
-				if strings.HasPrefix(lines[i], "@@") {
-					if len(current) > 0 {
-						hunks = append(hunks, current)
-					}
-					current = make([]string, 0)
-				} else {
-					current = append(current, lines[i])
+
+			chunks := make([]patchUpdateChunk, 0)
+			var current *patchUpdateChunk
+			startChunk := func(anchor string) {
+				chunks = append(chunks, patchUpdateChunk{Anchor: anchor})
+				current = &chunks[len(chunks)-1]
+			}
+			for i < len(lines)-1 {
+				raw := lines[i]
+				if strings.HasPrefix(raw, "*** Add File: ") || strings.HasPrefix(raw, "*** Delete File: ") || strings.HasPrefix(raw, "*** Update File: ") {
+					break
 				}
+				if raw == "*** End of File" {
+					if current == nil {
+						startChunk("")
+					}
+					if current.EndOfFile {
+						return nil, toolError("PATCH_FAILED", "duplicate end-of-file marker", "validation")
+					}
+					current.EndOfFile = true
+					i++
+					continue
+				}
+				if strings.HasPrefix(raw, "*** ") {
+					break
+				}
+				if current != nil && current.EndOfFile {
+					return nil, toolError("PATCH_FAILED", "end-of-file marker must terminate its update chunk", "validation")
+				}
+				if raw == "@@" || strings.HasPrefix(raw, "@@ ") {
+					anchor := strings.TrimPrefix(raw, "@@")
+					if strings.HasPrefix(anchor, " ") {
+						anchor = anchor[1:]
+					}
+					startChunk(anchor)
+					i++
+					continue
+				}
+				if current == nil {
+					startChunk("")
+				}
+				current.Lines = append(current.Lines, raw)
 				i++
 			}
-			if len(current) > 0 {
-				hunks = append(hunks, current)
-			}
-			operations = append(operations, patchOperation{Kind: "update", Path: path, Hunks: hunks, MoveTo: moveTo})
+			operations = append(operations, patchOperation{Kind: "update", Path: path, Chunks: chunks, MoveTo: moveTo})
 			continue
 		}
 		return nil, toolErrorDetails("PATCH_FAILED", "unrecognized patch line", "validation", map[string]any{"line": line})
@@ -76,10 +111,11 @@ func parseEnvelopePatch(patch string) ([]patchOperation, error) {
 	return operations, nil
 }
 
-func applyUpdateHunks(content string, hunks [][]string, path string) (string, error) {
-	if len(hunks) == 0 {
+func applyUpdateHunks(content string, chunks []patchUpdateChunk, path string) (string, error) {
+	if len(chunks) == 0 {
 		return content, nil
 	}
+
 	hasBOM := strings.HasPrefix(content, "\ufeff")
 	if hasBOM {
 		content = strings.TrimPrefix(content, "\ufeff")
@@ -88,32 +124,65 @@ func applyUpdateHunks(content string, hunks [][]string, path string) (string, er
 	if strings.Contains(content, "\r\n") {
 		lineEnding = "\r\n"
 	}
-	lines := strings.Split(strings.TrimSuffix(strings.ReplaceAll(content, "\r\n", "\n"), "\n"), "\n")
-	if content == "" {
-		lines = []string{}
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	trailingNewline := strings.HasSuffix(normalized, "\n")
+	body := normalized
+	if trailingNewline {
+		body = strings.TrimSuffix(body, "\n")
 	}
-	trailing := strings.HasSuffix(content, "\n")
-	for hunkIndex, hunk := range hunks {
-		oldLines, newLines, err := parseUpdateHunk(hunk)
+	var lines []string
+	if body != "" || normalized != "" {
+		lines = strings.Split(body, "\n")
+	}
+
+	searchStart := 0
+	for chunkIndex, chunk := range chunks {
+		oldLines, newLines, err := parseUpdateChunk(chunk)
 		if err != nil {
 			return "", err
 		}
-		idxs := findAllSubsequences(lines, oldLines)
-		if len(idxs) == 0 {
-			return "", toolErrorDetails("PATCH_FAILED", "patch context did not match", "validation", map[string]any{"path": path, "diagnostic": map[string]any{"code": "CONTEXT_NOT_FOUND", "path": path, "hunk_index": hunkIndex, "message": "patch context did not match", "nearby_context": patchNearbyContext(lines, oldLines)}})
+
+		if chunk.Anchor != "" {
+			matches := findPatchMatches(lines, []string{chunk.Anchor}, searchStart, false)
+			if len(matches) == 0 {
+				return "", patchContextError("patch anchor did not match", "CONTEXT_NOT_FOUND", path, chunkIndex, lines, []string{chunk.Anchor}, nil)
+			}
+			if len(matches) > 1 {
+				return "", patchContextError("patch anchor matched multiple locations", "AMBIGUOUS_CONTEXT", path, chunkIndex, lines, []string{chunk.Anchor}, matches)
+			}
+			searchStart = matches[0] + 1
 		}
-		if len(idxs) > 1 {
-			return "", toolErrorDetails("PATCH_FAILED", "patch context matched multiple locations", "validation", map[string]any{"path": path, "matches": len(idxs), "diagnostic": map[string]any{"code": "AMBIGUOUS_CONTEXT", "path": path, "hunk_index": hunkIndex, "message": "patch context matched multiple locations", "nearby_context": patchContextsForMatches(lines, idxs)}})
+
+		if len(oldLines) == 0 {
+			if len(newLines) == 0 {
+				continue
+			}
+			insertAt := len(lines)
+			lines = append(lines, newLines...)
+			searchStart = insertAt + len(newLines)
+			continue
 		}
-		idx := idxs[0]
+
+		matches := findPatchMatches(lines, oldLines, searchStart, chunk.EndOfFile)
+		if len(matches) == 0 {
+			return "", patchContextError("patch context did not match", "CONTEXT_NOT_FOUND", path, chunkIndex, lines, oldLines, nil)
+		}
+		if len(matches) > 1 {
+			return "", patchContextError("patch context matched multiple locations", "AMBIGUOUS_CONTEXT", path, chunkIndex, lines, oldLines, matches)
+		}
+		idx := matches[0]
+		// 匹配允许忽略行尾空白，但未修改的 context 行仍保留磁盘原文，避免容错匹配带来附带格式变更。
+		newLines = materializeUpdateLines(chunk, lines[idx:idx+len(oldLines)])
 		updated := make([]string, 0, len(lines)-len(oldLines)+len(newLines))
 		updated = append(updated, lines[:idx]...)
 		updated = append(updated, newLines...)
 		updated = append(updated, lines[idx+len(oldLines):]...)
 		lines = updated
+		searchStart = idx + len(newLines)
 	}
+
 	result := strings.Join(lines, lineEnding)
-	if trailing || len(lines) > 0 {
+	if trailingNewline {
 		result += lineEnding
 	}
 	if hasBOM {
@@ -122,15 +191,15 @@ func applyUpdateHunks(content string, hunks [][]string, path string) (string, er
 	return result, nil
 }
 
-func parseUpdateHunk(hunk []string) ([]string, []string, error) {
-	oldLines := make([]string, 0)
-	newLines := make([]string, 0)
-	for _, raw := range hunk {
-		if raw == "*** End of File" {
-			continue
-		}
+func parseUpdateChunk(chunk patchUpdateChunk) ([]string, []string, error) {
+	oldLines := make([]string, 0, len(chunk.Lines))
+	newLines := make([]string, 0, len(chunk.Lines))
+	for _, raw := range chunk.Lines {
 		if raw == "" {
-			return nil, nil, toolError("PATCH_FAILED", "invalid empty patch line", "validation")
+			// 部分模型或传输层会去掉空上下文行唯一的前导空格；按 Codex 的宽松解析视为空上下文。
+			oldLines = append(oldLines, "")
+			newLines = append(newLines, "")
+			continue
 		}
 		marker := raw[0]
 		value := raw[1:]
@@ -149,16 +218,63 @@ func parseUpdateHunk(hunk []string) ([]string, []string, error) {
 	return oldLines, newLines, nil
 }
 
-func findAllSubsequences(lines, needle []string) []int {
-	if len(needle) == 0 {
-		return []int{0}
+func materializeUpdateLines(chunk patchUpdateChunk, matchedOld []string) []string {
+	result := make([]string, 0, len(chunk.Lines))
+	oldIndex := 0
+	for _, raw := range chunk.Lines {
+		if raw == "" {
+			result = append(result, matchedOld[oldIndex])
+			oldIndex++
+			continue
+		}
+		switch raw[0] {
+		case ' ':
+			result = append(result, matchedOld[oldIndex])
+			oldIndex++
+		case '-':
+			oldIndex++
+		case '+':
+			result = append(result, raw[1:])
+		}
 	}
-	limit := len(lines) - len(needle) + 1
+	return result
+}
+
+func findPatchMatches(lines, needle []string, start int, endOfFile bool) []int {
+	exact := findPatchMatchesWith(lines, needle, start, endOfFile, func(left, right string) bool { return left == right })
+	if len(exact) > 0 {
+		return exact
+	}
+	return findPatchMatchesWith(lines, needle, start, endOfFile, func(left, right string) bool {
+		return strings.TrimRight(left, " \t") == strings.TrimRight(right, " \t")
+	})
+}
+
+func findPatchMatchesWith(lines, needle []string, start int, endOfFile bool, equal func(string, string) bool) []int {
+	if len(needle) == 0 {
+		if endOfFile {
+			return []int{len(lines)}
+		}
+		if start > len(lines) {
+			return nil
+		}
+		return []int{start}
+	}
+	if start < 0 {
+		start = 0
+	}
+	last := len(lines) - len(needle)
+	if last < start {
+		return nil
+	}
+	if endOfFile {
+		start = last
+	}
 	matches := make([]int, 0)
-	for i := 0; i < limit; i++ {
+	for i := start; i <= last; i++ {
 		ok := true
 		for j := range needle {
-			if lines[i+j] != needle[j] {
+			if !equal(lines[i+j], needle[j]) {
 				ok = false
 				break
 			}
@@ -166,6 +282,28 @@ func findAllSubsequences(lines, needle []string) []int {
 		if ok {
 			matches = append(matches, i)
 		}
+		if endOfFile {
+			break
+		}
 	}
 	return matches
+}
+
+func patchContextError(message, code, path string, chunkIndex int, lines, needle []string, matches []int) error {
+	diagnostic := map[string]any{
+		"code":       code,
+		"path":       path,
+		"hunk_index": chunkIndex,
+		"message":    message,
+	}
+	if len(matches) > 0 {
+		diagnostic["nearby_context"] = patchContextsForMatches(lines, matches)
+	} else {
+		diagnostic["nearby_context"] = patchNearbyContext(lines, needle)
+	}
+	details := map[string]any{"path": path, "diagnostic": diagnostic}
+	if len(matches) > 1 {
+		details["matches"] = len(matches)
+	}
+	return toolErrorDetails("PATCH_FAILED", message, "validation", details)
 }

--- a/internal/tool/file/service_behavior_test.go
+++ b/internal/tool/file/service_behavior_test.go
@@ -235,6 +235,204 @@ func TestApplyEnvelopePatchDryRunAndDiagnostics(t *testing.T) {
 	}
 }
 
+func TestApplyEnvelopePatchContextAnchorDisambiguates(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.go")
+	content := "func first() {\n\treturn nil\n}\n\nfunc second() {\n\treturn nil\n}\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.go\n@@ func second() {\n-\treturn nil\n+\treturn secondErr\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "func first() {\n\treturn nil\n}\n\nfunc second() {\n\treturn secondErr\n}\n"
+	if string(got) != want {
+		t.Fatalf("anchored patch content = %q, want %q", got, want)
+	}
+}
+
+func TestApplyEnvelopePatchContextAnchorSearchesForward(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.go")
+	content := "func target() {\n\tprepare()\n\twork()\n\treturn nil\n}\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.go\n@@ func target() {\n-\treturn nil\n+\treturn targetErr\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "func target() {\n\tprepare()\n\twork()\n\treturn targetErr\n}\n"
+	if string(got) != want {
+		t.Fatalf("forward anchored patch content = %q, want %q", got, want)
+	}
+}
+
+func TestApplyEnvelopePatchAcceptsBlankContextLine(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.txt")
+	if err := os.WriteFile(path, []byte("alpha\n\nbeta\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.txt\n@@\n alpha\n\n-beta\n+BETA\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "alpha\n\nBETA\n" {
+		t.Fatalf("blank-context patch content = %q", got)
+	}
+}
+
+func TestApplyEnvelopePatchEndOfFileAnchorsLastMatch(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.txt")
+	if err := os.WriteFile(path, []byte("alpha\nomega\nalpha\nomega\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.txt\n@@\n-alpha\n-omega\n+ALPHA\n+OMEGA\n*** End of File\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "alpha\nomega\nALPHA\nOMEGA\n" {
+		t.Fatalf("EOF-anchored patch content = %q", got)
+	}
+}
+
+func TestApplyEnvelopePatchEndOfFilePureInsertAppends(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.txt\n@@\n+omega\n*** End of File\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "alpha\nomega\n" {
+		t.Fatalf("EOF pure insert content = %q", got)
+	}
+}
+
+func TestApplyEnvelopePatchPreservesMissingTrailingNewline(t *testing.T) {
+	rt, root := newFileTestService(t)
+	path := filepath.Join(root, "main.txt")
+	if err := os.WriteFile(path, []byte("alpha"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: main.txt\n@@\n-alpha\n+beta\n*** End Patch"
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "beta" {
+		t.Fatalf("patch added an unexpected trailing newline: %q", got)
+	}
+}
+
+func TestApplyUpdateHunksRStripFallbackRequiresUniqueMatch(t *testing.T) {
+	t.Run("rstrip fallback", func(t *testing.T) {
+		got, err := applyUpdateHunks("alpha   \nbeta\n", []patchUpdateChunk{{Lines: []string{"-alpha", "+ALPHA"}}}, "main.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "ALPHA\nbeta\n" {
+			t.Fatalf("rstrip patch content = %q", got)
+		}
+	})
+
+	t.Run("rstrip keeps unchanged context text", func(t *testing.T) {
+		got, err := applyUpdateHunks("alpha   \nbeta\n", []patchUpdateChunk{{Lines: []string{" alpha", "-beta", "+BETA"}}}, "main.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "alpha   \nBETA\n" {
+			t.Fatalf("rstrip context was rewritten: %q", got)
+		}
+	})
+
+	t.Run("rstrip ambiguity", func(t *testing.T) {
+		_, err := applyUpdateHunks("alpha \nalpha\t\n", []patchUpdateChunk{{Lines: []string{"-alpha", "+ALPHA"}}}, "main.txt")
+		var toolErr *ToolError
+		if !errors.As(err, &toolErr) || toolErr.Code != "PATCH_FAILED" {
+			t.Fatalf("ambiguous rstrip error = %#v", err)
+		}
+		diagnostic, _ := toolErr.Details["diagnostic"].(map[string]any)
+		if diagnostic["code"] != "AMBIGUOUS_CONTEXT" {
+			t.Fatalf("ambiguous rstrip diagnostic = %#v", diagnostic)
+		}
+	})
+
+	t.Run("leading whitespace remains significant", func(t *testing.T) {
+		_, err := applyUpdateHunks("    alpha\n", []patchUpdateChunk{{Lines: []string{"-  alpha", "+ALPHA"}}}, "main.txt")
+		var toolErr *ToolError
+		if !errors.As(err, &toolErr) || toolErr.Code != "PATCH_FAILED" {
+			t.Fatalf("leading-whitespace error = %#v", err)
+		}
+		diagnostic, _ := toolErr.Details["diagnostic"].(map[string]any)
+		if diagnostic["code"] != "CONTEXT_NOT_FOUND" {
+			t.Fatalf("leading-whitespace diagnostic = %#v", diagnostic)
+		}
+	})
+}
+
+func TestApplyEnvelopePatchDoesNotWriteEarlierFileWhenLaterContextFails(t *testing.T) {
+	rt, root := newFileTestService(t)
+	first := filepath.Join(root, "first.txt")
+	second := filepath.Join(root, "second.txt")
+	if err := os.WriteFile(first, []byte("first old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("second old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := strings.Join([]string{
+		"*** Begin Patch",
+		"*** Update File: first.txt",
+		"@@",
+		"-first old",
+		"+first new",
+		"*** Update File: second.txt",
+		"@@",
+		"-missing",
+		"+second new",
+		"*** End Patch",
+	}, "\n")
+	if _, err := rt.applyPatchTest(context.Background(), map[string]any{"patch": patch}); err == nil {
+		t.Fatal("expected the second file context to fail")
+	}
+	got, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first old\n" {
+		t.Fatalf("first file was written before full patch validation: %q", got)
+	}
+}
+
 func TestApplyUnifiedDiffDryRunDoesNotWrite(t *testing.T) {
 	rt, root := newFileTestService(t)
 	path := filepath.Join(root, "main.go")

--- a/internal/tool/file/wsl_file_edit_windows.go
+++ b/internal/tool/file/wsl_file_edit_windows.go
@@ -239,7 +239,7 @@ func (svc *Service) fileEditPatchWSL(ctx context.Context, request EditRequest, s
 			if stage.NewContent == nil {
 				return nil, toolErrorDetails("PATCH_FAILED", "cannot update a deleted file", "validation", map[string]any{"path": sourcePath})
 			}
-			updated, err := applyUpdateHunks(*stage.NewContent, operation.Hunks, sourcePath)
+			updated, err := applyUpdateHunks(*stage.NewContent, operation.Chunks, sourcePath)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## 变更
- 补齐 file_edit(action=patch) 的 structured patch grammar
- 支持 @@ context、End of File、空上下文与无尾换行保真
- 增加 exact → rstrip 唯一匹配并保持 staged transaction/rollback
- 补齐 patch output contract 与回归测试

## 验证
- go test ./...
- go vet ./...
- git diff --check
- GOOS=windows GOARCH=amd64 file tool 交叉编译
- agy 只读 review：无高/中优先级问题