### PR TITLE
fix(tunnel): 用空配置隔离 cloudflared 默认 config.yml 的兜底 404

### DIFF
--- a/internal/desktopruntime/tunnel_unix.go
+++ b/internal/desktopruntime/tunnel_unix.go
@@ -216,7 +216,11 @@ func platformLaunchTunnel(ctx context.Context, runtimeRoot string) error {
 				return err
 			}
 		}
-		command := exec.CommandContext(ctx, manifest.CloudflaredBinary, "tunnel", "--no-autoupdate", "run")
+		isolatedConfig, err := ensureIsolatedConfig(root)
+		if err != nil {
+			return err
+		}
+		command := exec.CommandContext(ctx, manifest.CloudflaredBinary, "--config", isolatedConfig, "tunnel", "--no-autoupdate", "run")
 		command.Env = append(os.Environ(), "TUNNEL_TOKEN="+token)
 		command.Stdout = stdout
 		command.Stderr = stderr
@@ -226,8 +230,23 @@ func platformLaunchTunnel(ctx context.Context, runtimeRoot string) error {
 	}
 }
 
+// ensureIsolatedConfig 在运行目录写一个空 cloudflared 配置，用于 --config 隔离。
+// cloudflared 默认加载 ~/.cloudflared/config.yml，其兜底 ingress
+// `- service: http_status:404` 会把隧道入站请求就地吞成 404。
+func ensureIsolatedConfig(root string) (string, error) {
+	path := filepath.Join(root, "cloudflared-isolated.yml")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		return "", fmt.Errorf("写入 cloudflared 隔离配置失败: %w", err)
+	}
+	return path, nil
+}
+
 func runQuickTunnel(ctx context.Context, manifest unixRuntimeManifest, root, runtimeRoot, target string, logOutput io.Writer) error {
-	command := exec.CommandContext(ctx, manifest.CloudflaredBinary, "tunnel", "--no-autoupdate", "--url", target)
+	isolatedConfig, err := ensureIsolatedConfig(root)
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(ctx, manifest.CloudflaredBinary, "--config", isolatedConfig, "tunnel", "--no-autoupdate", "--url", target)
 	reader, writer := io.Pipe()
 	command.Stdout = writer
 	command.Stderr = writer

--- a/internal/desktopruntime/tunnel_windows.go
+++ b/internal/desktopruntime/tunnel_windows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"syscall"
@@ -326,8 +327,23 @@ func launchCloudflared(runtime tunnelRuntime) error {
 	return nil
 }
 
+// ensureIsolatedConfig 在运行目录写一个空 cloudflared 配置，用于 --config 隔离。
+// cloudflared 默认加载 %USERPROFILE%\.cloudflared\config.yml，其兜底 ingress
+// `- service: http_status:404` 会把隧道入站请求就地吞成 404。
+func ensureIsolatedConfig(root string) (string, error) {
+	path := filepath.Join(root, "cloudflared-isolated.yml")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		return "", fmt.Errorf("写入 cloudflared 隔离配置失败: %w", err)
+	}
+	return path, nil
+}
+
 func cloudflaredCommand(ctx context.Context, runtime tunnelRuntime) (*exec.Cmd, error) {
-	arguments := []string{"tunnel", "--no-autoupdate"}
+	isolatedConfig, err := ensureIsolatedConfig(runtime.root)
+	if err != nil {
+		return nil, err
+	}
+	arguments := []string{"--config", isolatedConfig, "tunnel", "--no-autoupdate"}
 	environment := environmentWithout(os.Environ(), "TUNNEL_TOKEN")
 	if runtime.mode == "quick" {
 		arguments = append(arguments, "--url", fmt.Sprintf("http://127.0.0.1:%d", runtime.settings.Port))


### PR DESCRIPTION
cloudflared 不带 --config 时会无条件加载 ~/.cloudflared/config.yml， 如果其兜底 ingress `- service: http_status:404` 会把隧道入站请求就地 吞成 404（带 cf-ray、源站零请求）。Quick/Named Tunnel 启动统一加上
--config <运行目录>/cloudflared-isolated.yml 隔离。